### PR TITLE
feat(agents): add riskmancer security reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ git pull
 A hook automatically runs when you end a Claude session to check if code changes require documentation updates. This helps maintain documentation quality without manual effort.
 
 ### Specialized Agents
-**Quill** - Documentation specialist agent that creates and updates project documentation, API specs, and architecture guides.
+Specialized AI assistants are available for documentation (Quill) and security reviews (Riskmancer). See [docs/AGENTS.md](/docs/AGENTS.md) for the complete agent catalog.
 
 ### Skills Library
 Reusable capabilities including skill creation, commit message generation, and pull request automation.

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -1,0 +1,31 @@
+---
+name: riskmancer
+description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
+model: claude-opus-4-6
+level: 3
+disallowedTools: Write, Edit
+---
+
+# Riskmancer - Security Reviewer Agent
+
+## Core Mission
+The Riskmancer agent identifies and prioritizes vulnerabilities before production deployment, focusing on OWASP Top 10 analysis, secrets detection, input validation, and authentication checks. It operates in read-only mode with blocked write/edit capabilities.
+
+## Key Responsibilities
+- Evaluate all applicable OWASP Top 10 categories
+- Conduct secrets scanning for hardcoded credentials
+- Run dependency audits across package managers
+- Prioritize findings by severity × exploitability × blast radius
+- Provide remediation with secure code examples matching the source language
+
+## Investigation Protocol
+The agent follows a structured approach: identifying scope and technology stack, scanning for exposed secrets, running appropriate audits (npm, pip, cargo, govulncheck), evaluating each OWASP category systematically, prioritizing vulnerabilities, and delivering actionable remediation guidance.
+
+## Tool Usage
+Permitted tools include Grep for pattern detection, ast_grep_search for structural vulnerabilities, Bash for dependency audits, and Read for code examination. The agent may delegate via Task agents for cross-validation but skips silently if unavailable.
+
+## Output Standards
+Reports must include scope, overall risk level, issue summaries, detailed findings with locations/severity/remediation, and security checklists. Each vulnerability requires clear exploitation pathways and blast radius assessment.
+
+## Success Criteria
+Complete OWASP evaluation, findings prioritized appropriately, location-specific remediation with code examples, completed secrets/dependency scans, and explicit risk-level assessment.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,106 @@
+# Agent Reference
+
+This document provides a comprehensive guide to the specialized agents available in this Claude Code configuration.
+
+## Quick Reference
+
+| Agent | Purpose | Primary Use Cases | Model |
+|-------|---------|-------------------|-------|
+| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4.5 |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-6 |
+
+## When to Use Which Agent
+
+```
+Documentation needs → Quill
+Security review → Riskmancer
+```
+
+## Detailed Agent Profiles
+
+### Quill - Documentation Specialist
+
+**Core Mission:** Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
+
+**Invoke when:**
+- Adding major features or API changes
+- Onboarding new developers to a project
+- Documentation is out of sync with code
+- Creating architecture or design documentation
+- Generating API specifications
+
+**Key Capabilities:**
+- Gap analysis of existing documentation
+- README generation and updates
+- API specification creation (including OpenAPI/YAML)
+- Architecture guide development
+- User manual creation
+- Technical accuracy validation
+- Code example extraction from tests and implementations
+
+**Available Tools:**
+- File operations: Read, Write, Edit
+- Search: Grep, Glob
+- Bash commands for system tasks
+
+**Typical Workflow:**
+1. Audits existing documentation against current codebase
+2. Identifies gaps, outdated content, and missing sections
+3. Plans document structure with hierarchical headings
+4. Creates clear Markdown with functional code snippets
+5. Validates technical precision and link integrity
+
+**Output Format:** Concise change log listing created/modified files with single-line summaries.
+
+**Best Practice:** Invoke Quill proactively after completing features rather than waiting for documentation to become severely outdated.
+
+**Configuration File:** `/claude/agents/quill.md`
+
+---
+
+### Riskmancer - Security Reviewer
+
+**Core Mission:** Identify and prioritize vulnerabilities before production deployment, focusing on OWASP Top 10 analysis, secrets detection, input validation, and authentication checks.
+
+**Invoke when:**
+- Conducting pre-deployment security reviews
+- Auditing code for security vulnerabilities
+- Reviewing authentication or authorization changes
+- Checking for exposed secrets or credentials
+- Validating input handling and sanitization
+- Running dependency vulnerability checks
+
+**Key Capabilities:**
+- OWASP Top 10 vulnerability evaluation
+- Secrets scanning for hardcoded credentials, API keys, tokens
+- Dependency audit execution (npm, pip, cargo, govulncheck)
+- Input validation and sanitization analysis
+- Authentication and authorization review
+- Vulnerability prioritization by severity × exploitability × blast radius
+- Remediation guidance with secure code examples in source language
+
+**Available Tools:**
+- Read-only access: Read, Grep, ast_grep_search
+- Bash (for dependency audits only)
+- Write/Edit tools are explicitly blocked
+
+**Typical Workflow:**
+1. Identifies scope and technology stack
+2. Scans for exposed secrets and credentials
+3. Runs appropriate dependency vulnerability audits
+4. Evaluates each applicable OWASP Top 10 category systematically
+5. Prioritizes findings by risk level
+6. Delivers actionable remediation guidance
+
+**Output Format:** Security report including:
+- Scope definition
+- Overall risk level assessment
+- Issue summaries by severity
+- Detailed findings with file locations, severity ratings, and remediation steps
+- Security checklists for validation
+- Exploitation pathways and blast radius for each vulnerability
+
+**Best Practice:** Invoke Riskmancer before production deployments or when reviewing security-sensitive code changes. The read-only nature ensures no accidental modifications during security audits.
+
+**Configuration File:** `/claude/agents/riskmancer.md`
+

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -45,32 +45,14 @@ This hook helps maintain documentation quality by catching missing updates befor
 
 Agents are specialized AI assistants that help with specific tasks. They are automatically available in Claude Code.
 
-### Quill - Documentation Specialist
+**Available agents:**
+- **Quill** - Documentation specialist for README files, API specs, and architecture guides
+- **Riskmancer** - Security reviewer for vulnerability detection, secrets scanning, and OWASP analysis
 
-**Purpose:** Create and update project documentation
+**Invoking an agent:**
+Simply @-mention the agent by name (e.g., `@quill` or `@riskmancer`) in your Claude conversation to activate it.
 
-**Use when:**
-- Adding major features
-- Making API changes
-- Onboarding new developers
-- Documentation is out of sync with code
-
-**Capabilities:**
-- Generate README files
-- Create API specifications (including OpenAPI/YAML)
-- Write architecture guides
-- Develop user manuals
-- Audit existing documentation for gaps
-
-**Available tools:** File operations (Read, Write, Edit), search (Grep, Glob), and Bash commands
-
-**Workflow:**
-1. Analyzes codebase and existing documentation
-2. Identifies gaps and outdated content
-3. Creates structured documentation with examples
-4. Validates technical accuracy
-
-Invoke Quill proactively after completing features rather than waiting for documentation to become severely outdated.
+For complete agent capabilities, workflows, use cases, and best practices, see [docs/AGENTS.md](/docs/AGENTS.md).
 
 ## Skills (`claude/skills/`)
 


### PR DESCRIPTION
## Summary
- Adds Riskmancer agent for security vulnerability detection (OWASP Top 10, secrets scanning, dependency audits)
- Creates centralized agent catalog at docs/AGENTS.md
- Refactors README and CONFIGURATION docs to eliminate duplication and follow DRY principle

## Test plan
- [ ] Verify riskmancer agent definition is valid
- [ ] Confirm AGENTS.md catalog is accessible and complete
- [ ] Check that README and CONFIGURATION.md link correctly to AGENTS.md
- [ ] Review documentation for clarity and consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)