### PR TITLE
chore(agents): harden tool permissions and reviewer posture

### DIFF
--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -1,7 +1,7 @@
 ---
 name: knotcutter
 description: "Radical simplification specialist. Cuts through complexity by questioning necessity, eliminating over-engineering, and reducing systems to their essential core. Use when codebases are bloated, abstractions proliferate, or solutions feel needlessly complex."
-tools: "Read, Grep, Glob, Bash, Write, Edit"
+disallowedTools: Write, Edit
 model: claude-opus-4-6
 mandatory: false
 trigger_keywords: ["refactor", "architecture", "abstraction", "framework", "pattern", "generalize", "reusable", "complexity", "simplify", "redesign", "restructure"]
@@ -43,7 +43,7 @@ Knotcutter operates at two critical checkpoints to prevent complexity before it'
    - Review code for actual complexity vs. planned complexity
    - Identify over-engineering, unnecessary abstractions, and speculative features
    - Propose aggressive simplification and reduction
-   - Inline single-use helpers and remove unused configurations
+   - Flag single-use helpers that should be inlined and unused configurations that should be removed
 
 ## Operational Framework
 
@@ -126,15 +126,17 @@ Knotcutter operates at two critical checkpoints to prevent complexity before it'
 
 ## Tool Usage
 
-**Read & Analyze**: Study existing code to understand complexity sources
+**Permitted:**
+- Read: Study existing code to understand complexity sources
+- Grep: Find actual usage patterns vs. theoretical capabilities
+- Glob: Locate files by name or pattern
+- Bash: Test assumptions about what's actually being used (read-only commands only)
 
-**Grep & Glob**: Find actual usage patterns vs. theoretical capabilities
+**Blocked:**
+- Write: Knotcutter never creates or overwrites files
+- Edit: Knotcutter never modifies existing files
 
-**Bash**: Test assumptions about what's actually being used
-
-**Edit**: Inline abstractions, remove layers, simplify control flow
-
-**Write**: Replace complex systems with simple, direct solutions
+Knotcutter operates read-only and returns all findings in-memory. Recommendations are surfaced as review output to Dungeon Master — implementation is delegated to Bitsmith.
 
 ## Output Standards
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -1,7 +1,7 @@
 ---
 name: quill
 description: "MUST BE USED to craft or update project documentation. Use PROACTIVELY after major features, API changes, or when onboarding developers. Produces READMEs, API specs, architecture guides, and user manuals."
-tools: "LS, Read, Grep, Glob, Bash, Write, Edit"
+tools: "Read, Grep, Glob, Bash, Write, Edit"
 model: claude-haiku-4-5
 ---
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -39,6 +39,7 @@
       }
     ]
   },
+  "defaultMode": "dontAsk",
   "enabledPlugins": {},
   "extraKnownMarketplaces": {
     "claude-plugins-official": {


### PR DESCRIPTION
Enforces a strict read-only posture for Knotcutter by switching from a tools allowlist to disallowedTools: Write, Edit, and updates the agent body text to match. Removes the invalid LS tool entry from Quill. Sets defaultMode: dontAsk in claude/settings.json so unrecognized tool permission requests fail closed instead of prompting interactively.