### PR TITLE
docs(agents): add Talekeeper avatar to agent reference

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -526,6 +526,8 @@ Activate with `--consensus` flag for enhanced decision support:
 
 ### Talekeeper - Session Chronicler
 
+<img src="avatars/talekeeper.png" alt="Talekeeper Avatar" width="300">
+
 > *"Every deed deserves its verse."*
 
 **Configuration:** `claude/agents/talekeeper.md`


### PR DESCRIPTION
Adds the Talekeeper portrait to the agent reference so it matches the other profiles in `docs/AGENTS.md`. The image file was already in the repo; this wires it into the documentation.

Made with [Cursor](https://cursor.com)