### PR TITLE
feat(install): whitelist Claude paths and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Match install.sh whitelist: only settings.json, skills/, agents/ are tracked under claude/
+claude/**
+!claude/settings.json
+!claude/skills/
+!claude/skills/**
+!claude/agents/
+!claude/agents/**

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Keep AI tool configurations version-controlled and portable across machines. The
 
 ```
 .
-├── claude/          # Claude Code configurations
+├── claude/          # Claude Code configs (whitelist: settings.json, skills/, agents/)
 ├── cursor/          # Cursor configurations (coming soon)
 └── install.sh       # Installation script
 ```
+
+The installer only installs these paths from `claude/` into `~/.claude/`: `settings.json`, `skills/`, and `agents/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
 
 ## Installation
 
@@ -36,14 +38,14 @@ Run the installation script:
 ./install.sh
 ```
 
-Creates symbolic links to `~/.claude/` and `~/.cursor/`. Changes sync automatically with the repository.
+Creates symbolic links for the whitelisted Claude paths (`settings.json`, `skills/`, `agents/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
 
 ### Option 2: Copy Files
 ```bash
 ./install.sh --copy
 ```
 
-Copies files to `~/.claude/` and `~/.cursor/`. Manual sync required (see Updating below).
+Copies the same whitelisted Claude paths into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
 
 **Note:** The installer automatically backs up any existing configurations with a timestamp.
 

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,9 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Install AI dotfiles to your home directory."
       echo ""
+      echo "Claude Code: installs only whitelisted paths from claude/ into ~/.claude/:"
+      echo "  settings.json, skills/, agents/"
+      echo ""
       echo "Options:"
       echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
       echo "  --help    Show this help message"
@@ -51,35 +54,24 @@ echo "Installation method: ${GREEN}${INSTALL_METHOD}${NC}"
 echo "Source directory: ${SCRIPT_DIR}"
 echo ""
 
-# Function to backup existing directory
+# Function to backup existing path if present (always returns 0 so set -e is safe)
 backup_if_exists() {
   local target="$1"
   if [[ -e "$target" ]]; then
     local backup="${target}.backup.$(date +%Y%m%d_%H%M%S)"
     echo -e "${YELLOW}Backing up existing ${target} to ${backup}${NC}"
     mv "$target" "$backup"
-    return 0
   fi
-  return 1
+  return 0
 }
 
-# Function to install a directory
-install_dir() {
-  local src_name="$1"
-  local dest_name="$2"
-  local src_path="${SCRIPT_DIR}/${src_name}"
-  local dest_path="${HOME}/${dest_name}"
+# Install a source path to a destination path (file or directory)
+install_path() {
+  local src_path="$1"
+  local dest_path="$2"
 
-  # Check if source exists
-  if [[ ! -d "$src_path" ]]; then
-    echo -e "${YELLOW}Skipping ${src_name} (not found in repository)${NC}"
-    return
-  fi
-
-  # Backup existing configuration
   backup_if_exists "$dest_path"
 
-  # Install based on method
   if [[ "$INSTALL_METHOD" == "symlink" ]]; then
     echo -e "${GREEN}Creating symlink:${NC} ${dest_path} -> ${src_path}"
     ln -s "$src_path" "$dest_path"
@@ -89,8 +81,55 @@ install_dir() {
   fi
 }
 
-# Install each configuration directory
-install_dir "claude" ".claude"
+# Function to install a top-level directory from the repo into the home directory
+install_dir() {
+  local src_name="$1"
+  local dest_name="$2"
+  local src_path="${SCRIPT_DIR}/${src_name}"
+  local dest_path="${HOME}/${dest_name}"
+
+  if [[ ! -d "$src_path" ]]; then
+    echo -e "${YELLOW}Skipping ${src_name} (not found in repository)${NC}"
+    return
+  fi
+
+  install_path "$src_path" "$dest_path"
+}
+
+# Whitelist only: ~/.claude/settings.json, ~/.claude/skills/, ~/.claude/agents/
+install_claude_whitelist() {
+  local claude_src="${SCRIPT_DIR}/claude"
+
+  if [[ ! -d "$claude_src" ]]; then
+    echo -e "${YELLOW}Skipping claude/ (not found in repository)${NC}"
+    return
+  fi
+
+  # Replace legacy full-tree ~/.claude symlink with a real directory
+  if [[ -L "${HOME}/.claude" ]]; then
+    backup_if_exists "${HOME}/.claude"
+  fi
+  mkdir -p "${HOME}/.claude"
+
+  local settings_src="${claude_src}/settings.json"
+  if [[ -f "$settings_src" ]]; then
+    install_path "$settings_src" "${HOME}/.claude/settings.json"
+  else
+    echo -e "${YELLOW}Skipping claude/settings.json (not found in repository)${NC}"
+  fi
+
+  local name
+  for name in skills agents; do
+    local sub_src="${claude_src}/${name}"
+    if [[ -d "$sub_src" ]]; then
+      install_path "$sub_src" "${HOME}/.claude/${name}"
+    else
+      echo -e "${YELLOW}Skipping claude/${name}/ (not found in repository)${NC}"
+    fi
+  done
+}
+
+install_claude_whitelist
 install_dir "cursor" ".cursor"
 
 echo ""


### PR DESCRIPTION
Installs only `~/.claude/settings.json`, `skills/`, and `agents/` from the repo so machine-local Claude data stays out of the dotfiles tree. Adds a matching `.gitignore` under `claude/` so only those paths are tracked. README and `--help` describe the whitelist.

Made with [Cursor](https://cursor.com)