### PR TITLE
feat: add installation script with symlink and copy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,45 +17,46 @@ Keep AI tool configurations version-controlled and portable across machines. The
 ```
 .
 ├── claude/          # Claude Code configurations
-│   ├── settings.json
-│   └── ...
-└── cursor/          # Cursor configurations
-    └── ...
+│   └── settings.local.json
+├── cursor/          # Cursor configurations (coming soon)
+└── install.sh       # Installation script
 ```
 
 ## Installation
 
-### Option 1: Manual Copy
+Clone the repository:
 ```bash
-# Clone this repository
 git clone git@github.com:alkofu/ai-dotfiles.git
 cd ai-dotfiles
-
-# Copy configurations to home directory
-cp -r claude ~/.claude
-cp -r cursor ~/.cursor
 ```
 
-### Option 2: Symlinks (Recommended)
+Run the installation script:
+
+### Option 1: Symlinks (Recommended)
 ```bash
-# Clone this repository
-git clone git@github.com:alkofu/ai-dotfiles.git ~/ai-dotfiles
-
-# Create symlinks
-ln -s ~/ai-dotfiles/claude ~/.claude
-ln -s ~/ai-dotfiles/cursor ~/.cursor
+./install.sh
 ```
 
-Using symlinks keeps your configurations in sync with this repository automatically.
+Creates symbolic links to `~/.claude/` and `~/.cursor/`. Changes sync automatically with the repository.
+
+### Option 2: Copy Files
+```bash
+./install.sh --copy
+```
+
+Copies files to `~/.claude/` and `~/.cursor/`. Manual sync required (see Updating below).
+
+**Note:** The installer automatically backs up any existing configurations with a timestamp.
 
 ## Updating
 
 ```bash
-cd ~/ai-dotfiles
-git pull origin main
+cd ai-dotfiles
+git pull
 ```
 
-If using symlinks, changes take effect immediately. If using manual copy, re-run the copy commands.
+**With symlinks:** Changes take effect immediately.
+**With copy:** Re-run `./install.sh --copy` after pulling updates.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# AI Dotfiles
+
+Configuration files for AI coding assistants, managed centrally and deployed to your home directory.
+
+## Overview
+
+This repository maintains user-scope configuration for:
+- **Claude Code** - Anthropic's AI coding assistant CLI
+- **Cursor** - AI-powered code editor
+
+## Purpose
+
+Keep AI tool configurations version-controlled and portable across machines. These configs are meant to be copied or symlinked to your user home directory (`~/.claude/`, `~/.cursor/`, etc.).
+
+## Structure
+
+```
+.
+├── claude/          # Claude Code configurations
+│   ├── settings.json
+│   └── ...
+└── cursor/          # Cursor configurations
+    └── ...
+```
+
+## Installation
+
+### Option 1: Manual Copy
+```bash
+# Clone this repository
+git clone git@github.com:alkofu/ai-dotfiles.git
+cd ai-dotfiles
+
+# Copy configurations to home directory
+cp -r claude ~/.claude
+cp -r cursor ~/.cursor
+```
+
+### Option 2: Symlinks (Recommended)
+```bash
+# Clone this repository
+git clone git@github.com:alkofu/ai-dotfiles.git ~/ai-dotfiles
+
+# Create symlinks
+ln -s ~/ai-dotfiles/claude ~/.claude
+ln -s ~/ai-dotfiles/cursor ~/.cursor
+```
+
+Using symlinks keeps your configurations in sync with this repository automatically.
+
+## Updating
+
+```bash
+cd ~/ai-dotfiles
+git pull origin main
+```
+
+If using symlinks, changes take effect immediately. If using manual copy, re-run the copy commands.
+
+## Contributing
+
+When updating configurations:
+1. Make changes in this repository
+2. Test the configurations
+3. Commit and push changes
+4. Pull on other machines to sync
+
+## License
+
+Personal configuration files - use as needed.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Keep AI tool configurations version-controlled and portable across machines. The
 ```
 .
 ├── claude/          # Claude Code configurations
-│   └── settings.local.json
 ├── cursor/          # Cursor configurations (coming soon)
 └── install.sh       # Installation script
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default installation method
+INSTALL_METHOD="symlink"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --copy)
+      INSTALL_METHOD="copy"
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--copy]"
+      echo ""
+      echo "Install AI dotfiles to your home directory."
+      echo ""
+      echo "Options:"
+      echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
+      echo "  --help    Show this help message"
+      echo ""
+      echo "Installation methods:"
+      echo "  symlink (default): Creates symbolic links. Changes sync automatically."
+      echo "  copy:              Copies files. Manual sync required with git pull."
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Error: Unknown option $1${NC}"
+      echo "Run '$0 --help' for usage information."
+      exit 1
+      ;;
+  esac
+done
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo -e "${BLUE}AI Dotfiles Installer${NC}"
+echo -e "${BLUE}=====================${NC}"
+echo ""
+echo "Installation method: ${GREEN}${INSTALL_METHOD}${NC}"
+echo "Source directory: ${SCRIPT_DIR}"
+echo ""
+
+# Function to backup existing directory
+backup_if_exists() {
+  local target="$1"
+  if [[ -e "$target" ]]; then
+    local backup="${target}.backup.$(date +%Y%m%d_%H%M%S)"
+    echo -e "${YELLOW}Backing up existing ${target} to ${backup}${NC}"
+    mv "$target" "$backup"
+    return 0
+  fi
+  return 1
+}
+
+# Function to install a directory
+install_dir() {
+  local src_name="$1"
+  local dest_name="$2"
+  local src_path="${SCRIPT_DIR}/${src_name}"
+  local dest_path="${HOME}/${dest_name}"
+
+  # Check if source exists
+  if [[ ! -d "$src_path" ]]; then
+    echo -e "${YELLOW}Skipping ${src_name} (not found in repository)${NC}"
+    return
+  fi
+
+  # Backup existing configuration
+  backup_if_exists "$dest_path"
+
+  # Install based on method
+  if [[ "$INSTALL_METHOD" == "symlink" ]]; then
+    echo -e "${GREEN}Creating symlink:${NC} ${dest_path} -> ${src_path}"
+    ln -s "$src_path" "$dest_path"
+  else
+    echo -e "${GREEN}Copying:${NC} ${src_path} -> ${dest_path}"
+    cp -r "$src_path" "$dest_path"
+  fi
+}
+
+# Install each configuration directory
+install_dir "claude" ".claude"
+install_dir "cursor" ".cursor"
+
+echo ""
+echo -e "${GREEN}✓ Installation complete!${NC}"
+echo ""
+
+if [[ "$INSTALL_METHOD" == "symlink" ]]; then
+  echo "Your configurations are now symlinked to this repository."
+  echo "To update: cd ${SCRIPT_DIR} && git pull"
+else
+  echo "Your configurations have been copied from this repository."
+  echo "To update: cd ${SCRIPT_DIR} && git pull && ./install.sh --copy"
+fi


### PR DESCRIPTION
## Summary

- Added `install.sh` script to automate repository installation
- Updated README.md with simplified installation instructions
- Supports both symlink (default) and copy modes for flexibility

## Features

The installation script includes:
- **Symlink mode** (default): Creates symbolic links for automatic sync with the repository
- **Copy mode** (`--copy` flag): Copies files for manual sync
- Automatic backup of existing configurations with timestamps
- Color-coded output for better user experience
- Help text (`--help` flag) with clear usage instructions

## Changes

- Created `install.sh` executable script
- Updated README.md installation section to use the new script
- Updated README.md structure section to reflect actual repository contents

## Test plan

- [ ] Run `./install.sh --help` to verify help text displays correctly
- [ ] Run `./install.sh` to test symlink installation
- [ ] Run `./install.sh --copy` to test copy installation
- [ ] Verify backups are created when existing configurations exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)