### PR TITLE
chore(skills): add probe-based GitHub account validation

### DIFF
--- a/claude/skills/commit-message-guide/SKILL.md
+++ b/claude/skills/commit-message-guide/SKILL.md
@@ -123,6 +123,7 @@ Created with `git commit --fixup=<commit-hash>` for automatic squashing during r
 
 Before creating a commit, verify:
 
+- [ ] **GitHub account**: Extract `{owner}/{repo}` from `git remote get-url origin`. Run `gh api repos/{owner}/{repo}` as a harmless probe. If it succeeds, the current account has access — proceed. If it fails, run `gh auth switch` to cycle to the next authenticated account and probe again. Repeat until access is confirmed or all accounts are exhausted. If all accounts fail, abort and report.
 - [ ] Code builds successfully
 - [ ] All tests pass
 - [ ] Code is formatted (run formatter)

--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -158,6 +158,8 @@ After push, open with draft + assignee, e.g. `gh pr create --draft --assignee @m
 
 ## Pre-flight checklist
 
+- [ ] **GitHub account**: Extract `{owner}/{repo}` from `git remote get-url origin`. Run `gh api repos/{owner}/{repo}` as a harmless probe. If it succeeds, the current account has access — proceed. If it fails, run `gh auth switch` to cycle to the next authenticated account and probe again. Repeat until access is confirmed or all accounts are exhausted. If all accounts fail, abort and report. Do not push or open the PR until the probe succeeds.
+- [ ] **Commit author**: Once the correct account is confirmed, verify `git config user.email` belongs to that account (cross-check with `gh api user --jq '.email'` if unsure). Fix with `git config user.email "correct@email.com"` if wrong.
 - [ ] **Branch has no existing PR**: Verified that the current branch has no open or merged PR—if one exists, switched to main, fetched latest, and created a new branch
 - [ ] **Before push**: all tracked changes (and intended new files) are **committed**—`git status` shows nothing that still needs committing for work going into the PR
 - [ ] History is **compact**: prefer `--amend` / `--fixup` + autosquash; new commits only when scope or topic differs


### PR DESCRIPTION
## Summary

- Adds a GitHub account validation step as the first item in both `commit-message-guide` and `open-pull-request` skill checklists
- Uses `gh api repos/{owner}/{repo}` as a harmless read probe to confirm the active `gh` account has access to the repo
- If the probe fails, cycles through authenticated accounts via `gh auth switch` until one succeeds or all are exhausted
- No hardcoded emails, usernames, or mappings required — works for personal accounts, personal orgs, work orgs, and any number of accounts

## Test plan

- [ ] Clone a repo belonging to account A while `gh` is authenticated as account B — confirm the probe detects the mismatch and switches to account A
- [ ] Verify the pre-commit check in `commit-message-guide` runs before any commit is made
- [ ] Verify the pre-flight check in `open-pull-request` blocks push/PR until the probe succeeds
- [ ] Confirm behaviour when all accounts lack access (should abort and report)