### PR TITLE
feat(agents): add git worktree isolation for parallel dungeonmaster sessions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,8 +28,14 @@
     "RALPLAN",
     "backpressure",
     "hotspots",
+    "slugified",
     "underspecified",
-    "unreviewed"
+    "unreviewed",
+    "Worktree",
+    "worktree",
+    "Worktrees",
+    "worktrees",
+    "WORKTREE"
   ],
   "ignoreWords": ["dontAsk"]
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ git pull
 
 ## Features
 
+### Parallel Sessions via Git Worktrees
+
+The Dungeon Master now supports true parallel development workflows using Git worktrees. Each session automatically creates an isolated worktree on a dedicated branch (e.g., `.worktrees/dm-add-oauth-login/` on `dm/add-oauth-login`), enabling multiple simultaneous `claude --agent dungeonmaster` terminals to work on unrelated issues without git conflicts or interference.
+
+**Key benefits:**
+- Run multiple DungeonMaster sessions simultaneously on the same repository
+- Each session operates on its own branch in its own worktree
+- Plans are isolated within each worktree's `plans/` directory
+- Zero git conflicts between parallel sessions
+- At completion, choose to create PR, merge to main, or keep the branch for later
+- Manual cleanup with `git worktree remove` or automatic cleanup at Phase 5
+
+Use `--no-worktree` flag to suppress worktree creation and operate in the main working tree (backwards compatible). See [docs/WORKTREE_ISOLATION.md](/docs/WORKTREE_ISOLATION.md) for comprehensive guide with examples and troubleshooting.
+
 ### Documentation Integration
 The Dungeon Master orchestration agent automatically invokes Quill (documentation specialist) as the final step of Phase 5 (Completion) when a planning session was conducted. Quill receives the plan file, list of changed files, and feature summary, then updates documentation to reflect the implementation. This ensures documentation stays synchronized with code without manual effort.
 

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -14,6 +14,17 @@ Bitsmith is the implementor. She takes the plan laid out by the architect and tu
 
 **She does not theorize. She builds.**
 
+## Worktree Awareness
+
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line, Bitsmith scopes ALL operations to that directory:
+
+- **Bash commands:** Use absolute paths rooted in `{WORKING_DIRECTORY}` as the primary approach. Use `cd {WORKING_DIRECTORY} &&` as a fallback only for commands that require a specific CWD (e.g., `npm install`, `make`, or tools that resolve config relative to CWD).
+- **File operations (Read/Write/Edit/Grep/Glob):** Use absolute paths under `{WORKING_DIRECTORY}`. Never use relative paths.
+- **Git commands** (commit, branch, status, diff): Automatically operate on the worktree's branch when Bash runs within `{WORKING_DIRECTORY}`. No special handling needed.
+- **Session worktree setup:** When DM delegates worktree creation, run the exact commands from the DM's prompt (e.g., `git worktree add`, `mkdir -p`) and report `WORKTREE_PATH` and `WORKTREE_BRANCH` back to DM.
+
+When `WORKING_DIRECTORY` is absent from the delegation prompt, behavior is unchanged — operate in the main working tree as before.
+
 ## The Forge's Jurisdiction
 
 ### What Bitsmith Touches

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -34,7 +34,9 @@ Your job is to coordinate work exclusively. You must NEVER perform implementatio
 ### What the Dungeon Master may do directly
 
 - Read files, grep, glob — to understand context before delegating
-- Run read-only Bash commands: `git status`, `git log`, `ls`, `git diff`
+- Run read-only Bash commands: `git status`, `git log`, `ls`, `git diff`, `git worktree list`
+
+Note: `git worktree add` and `git worktree remove` are write operations and must be delegated to Bitsmith.
 - Write status summaries back to the user
 
 ### What the Dungeon Master must NEVER do directly
@@ -85,6 +87,19 @@ Workflow flags control how the DM routes work through the pipeline. They are dis
 | Flag | Effect |
 |------|--------|
 | `--explore-options` | Trigger options exploration before execution planning, even if the DM would otherwise proceed directly |
+| `--no-worktree` | Suppress worktree creation; operate in the main working tree |
+
+### Worktree Context Block
+
+When a session worktree is active, prepend the following block to every Pathfinder, Bitsmith, and Quill delegation prompt:
+
+```
+WORKING_DIRECTORY: /absolute/path/to/.worktrees/dm-slug
+WORKTREE_BRANCH: dm/feature-name
+All file operations and Bash commands must use this directory as the working root.
+```
+
+Ruinor and other reviewer agents do not receive this block — instead, pass worktree-absolute file paths directly in their delegation prompts.
 
 ## Specialist Review Triggering
 
@@ -128,6 +143,37 @@ If no user flags and Ruinor doesn't recommend specialists, check plan/request fo
 
 Follow this sequence:
 
+### Phase 0: Session Isolation
+
+Before any planning begins, create an isolated git worktree for this session so it does not conflict with other parallel DM sessions.
+
+**Skip condition:** Skip Phase 0 entirely (and operate in the main working tree) if:
+- The `--no-worktree` flag is present, OR
+- The task is trivially single-file (preliminary assessment — will skip Pathfinder)
+
+Log: "Worktree: skipped (--no-worktree / trivial task)"
+
+**Note on late initialization:** The triviality assessment at Phase 0 is a best-effort, preliminary call. If DM initially skips worktree creation but later determines the task is non-trivial (e.g., decides to invoke Pathfinder), it must create the worktree at that point before proceeding with planning.
+
+**When creating a worktree:**
+
+1. **Derive branch name:** Slugify the task description → `dm/{slugified-task}` (e.g., "Add OAuth login" → `dm/add-oauth-login`). If the request is ambiguous, use `dm/session-{YYYYMMDD-HHmmss}` (local time). Max 60 characters, lowercase, alphanumeric and hyphens only.
+
+2. **Delegate worktree creation to Bitsmith** (DM's Bash is read-only scoped; `mkdir` and `git worktree add` are write operations):
+   ```
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+   WORKTREE_PATH="${REPO_ROOT}/.worktrees/{branch-slug}"
+   mkdir -p "$(dirname "${WORKTREE_PATH}")"
+   git worktree add "${WORKTREE_PATH}" -b {branch-name} HEAD
+   mkdir -p "${WORKTREE_PATH}/plans"
+   ```
+
+3. **Handle branch collisions:** If `git worktree add` fails because the branch already exists, retry with a numeric suffix (`dm/add-oauth-login-2`, then `-3`). After 3 failures, fall back to main working tree and warn the user.
+
+4. **Set session context:** The DM carries `WORKTREE_PATH` and `WORKTREE_BRANCH` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used.
+
+5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
+
 ### Phase 1: Planning
 
 1. Clarify the user goal in one sentence.
@@ -155,6 +201,8 @@ When not triggered: proceed directly to step 3.
    - step-by-step execution plan
    - validation criteria
    - risks / rollback considerations
+
+   Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block (defined above) if a session worktree is active. Pathfinder must write plans to `{WORKING_DIRECTORY}/plans/`.
 4. Pathfinder will save the plan to `plans/{feature-name}.md`.
 
 ### Phase 2: Plan Review (Quality Gate)
@@ -188,13 +236,13 @@ When not triggered: proceed directly to step 3.
 ### Phase 3: Execution
 
 1. Convert the approved plan into execution tasks.
-2. Delegate each execution task to Bitsmith or another specialist.
+2. Delegate each execution task to Bitsmith or another specialist. Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active. Bitsmith must operate entirely within this directory.
 3. After each delegated task:
     - compare results against the plan
     - decide whether to continue, retry, or adjust
 4. Track implementation artifacts (changed files, new code).
 
-**Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3.
+**Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree.
 
 ### Phase 4: Implementation Review (Quality Gate)
 
@@ -233,7 +281,7 @@ When not triggered: proceed directly to step 3.
 1. Before finishing, execute the following three sub-steps in order:
 
     **5a — Reservations logging:**
-    When any reviewer issues ACCEPT-WITH-RESERVATIONS, extract the reservations from the review findings and include them in your completion summary. Then delegate to Bitsmith: instruct it to append the reservations to `plans/open-questions.md` under a section titled "Review Reservations - [session date]" with the specific issues noted. If the file does not exist, Bitsmith should create it first with the following header:
+    When any reviewer issues ACCEPT-WITH-RESERVATIONS, extract the reservations from the review findings and include them in your completion summary. Then delegate to Bitsmith: instruct it to append the reservations to `plans/open-questions.md` under a section titled "Review Reservations - [session date]" with the specific issues noted. When a session worktree is active, write to `{WORKING_DIRECTORY}/plans/open-questions.md` instead of `plans/open-questions.md`. If the file does not exist, Bitsmith should create it first with the following header:
 
       ```
       # Open Questions and Review Reservations
@@ -249,6 +297,8 @@ When not triggered: proceed directly to step 3.
     - (b) list of files changed during implementation, collected via `git diff --name-only` against the pre-execution commit
     - (c) one-sentence feature summary
 
+    Include the `WORKING_DIRECTORY` context block if a session worktree is active. Quill must write documentation relative to this directory.
+
     If Pathfinder was NOT invoked during this session, skip Quill entirely.
 
     Quill must only be invoked after Phase 4 implementation review is fully complete and all reviewers have issued ACCEPT or ACCEPT-WITH-RESERVATIONS. If any Bitsmith implementation work is needed after Quill completes, that work must re-enter Phase 4 (Implementation Review) before the session can be declared complete — do not treat post-documentation Bitsmith invocations as pre-reviewed work.
@@ -258,7 +308,22 @@ When not triggered: proceed directly to step 3.
     - summarize completed work (plan, reviews, execution, validation)
     - note any unfinished items or follow-ups
     - if Quill was invoked in 5b, include a line noting that documentation was updated; otherwise note that documentation update was skipped (no planning session)
+    - Worktree status (path, branch, cleanup action taken, or 'skipped' if no worktree)
     - if notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
+
+    **5d — Worktree cleanup:**
+    If no session worktree is active, skip this step.
+
+    Otherwise, ask the user:
+    > "Session branch `{WORKTREE_BRANCH}` is ready. Would you like to: (a) create a PR, (b) merge to main locally, or (c) keep the branch for later?"
+
+    - **If PR:** Delegate to Bitsmith to push the branch and create a PR (using the `/open-pr` command or `gh pr create`). Then ask: "PR created. Would you like to keep the worktree for iterating on review feedback, or remove it?" If keep: log "Branch `{WORKTREE_BRANCH}` preserved at `{WORKTREE_PATH}` for PR iteration." If remove: delegate to Bitsmith to run `git worktree remove {WORKTREE_PATH}`.
+
+    - **If merge:** Delegate to Bitsmith to run `git checkout main && git merge --no-ff {WORKTREE_BRANCH}`. **Error handling:** If the merge fails (conflicts), do NOT proceed with worktree removal or branch deletion. Abort cleanup, inform the user of the merge failure, and fall back to the "keep" option. If successful: delegate to Bitsmith to run `git worktree remove {WORKTREE_PATH}` and `git branch -d {WORKTREE_BRANCH}`.
+
+    - **If keep:** Log "Branch `{WORKTREE_BRANCH}` preserved at `{WORKTREE_PATH}`. Run `git worktree remove {WORKTREE_PATH}` when done." Do NOT remove the worktree.
+
+    Log the cleanup result in the completion summary.
 
 ## Output contract
 
@@ -276,6 +341,7 @@ When responding back to the main thread, structure your result as:
   - Specialist reviews invoked (if any): Riskmancer / Windwarden / Knotcutter / Truthhammer verdicts
 - Final validation
 - Documentation: updated by Quill / skipped (no planning session)
+- Worktree: `{path}` on branch `{branch}` — {cleanup action taken} / skipped (no worktree)
 - Risks / follow-ups
 
 Keep it concise and operational. Prefer facts over narration.
@@ -380,3 +446,15 @@ Action:
 - DM re-invokes Pathfinder for execution plan, passing "Option B: Redis + BullMQ" and the full Consensus Mode output as context
 - Pathfinder saves plan to `plans/background-jobs.md`
 - Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
+
+Example 6:
+User asks: "Add OAuth login" (while another DM session is already working on an unrelated issue)
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/dm-add-oauth-login` on branch `dm/add-oauth-login`
+- All subsequent Pathfinder, Bitsmith, and Quill delegation prompts include:
+  `WORKING_DIRECTORY: {REPO_ROOT}/.worktrees/dm-add-oauth-login`
+  `WORKTREE_BRANCH: dm/add-oauth-login`
+- Pathfinder writes plans to `{WORKING_DIRECTORY}/plans/`
+- Bitsmith operates in the worktree, commits land on `dm/add-oauth-login`
+- **Phase 5:** DM offers PR/merge/keep options, cleans up worktree based on user choice
+- Both sessions operate independently on separate branches without git conflicts

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -12,6 +12,15 @@ tools: "Read, Write, Grep, Glob, Bash, Agent"
 
 Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/*.md`. You never implement code. You plan.
 
+## Worktree Awareness
+
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line:
+
+- Write all plan files to `{WORKING_DIRECTORY}/plans/{name}.md` instead of `plans/{name}.md`
+- Write `open-questions.md` to `{WORKING_DIRECTORY}/plans/open-questions.md`
+- All codebase research (Grep, Glob, Read, Bash) should target `{WORKING_DIRECTORY}` as the search root
+- When `WORKING_DIRECTORY` is absent, behavior is unchanged — write to `plans/{name}.md` as before
+
 ## Key Responsibilities
 
 - Interview users with structured question workflow

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -10,6 +10,16 @@ model: claude-haiku-4-5
 ## Core Mission
 Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
+## Worktree Awareness
+
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line:
+
+- All documentation reads and writes are relative to `{WORKING_DIRECTORY}`
+- File generation targets `{WORKING_DIRECTORY}/README.md`, `{WORKING_DIRECTORY}/docs/`, etc.
+- When `WORKING_DIRECTORY` is absent, behavior is unchanged — operate in the main working tree as before
+
+**Note:** Talekeeper is unaffected by worktree isolation. It writes to gitignored session logs (not to the working tree) and is user-invoked only.
+
 ## Operational Workflow
 
 **1. Gap Analysis**

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -87,6 +87,20 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 
 **Workflow Flags:**
 - **`--explore-options`**: Triggers options exploration before execution planning. Presents 2–4 viable approaches with trade-offs for user selection before committing to an execution plan. Useful for architectural decisions, technology selection, or ambiguous approaches with multiple viable paths. Can be explicitly passed or triggered automatically when the DM detects ambiguous decisions.
+- **`--no-worktree`**: Suppress automatic git worktree creation; operate in the main working tree instead. Use for read-only analysis or trivial single-file changes. Useful for backwards compatibility with pre-worktree workflows. See [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md) for details.
+
+**Parallel Sessions via Worktree Isolation:**
+
+Each DungeonMaster session automatically creates an isolated git worktree on a dedicated branch (e.g., `.worktrees/dm-add-oauth-login/` on `dm/add-oauth-login`). This enables truly parallel sessions without git conflicts:
+
+- **Multiple simultaneous sessions:** Run multiple `claude --agent dungeonmaster` terminals on unrelated issues
+- **Independent branches:** Each session operates on its own branch, preventing conflicts
+- **Isolated plans:** Each worktree has its own local `plans/` directory
+- **Phase 0 worktree creation:** Automatic at session start (skipped only with `--no-worktree` flag or for trivial tasks)
+- **Phase 5 cleanup:** At completion, choose to create PR, merge to main, or keep the branch for later
+- **Manual cleanup:** `git worktree list`, `git worktree remove .worktrees/{slug}`, `git worktree prune`
+
+For comprehensive usage guide, examples, troubleshooting, and best practices, see [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md).
 
 **Specialist Triggering:**
 - **Riskmancer**: Invoked for auth/jwt/crypto/payment/pii/security-sensitive features
@@ -159,6 +173,20 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
   4. User selects Option B (Redis + BullMQ)
   5. Re-invokes Pathfinder for execution plan with selected option as context
   6. Continues with Plan Review → Execution → Implementation Review as normal
+
+*Example 4: Parallel sessions with git worktree isolation*
+- Terminal A: User: "Add OAuth login"
+  - Session automatically creates worktree at `.worktrees/dm-add-oauth-login/` on branch `dm/add-oauth-login`
+  - Pathfinder creates plan in worktree's `plans/`
+  - Bitsmith implements in worktree
+  - Reviews happen in worktree context
+  - At Phase 5, presents PR/merge/keep options
+- Terminal B (simultaneously): User: "Fix database query performance on issue #42"
+  - Session automatically creates separate worktree at `.worktrees/dm-fix-db-perf-issue-42/` on branch `dm/fix-db-perf-issue-42`
+  - Work proceeds independently without git conflicts
+  - Both sessions can commit, implement, and generate PRs in parallel
+- Result: Two independent feature branches, zero conflicts, true parallel development
+- See [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md) for comprehensive details
 
 **Best Practice:** Invoke Dungeon Master as the entry point for non-trivial development work. It intelligently routes between planning and execution, ensuring structured progress without requiring you to manually coordinate between agents. Use `--explore-options` explicitly when facing technology/architecture decisions to see trade-offs before committing.
 

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -1,0 +1,484 @@
+# Parallel DungeonMaster Sessions via Git Worktrees
+
+## Overview
+
+The Dungeon Master orchestration agent now supports **parallel isolated sessions** via Git worktrees. This feature enables multiple simultaneous `claude --agent dungeonmaster` terminals to work on unrelated issues without git conflicts or interference.
+
+Each DungeonMaster session automatically creates a dedicated git worktree on an isolated branch, ensuring clean separation of concerns and enabling truly parallel development workflows.
+
+## Quick Start
+
+### Running Parallel DungeonMaster Sessions
+
+Start your first DungeonMaster session normally:
+
+```bash
+claude --agent dungeonmaster
+# Prompt: "Add OAuth login"
+```
+
+The session automatically:
+1. Creates an isolated git worktree at `.worktrees/dm-add-oauth-login/`
+2. Creates a dedicated branch `dm/add-oauth-login`
+3. Executes all planning, implementation, and reviews within that worktree
+4. Provides cleanup options (PR, merge, or keep) at completion
+
+In another terminal, start a second DungeonMaster session:
+
+```bash
+claude --agent dungeonmaster
+# Prompt: "Fix database query performance on issue #42"
+```
+
+Both sessions operate independently:
+- Session 1 works on branch `dm/add-oauth-login` in `.worktrees/dm-add-oauth-login/`
+- Session 2 works on branch `dm/fix-db-perf-issue-42` in `.worktrees/dm-fix-db-perf-issue-42/`
+- No git conflicts, no interference, completely isolated development
+
+## How It Works
+
+### Worktree Creation (Phase 0)
+
+When you start a DungeonMaster session, it performs **Phase 0: Session Isolation** before any planning:
+
+1. **Branch naming:** The task description is converted to a branch name following the pattern `dm/{slugified-task}`. Examples:
+   - "Add OAuth login" → `dm/add-oauth-login`
+   - "Fix database query performance" → `dm/fix-database-query-performance`
+   - "Refactor auth module" → `dm/refactor-auth-module`
+
+2. **Worktree creation:** A new git worktree is created at `.worktrees/{slug}/` on the dedicated branch
+
+3. **Plans directory:** A local `plans/` directory is created within the worktree (gitignored, like the main repo's plans/)
+
+4. **Session context:** All subsequent work (Pathfinder planning, Bitsmith implementation, Quill documentation) operates within the worktree
+
+### Skip Conditions
+
+Phase 0 (worktree creation) is **skipped** if:
+
+- The `--no-worktree` flag is provided
+- The task is trivially single-file (identified early as not needing Pathfinder)
+
+Examples:
+
+```bash
+# Explicitly skip worktree creation (operate in main working tree)
+claude --agent dungeonmaster --no-worktree
+# Prompt: "Fix typo in README.md"
+
+# Trivial task: worktree skipped automatically
+claude --agent dungeonmaster
+# Prompt: "Rename AuthContext to AuthProvider in one file"
+```
+
+**Late initialization:** If DungeonMaster initially skips worktree creation but later determines the task is non-trivial (e.g., decides to invoke Pathfinder), it creates the worktree at that point before proceeding.
+
+### Worktree Structure
+
+After Phase 0 completes, your repository structure looks like:
+
+```
+.
+├── .git/                    # Main repo git directory (shared across worktrees)
+├── .worktrees/              # Worktrees directory (gitignored)
+│   ├── dm-add-oauth-login/  # Session 1 worktree
+│   │   ├── .git            # Pointer to main .git (shared objects)
+│   │   ├── plans/           # Local plans (gitignored)
+│   │   ├── src/
+│   │   └── ...
+│   └── dm-fix-db-perf/      # Session 2 worktree
+│       ├── .git
+│       ├── plans/
+│       └── ...
+├── src/
+├── plans/                   # Main repo plans (gitignored)
+└── .gitignore               # Contains .worktrees/ and plans/
+```
+
+Each worktree is on its own branch and has its own working tree, but shares the git object database for efficiency.
+
+## Managing Worktrees
+
+### Listing Active Worktrees
+
+To see all active worktrees:
+
+```bash
+git worktree list
+```
+
+Output example:
+
+```
+/path/to/repo                 abc1234 [main]
+/path/to/repo/.worktrees/dm-add-oauth-login
+                              def5678 [dm/add-oauth-login]
+/path/to/repo/.worktrees/dm-fix-db-perf
+                              ghi9012 [dm/fix-db-perf]
+```
+
+### Cleaning Up Worktrees
+
+#### Automatic Cleanup (Recommended)
+
+At Phase 5 (session completion), DungeonMaster presents cleanup options:
+
+```
+Session branch dm/add-oauth-login is ready. Would you like to:
+(a) create a PR
+(b) merge to main locally
+(c) keep the branch for later
+```
+
+**Option (a) - Create PR:**
+- Pushes the branch and creates a PR
+- Asks whether to keep or remove the worktree
+- If you choose "remove", the worktree is deleted automatically
+
+**Option (b) - Merge to main:**
+- Merges the branch to main locally: `git checkout main && git merge --no-ff dm/add-oauth-login`
+- Removes the worktree and branch automatically
+- If merge fails (conflicts), aborts cleanup and preserves the worktree for manual resolution
+
+**Option (c) - Keep the branch:**
+- Preserves the worktree and branch for later
+- You decide when to clean up manually
+
+#### Manual Cleanup
+
+If you have stale worktrees or want to clean up manually:
+
+```bash
+# Remove a specific worktree
+git worktree remove .worktrees/dm-add-oauth-login
+
+# Prune stale worktree entries (if a worktree directory was deleted manually)
+git worktree prune
+
+# List all worktree branches (those starting with dm/)
+git branch --list 'dm/*'
+
+# Delete a merged branch
+git branch -d dm/add-oauth-login
+
+# Force delete a branch (if not fully merged)
+git branch -D dm/add-oauth-login
+```
+
+**Cleanup checklist:**
+
+1. Check if the worktree is no longer needed: `git worktree list`
+2. Remove the worktree: `git worktree remove .worktrees/{slug}`
+3. Clean up any stale entries: `git worktree prune`
+4. Delete the branch: `git branch -d dm/{slug}`
+
+### Orphaned Worktrees
+
+If a DungeonMaster session crashes before Phase 5, worktrees may be left behind. These are harmless but clutter your working directory.
+
+To clean them up:
+
+```bash
+# List all worktrees to find orphans
+git worktree list
+
+# Remove the orphaned worktree
+git worktree remove .worktrees/dm-abandoned-task
+
+# Prune stale entries
+git worktree prune
+
+# Clean up the orphaned branch
+git branch -d dm/abandoned-task
+```
+
+## Suppressing Worktree Creation
+
+If you want to suppress worktree creation and work directly in the main working tree, use the `--no-worktree` flag:
+
+```bash
+claude --agent dungeonmaster --no-worktree
+# Prompt: "Add OAuth login"
+```
+
+With `--no-worktree`:
+- DungeonMaster operates in the main working tree
+- Plans are saved to `plans/` (main repo)
+- No `.worktrees/` directory is used
+- Useful for analysis-only sessions or read-only work
+- Backwards compatible with pre-worktree workflow
+
+## Worktree Awareness in Sub-Agents
+
+When a DungeonMaster session has an active worktree, all sub-agents (Pathfinder, Bitsmith, Quill) automatically receive worktree context:
+
+```
+WORKING_DIRECTORY: /absolute/path/to/.worktrees/dm-add-oauth-login
+WORKTREE_BRANCH: dm/add-oauth-login
+All file operations and Bash commands must use this directory as the working root.
+```
+
+Sub-agents respect this context:
+
+- **Pathfinder:** Writes plans to `{WORKING_DIRECTORY}/plans/` instead of the main repo's `plans/`
+- **Bitsmith:** Performs all code changes within the worktree, commits land on the worktree's branch
+- **Quill:** Writes documentation updates relative to the worktree
+
+You don't need to do anything — the context is automatically propagated by DungeonMaster.
+
+## Phase 5 Cleanup Flow
+
+At session completion (Phase 5), DungeonMaster summarizes your work and offers cleanup options:
+
+```
+Session worktree created: .worktrees/dm-add-oauth-login on branch dm/add-oauth-login
+...
+[Implementation completed and reviewed successfully]
+
+Session branch dm/add-oauth-login is ready. Would you like to:
+(a) create a PR
+(b) merge to main locally
+(c) keep the branch for later
+```
+
+### Option A: Create PR
+
+```bash
+# DungeonMaster delegates to Bitsmith:
+git push -u origin dm/add-oauth-login
+gh pr create --title "Add OAuth login" --body "..."
+
+# Then asks:
+# "PR created. Would you like to keep the worktree (for iterating on review feedback) or remove it?"
+```
+
+If you choose **keep:**
+- Worktree remains at `.worktrees/dm-add-oauth-login`
+- Branch remains at `dm/add-oauth-login`
+- You can iterate on review feedback without losing context
+- Clean up manually when done: `git worktree remove .worktrees/dm-add-oauth-login`
+
+If you choose **remove:**
+- Worktree is deleted: `git worktree remove .worktrees/dm-add-oauth-login`
+- Branch is not deleted (you can keep iterating on it if needed)
+
+### Option B: Merge to Main
+
+```bash
+# DungeonMaster delegates to Bitsmith:
+git checkout main
+git merge --no-ff dm/add-oauth-login
+
+# If successful, also runs:
+git worktree remove .worktrees/dm-add-oauth-login
+git branch -d dm/add-oauth-login
+```
+
+If the merge **fails** (conflicts):
+- Cleanup is aborted
+- Worktree and branch are preserved
+- You can resolve conflicts manually and clean up later
+
+### Option C: Keep the Branch
+
+- Worktree remains at `.worktrees/dm-add-oauth-login`
+- Branch remains at `dm/add-oauth-login`
+- No automatic cleanup
+- Clean up manually when ready: `git worktree remove .worktrees/dm-add-oauth-login`
+
+## Example: Two Parallel Sessions
+
+### Session 1: OAuth Implementation
+
+**Terminal A:**
+
+```bash
+$ claude --agent dungeonmaster
+> Add OAuth login to the authentication system
+...
+[DungeonMaster creates .worktrees/dm-add-oauth-login/ on branch dm/add-oauth-login]
+[Pathfinder creates plan at .worktrees/dm-add-oauth-login/plans/oauth-plan.md]
+[Bitsmith implements OAuth in the worktree]
+[Ruinor and Riskmancer review in the worktree context]
+[Quill updates documentation in the worktree]
+...
+Session branch dm/add-oauth-login is ready. Would you like to:
+(a) create a PR
+(b) merge to main locally
+(c) keep the branch for later
+> a
+```
+
+### Session 2: Database Performance
+
+**Terminal B (same time):**
+
+```bash
+$ claude --agent dungeonmaster
+> Fix slow database queries on issue #42
+...
+[DungeonMaster creates .worktrees/dm-fix-db-perf-issue-42/ on branch dm/fix-db-perf-issue-42]
+[Pathfinder creates plan at .worktrees/dm-fix-db-perf-issue-42/plans/db-optimization.md]
+[Bitsmith implements query fixes in the worktree]
+[Ruinor and Windwarden review in the worktree context]
+...
+Session branch dm/fix-db-perf-issue-42 is ready. Would you like to:
+(a) create a PR
+(b) merge to main locally
+(c) keep the branch for later
+> b
+[Merges to main and cleans up]
+```
+
+**Result:**
+- Session 1: PR ready for review at `dm/add-oauth-login`, worktree kept for iteration
+- Session 2: Merged to main, cleanup complete
+- Main branch not touched until merge
+- Zero git conflicts between sessions
+
+## Workflow Flags Summary
+
+| Flag | Effect | Use Case |
+|------|--------|----------|
+| `--no-worktree` | Suppress worktree creation; operate in main working tree | Read-only analysis, single-file trivial changes, explicit backwards compatibility |
+| `--explore-options` | Trigger options exploration before execution planning | Architectural decisions, technology selection, multiple viable paths |
+
+You can combine flags:
+
+```bash
+claude --agent dungeonmaster --no-worktree --explore-options
+```
+
+## Backwards Compatibility
+
+This feature is **fully backwards compatible**:
+
+- Sessions without `--no-worktree` automatically get worktree isolation
+- Sessions with `--no-worktree` behave exactly like pre-worktree DM sessions
+- Existing workflows are unaffected
+- The `.worktrees/` directory is already gitignored
+
+## Troubleshooting
+
+### "Branch already exists" Error
+
+If you see this error during worktree creation:
+
+```
+fatal: 'dm/add-oauth-login' already exists.
+```
+
+**Solution:** The branch already exists from a previous session. Either:
+
+1. Delete the stale branch: `git branch -D dm/add-oauth-login`
+2. Use `--no-worktree` to operate in the main tree for this session
+3. Start a new session with a different task description
+
+DungeonMaster retries with a numeric suffix (e.g., `dm/add-oauth-login-2`) after 3 attempts before falling back to the main working tree.
+
+### Stale Worktrees After Crash
+
+If a session crashes before Phase 5:
+
+```bash
+# List orphaned worktrees
+git worktree list
+
+# Remove the orphaned worktree
+git worktree remove .worktrees/dm-crashed-task
+
+# Clean up references
+git worktree prune
+git branch -D dm/crashed-task
+```
+
+### Worktree on Wrong Branch
+
+If you manually switch branches within a worktree, git may confuse the worktree state. To fix:
+
+```bash
+# Check current state
+git worktree list
+
+# Remove and recreate the worktree (Phase 0 will handle this next session)
+git worktree remove .worktrees/dm-corrupted-task
+git worktree prune
+```
+
+### "Merge failed - conflicts" at Phase 5
+
+If you choose merge (option b) and conflicts occur:
+
+1. Worktree is preserved at `.worktrees/dm-{task}/`
+2. Manual merge is required:
+
+   ```bash
+   cd .worktrees/dm-{task}
+   git diff main
+   # Resolve conflicts manually
+   git add .
+   git commit -m "Resolve merge conflicts"
+   cd ../..
+   git checkout main
+   git merge --no-ff dm/{task}
+   ```
+
+3. Clean up when ready:
+
+   ```bash
+   git worktree remove .worktrees/dm-{task}
+   git branch -d dm/{task}
+   ```
+
+## Design Rationale
+
+Worktree isolation was introduced to solve a critical limitation: multiple concurrent DungeonMaster sessions on the same repository would conflict over:
+
+- **Shared git working tree:** Both sessions modify the same files simultaneously
+- **Shared branch:** Both sessions try to checkout different branches, causing confusion
+- **Shared plans/ directory:** Both sessions try to write plans to the same files
+
+Git worktrees provide a lightweight solution:
+
+- Each worktree has its own working directory
+- Each worktree can be on a different branch
+- Worktrees share git object storage (efficient)
+- Cleanup is simple: `git worktree remove`
+
+This enables truly parallel development workflows where multiple issues can be worked on simultaneously without manual coordination.
+
+## Best Practices
+
+1. **Use descriptive task descriptions** so worktree branch names are meaningful
+   - Good: "Add OAuth login with multi-factor authentication"
+   - Bad: "Stuff"
+
+2. **Monitor your worktrees** periodically
+
+   ```bash
+   git worktree list  # Check active worktrees
+   git branch --list 'dm/*'  # List all DM branches
+   ```
+
+3. **Clean up after completion** even if you chose "keep" initially
+   - Stale worktrees consume disk space
+   - `git worktree remove` is quick and safe
+
+4. **Use option (b) - merge** for straightforward PRs
+   - If you're confident the work is ready
+   - Automatic cleanup saves manual steps
+   - Use option (a) - PR for review before merging
+
+5. **Use option (a) - PR** for features requiring review
+   - Keeps worktree active for feedback iteration
+   - Delete when PR is merged
+
+6. **Use `--no-worktree`** only for trivial changes
+   - Most tasks benefit from worktree isolation
+   - Only skip when explicitly needed (read-only work)
+
+## Related Documentation
+
+- [Agent Reference: Dungeon Master](/docs/AGENTS.md#dungeon-master---orchestrator) - Orchestration workflow details
+- [Configuration Guide](/docs/CONFIGURATION.md) - Setup and installation
+- [Review Workflow](/docs/adrs/REVIEW_WORKFLOW.md) - Quality gate and review process


### PR DESCRIPTION
Enables true parallel `claude --agent dungeonmaster` sessions by giving each session its own git worktree on a dedicated `dm/<feature-slug>` branch. Without this, simultaneous sessions conflict on the shared working tree, plans directory, and branch.

**What changes:**
- DM gains a Phase 0 that delegates worktree creation to Bitsmith at session start, carries `WORKING_DIRECTORY` / `WORKTREE_BRANCH` in conversation memory, and propagates them to every sub-agent delegation
- Bitsmith, Pathfinder, and Quill each gain a Worktree Awareness section that scopes all file ops and Bash commands to `{WORKING_DIRECTORY}` when the context is present; falls back to previous behaviour when absent
- Phase 5 adds step 5d: offers PR / merge / keep cleanup options with safe error handling (no premature worktree removal, merge-failure fallback to keep)
- `--no-worktree` flag suppresses the feature for trivial or read-only sessions
- `docs/WORKTREE_ISOLATION.md` documents the full lifecycle for users

Reviewer agents (Ruinor, Riskmancer, etc.) are unaffected — they receive worktree-absolute file paths from DM and need no changes.