### PR TITLE
feat(agents): add --explore-options decision-point routing

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -73,6 +73,14 @@ If additional specialist agents exist later, prefer:
 - Bitsmith as the fallback execution worker
 - Everwise for meta-analysis of agent coordination and session chronicles
 
+## Workflow Flags
+
+Workflow flags control how the DM routes work through the pipeline. They are distinct from specialist review flags (e.g., `--review-security`) which control which reviewers are invoked.
+
+| Flag | Effect |
+|------|--------|
+| `--explore-options` | Trigger options exploration before execution planning, even if the DM would otherwise proceed directly |
+
 ## Specialist Review Triggering
 
 ### User Flags (Explicit)
@@ -115,6 +123,22 @@ Follow this sequence:
 ### Phase 1: Planning
 1. Clarify the user goal in one sentence.
 2. Assess whether a plan already exists in the `plans/` directory.
+
+**Explore-Options Gate** (between step 2 and step 3):
+
+Trigger options exploration when: the `--explore-options` flag is present, OR the request appears to involve an architectural decision, technology selection, or an ambiguous approach with multiple viable paths.
+
+Suppress options exploration when: the user has already named a specific approach or technology, OR an approved plan already exists in `plans/`. The explicit `--explore-options` flag overrides suppression.
+
+When triggered:
+- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed), produce 2–4 viable options (not an execution plan), and return the options for user selection.
+- Present the options inline in the conversation — each option's name, summary, and Pathfinder's recommendation — then ask the user to select one or request changes. Do not proceed until the user responds.
+- **If user selects an option:** Re-invoke Pathfinder for an execution plan, passing both the selected option name and the full Consensus Mode output as context so Pathfinder does not re-research from scratch.
+- **If user rejects all options and requests different approaches:** Re-invoke Pathfinder in Consensus Mode with the user's feedback as additional constraints, then re-present options.
+- **If user wants to modify one option:** Re-invoke Pathfinder for an execution plan with the user's modifications folded in as constraints.
+
+When not triggered: proceed directly to step 3.
+
 3. If no plan exists, call Pathfinder and request:
    - objective
    - assumptions
@@ -239,6 +263,7 @@ Keep it concise and operational. Prefer facts over narration.
 
 ## Important constraints
 
+- When exploring options, DM must wait for explicit user selection before proceeding to execution planning.
 - Do not invent a plan when Pathfinder should provide one.
 - Do not skip Ruinor review. All plans and implementations must be reviewed by Ruinor (mandatory baseline).
 - Invoke specialists (Riskmancer, Windwarden, Knotcutter, Truthhammer) only when:
@@ -321,3 +346,18 @@ Action:
   * Invoke Ruinor + Truthhammer (user flag carried forward)
   * Both ACCEPT
 - Return summarized status
+
+Example 5:
+User asks: "We need a background job system for sending emails --explore-options"
+Action:
+- **Explore-Options Gate triggers** (explicit `--explore-options` flag; no plan in `plans/`)
+- Invoke Pathfinder in Consensus Mode: instruct it to produce 2–4 viable options (not an execution plan)
+- Pathfinder returns 3 options inline:
+  * Option A: In-process queue with a database-backed jobs table
+  * Option B: Redis-backed queue with BullMQ
+  * Option C: Dedicated message broker (e.g., RabbitMQ)
+- DM presents options to user with names, summaries, and Pathfinder's recommendation; waits for explicit selection
+- User selects Option B (Redis + BullMQ)
+- DM re-invokes Pathfinder for execution plan, passing "Option B: Redis + BullMQ" and the full Consensus Mode output as context
+- Pathfinder saves plan to `plans/background-jobs.md`
+- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -158,15 +158,27 @@ When user includes `--consensus` in their message (e.g., "Create a plan for X --
 3. Maintainability
 ```
 
-**Viable Options:** At least 2 alternatives with pros/cons
+**Viable Options:** 2–4 alternatives with pros/cons and reversibility
 ```
 **Option A: JWT-based auth**
 - Pros: Stateless, scalable, standard
 - Cons: Requires secure storage, token rotation complexity
+- Reversibility: Moderate (switching requires invalidating all tokens and migrating session storage)
 
 **Option B: Session-based auth**
 - Pros: Simple, server-controlled revocation
 - Cons: Requires server-side storage, less scalable
+- Reversibility: Easy (session store can be swapped without client-side changes)
+```
+
+**Comparison Matrix:** Lightweight summary across options and key decision drivers
+```
+| Driver          | Option A (JWT) | Option B (Sessions) |
+|-----------------|---------------|---------------------|
+| Scalability     | High          | Medium              |
+| Simplicity      | Medium        | High                |
+| Revocation ease | Low           | High                |
+| Reversibility   | Moderate      | Easy                |
 ```
 
 **ADR Fields:** Architecture Decision Record structure

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -85,6 +85,9 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
   - User explicitly requests with flags (--review-security, --review-performance, --review-complexity, --review-all), OR
   - Plan/code contains specialist-level keywords (fallback heuristic)
 
+**Workflow Flags:**
+- **`--explore-options`**: Triggers options exploration before execution planning. Presents 2–4 viable approaches with trade-offs for user selection before committing to an execution plan. Useful for architectural decisions, technology selection, or ambiguous approaches with multiple viable paths. Can be explicitly passed or triggered automatically when the DM detects ambiguous decisions.
+
 **Specialist Triggering:**
 - **Riskmancer**: Invoked for auth/jwt/crypto/payment/pii/security-sensitive features
 - **Windwarden**: Invoked for database/query/scale/cache/performance-critical features
@@ -93,17 +96,24 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 **Typical Workflow:**
 1. Clarifies user goal in one sentence
 2. Assesses whether a plan already exists
-3. If no plan exists, delegates to Pathfinder for planning
-4. **Plan Review Gate**: Delegates plan to Ruinor (mandatory baseline reviewer)
-5. If Ruinor flags specialists or user requested them, invokes specialists in parallel (Riskmancer/Windwarden/Knotcutter)
-6. If reviewers identify issues, sends consolidated feedback back to Pathfinder
-7. Once plan approved, converts plan into concrete execution tasks
-8. Delegates each task to appropriate agent
-9. **Implementation Review Gate**: Delegates code to Ruinor (mandatory baseline reviewer)
-10. If Ruinor flags specialists or user requested them, invokes specialists in parallel
-11. If issues found, delegates fixes back to Bitsmith
-12. Validates results against plan after all reviews pass
-13. Before finishing, confirms outcome achieved and summarizes work
+3. **Explore-Options Gate** (if `--explore-options` flag present OR request involves architectural decision/technology selection with multiple viable paths):
+   - Invokes Pathfinder with Consensus Mode (2–4 viable options, not an execution plan)
+   - Presents options inline with names, summaries, and recommendations
+   - Waits for explicit user selection
+   - If user selects: re-invokes Pathfinder for execution plan with selected option as context
+   - If user rejects all options: re-invokes Pathfinder in Consensus Mode with feedback as constraints
+   - If user wants to modify an option: re-invokes Pathfinder with modifications as constraints
+4. If no plan exists, delegates to Pathfinder for planning
+5. **Plan Review Gate**: Delegates plan to Ruinor (mandatory baseline reviewer)
+6. If Ruinor flags specialists or user requested them, invokes specialists in parallel (Riskmancer/Windwarden/Knotcutter)
+7. If reviewers identify issues, sends consolidated feedback back to Pathfinder
+8. Once plan approved, converts plan into concrete execution tasks
+9. Delegates each task to appropriate agent
+10. **Implementation Review Gate**: Delegates code to Ruinor (mandatory baseline reviewer)
+11. If Ruinor flags specialists or user requested them, invokes specialists in parallel
+12. If issues found, delegates fixes back to Bitsmith
+13. Validates results against plan after all reviews pass
+14. Before finishing, confirms outcome achieved and summarizes work
 
 **Output Format:**
 - Goal statement
@@ -132,7 +142,17 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 - User: "Rename this variable in one file"
 - Action: Skips Pathfinder → delegates directly to Bitsmith → returns brief summary
 
-**Best Practice:** Invoke Dungeon Master as the entry point for non-trivial development work. It intelligently routes between planning and execution, ensuring structured progress without requiring you to manually coordinate between agents.
+*Example 3: Options exploration with architectural decision*
+- User: "We need a background job system for sending emails --explore-options"
+- Action:
+  1. Explore-Options Gate triggers (explicit flag + architectural decision)
+  2. Invokes Pathfinder in Consensus Mode → returns 3 options (in-process queue, Redis+BullMQ, RabbitMQ)
+  3. Presents options with trade-offs (scalability, complexity, operational overhead)
+  4. User selects Option B (Redis + BullMQ)
+  5. Re-invokes Pathfinder for execution plan with selected option as context
+  6. Continues with Plan Review → Execution → Implementation Review as normal
+
+**Best Practice:** Invoke Dungeon Master as the entry point for non-trivial development work. It intelligently routes between planning and execution, ensuring structured progress without requiring you to manually coordinate between agents. Use `--explore-options` explicitly when facing technology/architecture decisions to see trade-offs before committing.
 
 **Configuration File:** `/claude/agents/dungeonmaster.md`
 
@@ -301,14 +321,20 @@ Quill has a single professional rival: documentation written by someone who clea
 - Task Flow (3-6 steps with checkboxes and acceptance criteria)
 - Success Criteria
 
-**Consensus Mode:**
-Activate with `--consensus` flag for enhanced decision support:
+**Consensus Mode (Options Exploration):**
+Activate automatically via Dungeon Master's `--explore-options` flag, or manually with `--consensus` for enhanced decision support. Pathfinder produces a structured options comparison (not an execution plan) with:
 - 3-5 guiding principles
 - Top 3 decision drivers
-- 2+ viable options with trade-offs
-- Architecture Decision Record format
-- Pre-mortem analysis (for high-risk work)
-- Expanded testing strategy
+- 2–4 viable options with:
+  - Pros and cons for each approach
+  - Reversibility assessment (Easy/Moderate/Difficult to switch later)
+  - Trade-off analysis against decision drivers
+- Comparison matrix summarizing options across key decision drivers
+- Architecture Decision Record format (Status, Context, Decision, Consequences)
+- Pre-mortem analysis (for high-risk scenarios)
+- Expanded testing strategy (Unit, Integration, E2E, Observability)
+
+Consensus Mode output is presented inline to the user for selection. Once selected, Dungeon Master re-invokes Pathfinder for execution planning with the chosen option as context, avoiding redundant research.
 
 **Output Location:**
 - Plans: `plans/{feature-name}.md`


### PR DESCRIPTION
Adds `--explore-options` flag and an automatic options-exploration gate to the Dungeon Master workflow. When triggered, the DM invokes Pathfinder in Consensus Mode to produce 2–4 solution alternatives inline for user selection before committing to an execution plan — preventing premature lock-in on the first reasonable approach.

Also extends Pathfinder's existing Consensus Mode with a `Reversibility` field and a lightweight Comparison Matrix to better support structured decision-making. Public-facing agent reference (`docs/AGENTS.md`) updated to document the new capability.