### PR TITLE
chore(config): add bash command style rule to CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -13,3 +13,8 @@ ALL git commits must follow the `commit-message-guide` skill. Conventional commi
 ### Open Pull Request
 
 ALL pull requests and merge requests must be created using the `open-pull-request` skill. No other PR creation method is allowed.
+
+## Bash Command Style
+
+- Never use compound shell commands (`&&`, `;`, `|` chaining).
+- Always issue each command as a separate, standalone Bash call.


### PR DESCRIPTION
Adds a global instruction prohibiting compound shell commands (`&&`, `;`, `|` chaining), requiring each command to be issued as a separate Bash call. Prevents permission prompts caused by Claude chaining commands that include individually-whitelisted but compound-blocked sequences.