### PR TITLE
feat(skills): enhance open-pr skill with mandatory triggers and pr checks

### DIFF
--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -1,21 +1,57 @@
 ---
 name: open-pull-request
-description: Open PRs with conventional branch names and conventional-commit titles. Use for pull/merge requests, gh pr create / glab, or naming branches and PR titles.
+description: REQUIRED for all pull requests. Always use when opening PRs, creating merge requests, or executing gh pr create / glab mr create commands. Enforces conventional branch names and conventional-commit PR titles.
+TRIGGER: user asks to open/create a PR or MR, mentions pushing and opening a PR, references gh/glab commands, or discusses pull request workflow.
+DO NOT SKIP: applies to all PR creation regardless of repository or context.
 ---
 
 # Open Pull Request (Conventional Branch + Conventional Title)
 
 This skill extends the usual workflow (inspect state → branch → commit or amend → confirm all tracked work is committed → push → open PR) so **branch names** follow [Conventional Branch](https://conventional-branch.github.io/) and **PR titles** follow the same rules as [Conventional Commits](https://www.conventionalcommits.org/)—aligned with the `commit-message-guide` skill for commits.
 
+## IMPORTANT: When This Skill Applies
+
+This skill is **mandatory** for:
+- Any request to open, create, or draft a pull request or merge request
+- Commands like `gh pr create`, `glab mr create`, or GitLab/GitHub UI PR creation
+- Workflows involving "push and open PR" or "create PR from branch"
+- Branch naming when the branch will be used for a PR
+
+**Do not** create PRs through other means or skip this workflow.
+
+## Non-Negotiable Requirements
+
+Every PR must:
+1. Use conventional branch naming (`<type>/<description>`)
+2. Have a conventional commit title (`<type>(<scope>): <subject>`)
+3. Be opened as `--draft` (unless explicitly requested otherwise)
+4. Be assigned to `@me` (the user)
+5. Have all changes committed before push
+
 ## Workflow
 
-1. **Inspect state**: `git status`, `git branch --show-current`, confirm remote and default branch.
-2. **Branch** (if needed): If on `main`/`master`/`develop` or the user wants a new branch, create one using the naming rules below. If already on a correctly named branch, keep it.
-3. **Commit**: Stage changes, then record history using the **commit-message-guide** for message text. Prefer **few commits** on the branch—see **Commit history** below. Every change that belongs in the PR must end up **committed** on this branch; uncommitted work will not appear on the PR.
-4. **Pre-push (required)**: Do **not** push to upstream until **every change Git already tracks** (and every new file that should be in the PR) is committed. Run `git status`; if you see unstaged changes, staged changes waiting for a commit, or deletions not yet committed, resolve via amend, fixup, or a new commit (per **Commit history**) until there is nothing left to commit for work that should ship. Untracked files stay out until you intentionally `git add` and commit them.
-5. **Push**: `git push -u origin <branch>` (or your remote/branch convention) to upstream. If you **amended or rebased** commits that were **already pushed**, use `git push --force-with-lease` instead of a plain push. The PR compares the default branch to this branch, so **all commits you pushed** are what the PR contains.
-6. **Open PR (always draft, assign to the user)**:
-   - **GitHub**: `gh pr create --draft --assignee @me --title "..." --body "..."`  
+1. **Check existing PR status**: Before starting work, check if the current branch already has an open or merged PR associated with it.
+   - **GitHub**: `gh pr list --head $(git branch --show-current)` to check for open PRs, and `gh pr list --head $(git branch --show-current) --state merged` for merged PRs.
+   - **GitLab**: `glab mr list --source-branch $(git branch --show-current)` for open MRs, and `glab mr list --source-branch $(git branch --show-current) --state merged` for merged MRs.
+   - **If a PR/MR exists** (open or merged): This branch has already been used. **Do not** add new commits to it. Instead:
+     - Stash any uncommitted changes: `git stash`
+     - Switch to the main branch: `git checkout main` (or `master`/`develop` as appropriate)
+     - Fetch latest changes: `git pull origin main` (or appropriate remote/branch)
+     - Proceed to step 2 to create a new branch for the new work
+   - **If no PR/MR exists**: Continue to step 2.
+
+2. **Inspect state**: `git status`, `git branch --show-current`, confirm remote and default branch.
+
+3. **Branch** (if needed): If on `main`/`master`/`develop` or the user wants a new branch, create one using the naming rules below. If already on a correctly named branch (with no existing PR per step 1), keep it.
+
+4. **Commit**: Stage changes, then record history using the **commit-message-guide** for message text. Prefer **few commits** on the branch—see **Commit history** below. Every change that belongs in the PR must end up **committed** on this branch; uncommitted work will not appear on the PR.
+
+5. **Pre-push (required)**: Do **not** push to upstream until **every change Git already tracks** (and every new file that should be in the PR) is committed. Run `git status`; if you see unstaged changes, staged changes waiting for a commit, or deletions not yet committed, resolve via amend, fixup, or a new commit (per **Commit history**) until there is nothing left to commit for work that should ship. Untracked files stay out until you intentionally `git add` and commit them.
+
+6. **Push**: `git push -u origin <branch>` (or your remote/branch convention) to upstream. If you **amended or rebased** commits that were **already pushed**, use `git push --force-with-lease` instead of a plain push. The PR compares the default branch to this branch, so **all commits you pushed** are what the PR contains.
+
+7. **Open PR (always draft, assign to the user)**:
+   - **GitHub**: `gh pr create --draft --assignee @me --title "..." --body "..."`
      Use `@me` so the PR is **assigned to the person opening it** (the user’s GitHub account). Adjust only if the repo uses a different assignee rule.
    - **GitLab**: `glab mr create --draft --assignee @me` (or your login) with the same title/body rules; use the web UI only if you mirror draft + assignee there.
 
@@ -122,6 +158,7 @@ After push, open with draft + assignee, e.g. `gh pr create --draft --assignee @m
 
 ## Pre-flight checklist
 
+- [ ] **Branch has no existing PR**: Verified that the current branch has no open or merged PR—if one exists, switched to main, fetched latest, and created a new branch
 - [ ] **Before push**: all tracked changes (and intended new files) are **committed**—`git status` shows nothing that still needs committing for work going into the PR
 - [ ] History is **compact**: prefer `--amend` / `--fixup` + autosquash; new commits only when scope or topic differs
 - [ ] Branch matches `<prefix>/<description>` and Conventional Branch character rules


### PR DESCRIPTION
Makes the open-pull-request skill mandatory for all PR creation by strengthening its description with REQUIRED/TRIGGER/DO NOT SKIP language. Adds a new pre-flight check that detects if the current branch already has an open or merged PR, preventing accidental commits to already-used branches by automatically switching to main and creating a fresh branch.

This prevents workflow errors where commits get added to merged PR branches and ensures the skill is consistently applied across all PR operations.