### PR TITLE
fix(hooks): use halt_pipeline to gate docs-check instead of exit 2

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,8 +16,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git diff --quiet HEAD && exit 2 || exit 0",
-            "timeout": 5
+            "command": "git diff --quiet HEAD && exit 1 || exit 0",
+            "timeout": 5,
+            "halt_pipeline": true
           },
           {
             "type": "agent",


### PR DESCRIPTION
Exit code 2 on Stop hooks prevents session termination rather than skipping subsequent hooks. Replacing with `halt_pipeline: true` + exit 1, which correctly halts the pipeline without blocking the session from ending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)