### PR TITLE
chore: remove superpowers plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,6 @@ Copies the same whitelisted Claude paths into `~/.claude/` and `~/.cursor/` when
 
 **Note:** The installer automatically backs up any existing configurations with a timestamp.
 
-## Claude Plugins
-
-The installation script automatically:
-1. Adds the **claude-plugins-official** marketplace (if not already configured)
-2. Installs the following plugins:
-   - **superpowers@claude-plugins-official** - Enhanced Claude Code capabilities
-
-If Claude Code is not installed when you run the script, plugin installation will be skipped. You can re-run the script later after installing Claude Code to install the plugins.
-
 For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
 
 ## Updating

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,7 +1,18 @@
 {
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "Check if code changes in this session require documentation updates. Steps: 1) Run git status and git diff to see uncommitted changes. 2) If no code changes (only docs changed or clean), return success with no message. 3) If code changes exist, check for README.md, docs/, or documentation/. If no docs exist, skip check. 4) Read relevant documentation and analyze if it covers the new/changed functionality. 5) Only if documentation genuinely needs updating, UPDATE THE DOCUMENTATION. Be conservative - minor refactors or internal changes rarely need doc updates.",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
   },
+  "enabledPlugins": {},
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {
@@ -9,19 +20,5 @@
         "repo": "anthropics/claude-plugins-official"
       }
     }
-  },
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "agent",
-            "agent": "quill",
-            "prompt": "Check if code changes in this session require documentation updates. Steps: 1) Run git status and git diff to see uncommitted changes. 2) If no code changes (only docs changed or clean), return success with no message. 3) If code changes exist, check for README.md, docs/, or documentation/. If no docs exist, skip check. 4) Read relevant documentation and analyze if it covers the new/changed functionality. 5) Only if documentation genuinely needs updating, UPDATE THE DOCUMENTATION. Be conservative - minor refactors or internal changes rarely need doc updates.",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,12 +6,6 @@ This document explains the Claude Code configurations included in this repositor
 
 The settings file configures Claude Code's behavior, including plugins, marketplaces, and hooks.
 
-### Plugins
-
-The configuration automatically enables:
-
-- **superpowers@claude-plugins-official** - Enhanced Claude Code capabilities including advanced features and integrations
-
 ### Marketplaces
 
 Pre-configured marketplaces for plugin discovery:

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Claude Code:"
       echo "  - Whitelisted paths: settings.json, skills/, agents/"
-      echo "  - Plugins: superpowers@claude-plugins-official (auto-installed)"
       echo ""
       echo "Options:"
       echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
@@ -130,51 +129,7 @@ install_claude_whitelist() {
   done
 }
 
-# Install Claude plugins
-install_claude_plugins() {
-  # Check if claude command is available
-  if ! command -v claude &> /dev/null; then
-    echo -e "${YELLOW}Claude command not found, skipping plugin installation${NC}"
-    echo -e "${YELLOW}Install Claude Code first, then run this script again${NC}"
-    return
-  fi
-
-  local marketplace="claude-plugins-official"
-  local plugin="superpowers@${marketplace}"
-
-  # Add marketplace if not already configured
-  if ! claude plugin marketplace list 2>/dev/null | grep -q "${marketplace}"; then
-    echo -e "${BLUE}Adding marketplace: ${marketplace}${NC}"
-    local marketplace_output
-    marketplace_output=$(claude plugin marketplace add "anthropics/${marketplace}" 2>&1)
-    if echo "$marketplace_output" | grep -qE "(Successfully added|already on disk)"; then
-      echo -e "${GREEN}✓ Marketplace ${marketplace} configured${NC}"
-    else
-      echo -e "${RED}Failed to add marketplace${NC}"
-      echo -e "${YELLOW}You can add it manually with: claude plugin marketplace add anthropics/${marketplace}${NC}"
-      return
-    fi
-  fi
-
-  # Check if plugin is already installed
-  if claude plugin list 2>/dev/null | grep -q "${plugin}"; then
-    echo -e "${GREEN}Plugin ${plugin} is already installed${NC}"
-  else
-    echo -e "${BLUE}Installing plugin: ${plugin}${NC}"
-    local plugin_output
-    plugin_output=$(claude plugin install "$plugin" 2>&1)
-    if echo "$plugin_output" | grep -qE "(Successfully installed|already installed)"; then
-      echo -e "${GREEN}✓ Successfully installed ${plugin}${NC}"
-    else
-      echo -e "${RED}Failed to install ${plugin}${NC}"
-      echo "$plugin_output"
-      echo -e "${YELLOW}You can install it manually with: claude plugin install ${plugin}${NC}"
-    fi
-  fi
-}
-
 install_claude_whitelist
-install_claude_plugins
 install_dir "cursor" ".cursor"
 
 echo ""


### PR DESCRIPTION
Removed superpowers plugin dependency to simplify setup and eliminate conflicts between plugin skills and custom agents. Repository now focuses exclusively on custom agents (Pathfinder, Quill, Riskmancer) and skills.