### PR TITLE
feat(agents): add test-first annotation to Pathfinder/Bitsmith pipeline

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -93,6 +93,8 @@ Break the implementation into discrete, ordered, verifiable steps using TodoWrit
 - **Verifiable** — Has a clear pass/fail condition
 - **Ordered** — Sequenced so earlier steps do not block later ones
 
+**Test-First Steps:** If a plan step is annotated with `**test-first:** true`, prepend a `[ ] Write failing test for: {step description}` atomic work item before any implementation items for that step. This test must fail (RED) before implementation begins. Do not skip this even if implementation seems straightforward. If a failing test cannot be written without partial implementation scaffolding (e.g., the type or interface under test does not yet exist), create the minimal type stub or interface first, then write the failing test, then implement. If even that is not feasible, escalate to Pathfinder.
+
 Do not begin hammering until the full sequence is planned.
 
 ### Phase 6: Implement Incrementally

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -65,6 +65,7 @@ Once requirements are clear and research is complete:
 3. Avoid over-specification (not 30 micro-steps)
 4. Avoid vagueness (not "step 1: implement")
 5. Get explicit user confirmation before finalizing
+6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created").
 
 ### 5. Save Plan
 
@@ -120,6 +121,8 @@ Objectives:
 ## Task Flow
 
 ### Step 1: {Component Name}
+- **test-first:** true
+<!-- Remove test-first line for steps with purely structural acceptance criteria -->
 - [ ] {Specific actionable task}
 - [ ] {Another specific task}
 - **Acceptance:** {Clear success criteria}


### PR DESCRIPTION
Pathfinder can now annotate plan steps with `test-first: true` when acceptance criteria describe behavior ("given X, the system does Y"). Bitsmith reads the annotation and writes a failing test before implementation, enforcing RED-phase discipline without a dedicated TDD agent. A three-tier fallback handles cases where a test cannot be written without scaffolding: write directly → create minimal stub first → escalate to Pathfinder.