### PR TITLE
chore(settings): allow cd in bash tools allowlist

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -14,6 +14,7 @@
     "Bash(mv *)",
     "Bash(touch *)",
     "Bash(ls *)",
+    "Bash(cd *)",
     "Bash(npm *)",
     "Bash(npx *)",
     "Bash(pnpm *)",


### PR DESCRIPTION
Compound shell commands prefixed with `cd` (e.g. `cd /worktree && git log`) were triggering approval prompts because `cd` had no matching entry in the allowlist. Adding `Bash(cd *)` globally eliminates these interruptions for all projects that inherit this settings file.