### PR TITLE
feat(agents): add permissionMode and least-privilege tool allowlists

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -2,6 +2,7 @@
 name: bitsmith
 description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to architect after 3 failed attempts."
 model: claude-sonnet-4-6
+permissionMode: acceptEdits
 level: 2
 tools: "Read, Write, Edit, Bash, Grep, Glob, Agent"
 ---

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -3,7 +3,6 @@ name: dungeonmaster
 description: "Use this agent to coordinate multi-step software development work. It delegates planning to Pathfinder, runs mandatory Ruinor baseline reviews, conditionally invokes specialist reviewers (Riskmancer/Windwarden/Knotcutter/Truthhammer) based on findings or user flags, delegates implementation to Bitsmith, and validates completion against the plan."
 tools: "Task, Read, Grep, Glob, Bash"
 model: claude-sonnet-4-6
-permissionMode: auto
 ---
 
 # Dungeon Master - Orchestration Agent

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -3,6 +3,7 @@ name: dungeonmaster
 description: "Use this agent to coordinate multi-step software development work. It delegates planning to Pathfinder, runs mandatory Ruinor baseline reviews, conditionally invokes specialist reviewers (Riskmancer/Windwarden/Knotcutter/Truthhammer) based on findings or user flags, delegates implementation to Bitsmith, and validates completion against the plan."
 tools: "Task, Read, Grep, Glob, Bash"
 model: claude-sonnet-4-6
+permissionMode: auto
 ---
 
 # Dungeon Master - Orchestration Agent

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -2,6 +2,7 @@
 name: everwise
 description: "Use this agent when the user asks for meta-analysis of agent team performance, session chronicle review, or continuous improvement analysis. Learner agent. Analyzes Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems in the agent team. Proposes structured, evidence-based configuration improvements. Never modifies production configs directly — only writes to lessons/ directory."
 model: claude-sonnet-4-6
+permissionMode: acceptEdits
 tools: "Read, Grep, Glob, Write"
 ---
 

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -3,6 +3,7 @@ name: knotcutter
 description: "Radical simplification specialist. Cuts through complexity by questioning necessity, eliminating over-engineering, and reducing systems to their essential core. Use when codebases are bloated, abstractions proliferate, or solutions feel needlessly complex."
 tools: "Read, Grep, Glob, Bash"
 model: claude-opus-4-6
+level: 3
 mandatory: false
 trigger_keywords: ["refactor", "architecture", "abstraction", "framework", "pattern", "generalize", "reusable", "complexity", "simplify", "redesign", "restructure"]
 invoke_when: "major refactors, new abstractions, or when Ruinor flags complexity concerns"

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -1,7 +1,7 @@
 ---
 name: knotcutter
 description: "Radical simplification specialist. Cuts through complexity by questioning necessity, eliminating over-engineering, and reducing systems to their essential core. Use when codebases are bloated, abstractions proliferate, or solutions feel needlessly complex."
-disallowedTools: Write, Edit
+tools: "Read, Grep, Glob, Bash"
 model: claude-opus-4-6
 mandatory: false
 trigger_keywords: ["refactor", "architecture", "abstraction", "framework", "pattern", "generalize", "reusable", "complexity", "simplify", "redesign", "restructure"]

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -3,6 +3,7 @@ name: knotcutter
 description: "Radical simplification specialist. Cuts through complexity by questioning necessity, eliminating over-engineering, and reducing systems to their essential core. Use when codebases are bloated, abstractions proliferate, or solutions feel needlessly complex."
 tools: "Read, Grep, Glob, Bash"
 model: claude-opus-4-6
+permissionMode: auto
 level: 3
 mandatory: false
 trigger_keywords: ["refactor", "architecture", "abstraction", "framework", "pattern", "generalize", "reusable", "complexity", "simplify", "redesign", "restructure"]

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -2,6 +2,7 @@
 name: pathfinder
 description: "Strategic planning consultant with interview workflow"
 model: claude-opus-4-6
+permissionMode: acceptEdits
 level: 4
 tools: "Read, Write, Grep, Glob, Bash, Agent"
 ---

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -3,6 +3,7 @@ name: quill
 description: "MUST BE USED to craft or update project documentation. Use PROACTIVELY after major features, API changes, or when onboarding developers. Produces READMEs, API specs, architecture guides, and user manuals."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
 model: claude-haiku-4-5
+permissionMode: acceptEdits
 ---
 
 # Quill - Documentation Specialist Agent

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -2,6 +2,7 @@
 name: riskmancer
 description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
 model: claude-opus-4-6
+permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -3,7 +3,7 @@ name: riskmancer
 description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
 model: claude-opus-4-6
 level: 3
-disallowedTools: Write, Edit
+tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false
 trigger_keywords: ["auth", "authentication", "authorization", "session", "jwt", "token", "password", "crypto", "encrypt", "decrypt", "secret", "credential", "payment", "pii", "personal data", "api key", "oauth", "saml", "security"]
 invoke_when: "security-sensitive features or when Ruinor flags security concerns"

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -3,7 +3,7 @@ name: ruinor
 description: "Final quality gate reviewer. Conducts structured multi-perspective analysis of plans and code, issuing REJECT/REVISE/ACCEPT verdicts. Operates read-only -- never modifies code or plans."
 model: claude-opus-4-6
 level: 3
-disallowedTools: Write, Edit
+tools: "Read, Grep, Glob, Bash"
 mandatory: true
 invoke_when: "all plan and implementation reviews"
 ---

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -2,6 +2,7 @@
 name: ruinor
 description: "Final quality gate reviewer. Conducts structured multi-perspective analysis of plans and code, issuing REJECT/REVISE/ACCEPT verdicts. Operates read-only -- never modifies code or plans."
 model: claude-opus-4-6
+permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash"
 mandatory: true

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -3,6 +3,7 @@ name: talekeeper
 description: "Manual narrator agent. Reads enriched session chronicle files and produces human-readable narrative summaries. Must ONLY be invoked by the user directly — never by hooks, the Dungeon Master, or any automated system."
 tools: "Read, Write, Glob"
 model: claude-haiku-4-5
+permissionMode: acceptEdits
 ---
 
 # Talekeeper - The Session Narrator

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -2,6 +2,7 @@
 name: truthhammer
 description: "Factual validation specialist. Verifies claims about external systems -- config keys, API signatures, version compatibility, CLI flags, library behavior -- against authoritative sources. Operates read-only."
 model: claude-haiku-4-5
+permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -3,7 +3,7 @@ name: truthhammer
 description: "Factual validation specialist. Verifies claims about external systems -- config keys, API signatures, version compatibility, CLI flags, library behavior -- against authoritative sources. Operates read-only."
 model: claude-haiku-4-5
 level: 3
-disallowedTools: Write, Edit
+tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false
 trigger_keywords: ["changelog", "breaking change", "deprecated", "upgrade path", "migration guide", "compatibility matrix", "release notes"]
 invoke_when: "plans or code reference specific external system behavior, or when Ruinor flags factual verification concerns"

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -2,6 +2,7 @@
 name: windwarden
 description: "Performance and scalability reviewer. Reviews plans and code for performance bottlenecks, inefficient algorithms, scalability issues, and resource optimization opportunities. Operates read-only with blocked write/edit capabilities."
 model: claude-sonnet-4-6
+permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash"
 mandatory: false

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -3,7 +3,7 @@ name: windwarden
 description: "Performance and scalability reviewer. Reviews plans and code for performance bottlenecks, inefficient algorithms, scalability issues, and resource optimization opportunities. Operates read-only with blocked write/edit capabilities."
 model: claude-sonnet-4-6
 level: 3
-disallowedTools: Write, Edit
+tools: "Read, Grep, Glob, Bash"
 mandatory: false
 trigger_keywords: ["database", "query", "performance", "scale", "scalability", "optimization", "cache", "index", "pagination", "algorithm", "batch", "real-time", "throughput", "latency", "memory", "cpu"]
 invoke_when: "performance-critical features or when Ruinor flags performance concerns"


### PR DESCRIPTION
Switches reviewer agents (ruinor, riskmancer, windwarden, knotcutter, truthhammer) from a `disallowedTools` denylist to an explicit `tools:` allowlist — a strictly stronger enforcement model. Adds `permissionMode` to all 11 agents using least-privilege assignments: `auto` for read-only reviewers and the orchestrator's subagents, `acceptEdits` for file-writing agents. Dungeonmaster intentionally omits `permissionMode` so subagent declarations are not overridden by parent inheritance.