### PR TITLE
chore(claude): add CLAUDE.md to mandate commit and PR skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Match install.sh whitelist: only settings.json, skills/, agents/ are tracked under claude/
+# Match install.sh whitelist: only CLAUDE.md, settings.json, skills/, agents/ are tracked under claude/
 claude/**
+!claude/CLAUDE.md
 !claude/settings.json
 !claude/skills/
 !claude/skills/**

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Keep AI tool configurations version-controlled and portable across machines. The
 
 ```
 .
-├── claude/          # Claude Code configs (whitelist: settings.json, skills/, agents/)
-│   ├── settings.json    # Plugin config, hooks, marketplace settings
+├── claude/          # Claude Code configs (whitelist: settings.json, CLAUDE.md, skills/, agents/)
+│   ├── CLAUDE.md         # User-global instructions (skill mandates)
+│   ├── settings.json     # Plugin config, hooks, marketplace settings
 │   ├── agents/          # Specialized AI assistants (e.g., Quill for docs)
 │   └── skills/          # Reusable capabilities
 ├── cursor/          # Cursor configurations (coming soon)
@@ -28,7 +29,7 @@ Keep AI tool configurations version-controlled and portable across machines. The
 └── install.sh       # Installation script
 ```
 
-The installer only installs these paths from `claude/` into `~/.claude/`: `settings.json`, `skills/`, and `agents/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
+The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, and `agents/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
 
 ## Installation
 
@@ -45,14 +46,14 @@ Run the installation script:
 ./install.sh
 ```
 
-Creates symbolic links for the whitelisted Claude paths (`settings.json`, `skills/`, `agents/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
+Creates symbolic links for the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
 
 ### Option 2: Copy Files
 ```bash
 ./install.sh --copy
 ```
 
-Copies the same whitelisted Claude paths into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
+Copies the same whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`) into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
 
 **Note:** The installer automatically backs up any existing configurations with a timestamp.
 
@@ -82,7 +83,7 @@ When you want a human-readable summary of past sessions, invoke the Talekeeper n
 Specialized AI assistants are available for orchestration (Dungeon Master), documentation (Quill), security reviews (Riskmancer), planning (Pathfinder), complexity reduction (Knotcutter), session narration (Talekeeper), and team meta-analysis (Everwise). The orchestration workflow uses an intelligent review system that reduces overhead by 60-70% while maintaining quality. See [docs/AGENTS.md](/docs/AGENTS.md) for the complete agent catalog and [docs/adrs/REVIEW_WORKFLOW.md](/docs/adrs/REVIEW_WORKFLOW.md) for the review workflow guide.
 
 ### Skills Library
-Reusable capabilities including skill creation, commit message generation, and pull request automation.
+Reusable capabilities including skill creation, commit message generation, and pull request automation. The `commit-message-guide` and `open-pull-request` skills are mandated globally via `CLAUDE.md` for all projects.
 
 ## Agent Orchestration Workflow
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,15 @@
+<!-- Managed by ai-tpk. Do not edit directly; changes will be overwritten by install.sh -->
+
+# User-Global Claude Code Instructions
+
+These instructions are loaded by Claude Code at session start for every project.
+
+## Mandatory Skills
+
+### Commit Message Guide
+
+ALL git commits must follow the `commit-message-guide` skill. Conventional commit format is required, no exceptions.
+
+### Open Pull Request
+
+ALL pull requests and merge requests must be created using the `open-pull-request` skill. No other PR creation method is allowed.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -63,6 +63,15 @@ Processes the raw sub-agent event log captured during the session into a structu
 - Timeout: 60 seconds
 - Requires `jq`; exits silently if unavailable or raw log is empty
 
+## User-Global Instructions (claude/CLAUDE.md)
+
+`CLAUDE.md` is loaded by Claude Code at session start for every project. It mandates two skills that apply globally across all work:
+
+- **`commit-message-guide`** — required for all git commits; conventional commit format is enforced, no exceptions
+- **`open-pull-request`** — required for all pull requests and merge requests; no other PR creation method is allowed
+
+These mandates are active for every project. Project-level `.claude/CLAUDE.md` files can provide additional instructions; however, skill mandate enforcement depends on Claude Code's instruction precedence behavior.
+
 ## Agents (`claude/agents/`)
 
 Agents are specialized AI assistants that help with specific tasks. They are automatically available in Claude Code.

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
       echo "Install AI TPK to your home directory."
       echo ""
       echo "Claude Code:"
-      echo "  - Whitelisted paths: settings.json, skills/, agents/"
+      echo "  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/"
       echo ""
       echo "Options:"
       echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
@@ -96,7 +96,7 @@ install_dir() {
   install_path "$src_path" "$dest_path"
 }
 
-# Whitelist only: ~/.claude/settings.json, ~/.claude/skills/, ~/.claude/agents/
+# Whitelist only: ~/.claude/settings.json, ~/.claude/CLAUDE.md, ~/.claude/skills/, ~/.claude/agents/
 install_claude_whitelist() {
   local claude_src="${SCRIPT_DIR}/claude"
 
@@ -116,6 +116,13 @@ install_claude_whitelist() {
     install_path "$settings_src" "${HOME}/.claude/settings.json"
   else
     echo -e "${YELLOW}Skipping claude/settings.json (not found in repository)${NC}"
+  fi
+
+  local claude_md_src="${claude_src}/CLAUDE.md"
+  if [[ -f "$claude_md_src" ]]; then
+    install_path "$claude_md_src" "${HOME}/.claude/CLAUDE.md"
+  else
+    echo -e "${YELLOW}Skipping claude/CLAUDE.md (not found in repository)${NC}"
   fi
 
   local name


### PR DESCRIPTION
## Summary

- Adds `claude/CLAUDE.md` as the user-global instruction file loaded by Claude Code at session start for every project
- Mandates `commit-message-guide` (conventional commits) and `open-pull-request` (conventional branch + PR titles, always draft) across all projects
- Updates `install.sh` to deploy `claude/CLAUDE.md` → `~/.claude/CLAUDE.md` alongside existing whitelisted paths
- Updates `README.md` and `docs/CONFIGURATION.md` to document the new file and its mandates

## Test plan

- [ ] Run `./install.sh` and verify `~/.claude/CLAUDE.md` is symlinked correctly
- [ ] Run `./install.sh --copy` and verify `~/.claude/CLAUDE.md` is copied correctly
- [ ] Confirm `./install.sh --help` lists `CLAUDE.md` in the whitelisted paths output
- [ ] Confirm `claude/CLAUDE.md` appears in `git status` / is tracked (not gitignored)