### PR TITLE
feat(agents): invoke quill from dungeon master phase 5

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,9 @@
     "Bitsmith",
     "Truthhammer",
     "Pathfinder",
-    "adrs"
-  ]
+    "adrs",
+    "talekeeper",
+    "anthropics"
+  ],
+  "ignoreWords": ["dontAsk"]
 }

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ git pull
 
 ## Features
 
-### Automated Documentation Checks
-A hook automatically runs when you end a Claude session to check if code changes require documentation updates. This helps maintain documentation quality without manual effort.
+### Documentation Integration
+The Dungeon Master orchestration agent automatically invokes Quill (documentation specialist) as the final step of Phase 5 (Completion) when a planning session was conducted. Quill receives the plan file, list of changed files, and feature summary, then updates documentation to reflect the implementation. This ensures documentation stays synchronized with code without manual effort.
 
 ### Session Logging
 Orchestration sessions are automatically chronicled by a two-stage shell pipeline. During each session, `talekeeper-capture.sh` runs as a SubagentStop command hook and appends raw sub-agent events to `logs/talekeeper-raw.jsonl`. At session end, `talekeeper-enrich.sh` runs as an async Stop hook and processes the raw log into a structured enriched JSONL chronicle (`logs/talekeeper-{session_id}.jsonl`). Both scripts filter out internal hook-agent noise. Logs are gitignored and stay local to your machine.

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -191,18 +191,31 @@ Follow this sequence:
 17. Phase 4 complete — all implementation reviewers have issued ACCEPT or ACCEPT-WITH-RESERVATIONS.
 
 ### Phase 5: Completion
-18. Before finishing:
-    - confirm the requested outcome was actually achieved
-    - summarize completed work (plan, reviews, execution, validation)
-    - note any unfinished items or follow-ups
-    - if notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
-    - When any reviewer issues ACCEPT-WITH-RESERVATIONS, extract the reservations from the review findings and include them in your completion summary. Then delegate to Bitsmith: instruct it to append the reservations to `plans/open-questions.md` under a section titled "Review Reservations - [session date]" with the specific issues noted. If the file does not exist, Bitsmith should create it first with the following header:
+18. Before finishing, execute the following three sub-steps in order:
+
+    **5a — Reservations logging:**
+    When any reviewer issues ACCEPT-WITH-RESERVATIONS, extract the reservations from the review findings and include them in your completion summary. Then delegate to Bitsmith: instruct it to append the reservations to `plans/open-questions.md` under a section titled "Review Reservations - [session date]" with the specific issues noted. If the file does not exist, Bitsmith should create it first with the following header:
       ```
       # Open Questions and Review Reservations
 
       This file tracks reservations from ACCEPT-WITH-RESERVATIONS reviewer verdicts and open questions from planning sessions.
       ```
       These become tracked items for future sessions.
+
+    **5b — Documentation update:**
+    If Pathfinder was invoked during this session, invoke Quill with the following three context items:
+    - (a) plan file path (e.g., `plans/oauth-login.md`)
+    - (b) list of files changed during implementation, collected via `git diff --name-only` against the pre-execution commit
+    - (c) one-sentence feature summary
+
+    If Pathfinder was NOT invoked during this session, skip Quill entirely.
+
+    **5c — Completion summary:**
+    - confirm the requested outcome was actually achieved
+    - summarize completed work (plan, reviews, execution, validation)
+    - note any unfinished items or follow-ups
+    - if Quill was invoked in 5b, include a line noting that documentation was updated; otherwise note that documentation update was skipped (no planning session)
+    - if notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
 
 ## Output contract
 
@@ -219,6 +232,7 @@ When responding back to the main thread, structure your result as:
   * Ruinor verdict (always included)
   * Specialist reviews invoked (if any): Riskmancer / Windwarden / Knotcutter / Truthhammer verdicts
 - Final validation
+- Documentation: updated by Quill / skipped (no planning session)
 - Risks / follow-ups
 
 Keep it concise and operational. Prefer facts over narration.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -13,21 +13,6 @@
     ],
     "Stop": [
       {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "git diff --quiet HEAD && exit 1 || exit 0",
-            "halt_pipeline": true,
-            "timeout": 5
-          },
-          {
-            "type": "agent",
-            "prompt": "Check if code changes in this session require documentation updates. Steps: 1) Run git status and git diff to see uncommitted changes. 2) If no code changes (only docs changed or clean), return success with no message. 3) If code changes exist, check for README.md, docs/, or documentation/. If no docs exist, skip check. 4) Read relevant documentation and analyze if it covers the new/changed functionality. 5) Only if documentation genuinely needs updating, UPDATE THE DOCUMENTATION. Be conservative - minor refactors or internal changes rarely need doc updates.",
-            "timeout": 60
-          }
-        ]
-      },
-      {
         "async": true,
         "hooks": [
           {

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -144,12 +144,16 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 
 **Core Mission:** Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
-**Invoke when:**
-- Adding major features or API changes
-- Onboarding new developers to a project
-- Documentation is out of sync with code
-- Creating architecture or design documentation
-- Generating API specifications
+**Trigger Mechanisms:**
+
+1. **Automatic via Dungeon Master (Phase 5)**: Automatically invoked after Pathfinder creates a plan and implementation is completed. Quill receives context from DM: plan file path, list of files changed during implementation, and feature summary.
+
+2. **Manual Invocation**: Explicitly invoke Quill for documentation work not tied to a planning session:
+   - Adding major features or API changes
+   - Onboarding new developers to a project
+   - Documentation is out of sync with code
+   - Creating architecture or design documentation
+   - Generating API specifications
 
 **Key Capabilities:**
 - Gap analysis of existing documentation
@@ -165,7 +169,15 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 - Search: Grep, Glob
 - Bash commands for system tasks
 
-**Typical Workflow:**
+**Typical Workflow (Automatic Invocation via DM):**
+1. Receives plan file path, changed files list, and feature summary from Dungeon Master
+2. Audits existing documentation against changes made during implementation
+3. Identifies gaps, outdated content, and missing sections in scope of the feature
+4. Plans document structure with hierarchical headings
+5. Creates clear Markdown with functional code snippets
+6. Validates technical precision and link integrity
+
+**Typical Workflow (Manual Invocation):**
 1. Audits existing documentation against current codebase
 2. Identifies gaps, outdated content, and missing sections
 3. Plans document structure with hierarchical headings
@@ -174,7 +186,7 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 
 **Output Format:** Concise change log listing created/modified files with single-line summaries.
 
-**Best Practice:** Invoke Quill proactively after completing features rather than waiting for documentation to become severely outdated.
+**Best Practice:** Quill runs automatically as part of the Dungeon Master's completion workflow when a plan has been created. For documentation work outside of planning sessions, manually invoke Quill proactively rather than waiting for documentation to become severely outdated.
 
 **Configuration File:** `/claude/agents/quill.md`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,21 +33,11 @@ Runs after every sub-agent completion to capture raw session event data.
 - Timeout: 5 seconds
 - Requires `jq` for filtering; falls back to a minimal entry if unavailable
 
-#### Stop Hook - Documentation Check + Session Enrichment
+#### Stop Hook - Session Enrichment
 
-Two hooks run when you end a Claude session.
+One hook runs when you end a Claude session.
 
-**Hook 1 — Documentation check (synchronous, gated):**
-
-1. First checks whether any code changes exist via `git diff --quiet HEAD`; exits early (halts pipeline) if the working tree is clean
-2. If changes exist, an agent reviews uncommitted changes, compares them against existing documentation, and updates docs if gaps are found
-
-**Configuration:**
-- Gate: Command hook (`git diff --quiet HEAD && exit 1 || exit 0`) with `halt_pipeline: true`, timeout 5 seconds
-- Docs agent: Agent-based hook, timeout 60 seconds
-- Conservative approach: Only triggers for substantive changes requiring documentation
-
-**Hook 2 — Session enrichment (async):**
+**Session enrichment (async):**
 
 Processes the raw sub-agent event log captured during the session into a structured chronicle.
 


### PR DESCRIPTION
Move Quill documentation from an anonymous, context-blind Stop hook into the Dungeon Master's orchestrated Phase 5. Quill now runs after implementation review passes, when a planning session was conducted, receiving the plan file path, changed-files list, and feature summary as context — producing accurate, in-session documentation instead of post-hoc diff-guessing.

The anonymous `git diff --quiet`-gated inline agent prompt is removed from `claude/settings.json`. `docs/CONFIGURATION.md` updated to reflect the single remaining Stop hook (Talekeeper). `docs/AGENTS.md` updated to document the new DM-orchestrated trigger.