### PR TITLE
docs(agents): slim AGENTS.md to compact reference, remove config duplication

### DIFF
--- a/.claude/skills/agent-creator/SKILL.md
+++ b/.claude/skills/agent-creator/SKILL.md
@@ -260,12 +260,10 @@ Optional frontmatter fields:
 
 After creating the agent file, update:
 
-1. **docs/AGENTS.md**: Add full profile with:
+1. **docs/AGENTS.md**: Add compact profile with:
    - Quick reference table entry
-   - Detailed profile section
-   - When to use guidance
-   - Example scenarios
-   - Configuration file path
+   - Compact profile section using the standard template (Core Mission, When to invoke, Key constraint, Best Practice, Configuration File)
+   - Lore paragraph if the agent has a fantasy persona
 
 2. **README.md**: Mention in the Features section if noteworthy
 
@@ -605,7 +603,7 @@ Identify code quality issues, anti-patterns, and convention violations through s
 ```
 
 **4. Document in AGENTS.md:**
-Add to the catalog with use cases and examples
+Add compact profile to docs/AGENTS.md using the standard template
 
 ## Avatar Images
 
@@ -647,7 +645,7 @@ When creating an agent, ensure:
 If you're unsure about agent design:
 
 1. Read existing agents in `claude/agents/` for patterns
-2. Review `docs/AGENTS.md` for comprehensive examples
+2. Review `docs/AGENTS.md` for agent catalog and `claude/agents/*.md` for detailed operational specs
 3. Consider whether this should be a skill instead of an agent
 4. Start simple - you can always expand later
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,7 +1,5 @@
 # Agent Reference
 
-This document provides a comprehensive guide to the specialized agents available in this Claude Code configuration.
-
 ## Quick Reference
 
 | Agent | Purpose | Primary Use Cases | Model | Review Type |
@@ -9,11 +7,11 @@ This document provides a comprehensive guide to the specialized agents available
 | **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | N/A |
 | **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
 | **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4.5 | N/A |
-| **Riskmancer** | Security reviewer | STRIDE threat modeling, trust boundary analysis, cryptographic assessment, race condition detection | claude-opus-4-6 | Specialist (opt-in) |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-6 | Specialist (opt-in) |
 | **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-6 | N/A |
-| **Knotcutter** | Complexity elimination specialist | Dependency graph analysis, complexity metrics, abstraction fitness assessment, cognitive load quantification | claude-sonnet-4.5 | Specialist (opt-in) |
+| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-sonnet-4.5 | Specialist (opt-in) |
 | **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-6 | Mandatory baseline |
-| **Windwarden** | Performance & scalability reviewer | Amdahl's Law bottleneck identification, latency budget decomposition, concurrency analysis, read/write path separation, cost-aware capacity modeling | claude-opus-4-6 | Specialist (opt-in) |
+| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-opus-4-6 | Specialist (opt-in) |
 | **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-haiku-4-5 | Specialist (opt-in) |
 | **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | N/A |
 | **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | (default) | N/A |
@@ -36,285 +34,41 @@ Session narrative / audit trail  → Talekeeper (manual invocation; narrates enr
 Meta-analysis / team improvement → Everwise (manual invocation, analyzes past sessions)
 ```
 
-## Detailed Agent Profiles
+> For detailed operational specs, tool lists, workflows, and output formats, see each agent's config file: `claude/agents/{name}.md`
 
+## Detailed Agent Profiles
 ### Dungeon Master - Orchestrator
 
 <img src="avatars/dungeonmaster.png" alt="Dungeon Master Avatar" width="300">
 
-**Core Mission:** Coordinate multi-step software development work by delegating planning to Pathfinder and execution to Bitsmith or specialist agents. Serves as the central coordinator for complex tasks requiring multiple steps, agents, or system interactions.
+**Core Mission:** Coordinate multi-step software development work by delegating planning to Pathfinder and execution to Bitsmith or specialist agents.
 
-**Invoke when:**
-- Working on multi-step or complex software development tasks
-- Requirements are ambiguous and need structured planning
-- Multiple files, systems, or components are involved
-- Need to coordinate work across different agents
-- Task requires both planning and execution tracking
-- Want structured progress validation and status summaries
+**When to invoke:** Invoke for multi-step or complex development tasks where requirements need structured planning, work spans multiple files or systems, or you need coordinated progress tracking across agents.
 
-**Key Capabilities:**
-- Planning delegation to Pathfinder for complex or ambiguous tasks
-- Execution delegation to Bitsmith or specialist agents
-- Progress tracking against established plans
-- Validation of outputs against plan requirements
-- Risk identification and follow-up tracking
-- Concise status summaries with actionable next steps
-- Decision-making on when to continue, retry, or adjust approach
-
-**Available Tools:**
-- Research: Read, Grep, Glob
-- Delegation: Task (calls other agents)
-- Validation: Bash
-
-**Delegation Policy:**
-- **Delegates to Pathfinder when:**
-  - Request is ambiguous or underspecified
-  - Work spans multiple files, systems, or steps
-  - Architectural or sequencing decisions needed
-  - Risk of rework without explicit plan
-  - User asks for design, scope, decomposition, or approach
-
-- **Delegates to Bitsmith when:**
-  - Plan exists and execution is needed
-  - Code changes, file edits, refactoring
-  - Debugging, test creation, running commands
-  - Multi-step repository operations
-
-**Review Workflow (Intelligent Triage):**
-- **Ruinor (mandatory)**: Always runs first for baseline quality, correctness, basic security, basic performance, basic complexity
-- **Specialists (opt-in)**: Only invoked when:
-  - Ruinor flags specialist concerns in its review, OR
-  - User explicitly requests with flags (--review-security, --review-performance, --review-complexity, --review-all), OR
-  - Plan/code contains specialist-level keywords (fallback heuristic)
-
-**Workflow Flags:**
-- **`--explore-options`**: Triggers options exploration before execution planning. Presents 2–4 viable approaches with trade-offs for user selection before committing to an execution plan. Useful for architectural decisions, technology selection, or ambiguous approaches with multiple viable paths. Can be explicitly passed or triggered automatically when the DM detects ambiguous decisions.
-- **`--no-worktree`**: Suppress automatic git worktree creation; operate in the main working tree instead. Use for read-only analysis or trivial single-file changes. Useful for backwards compatibility with pre-worktree workflows. See [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md) for details.
-
-**Parallel Sessions via Worktree Isolation:**
-
-Each DungeonMaster session automatically creates an isolated git worktree on a dedicated branch (e.g., `.worktrees/dm-add-oauth-login/` on `dm/add-oauth-login`). This enables truly parallel sessions without git conflicts:
-
-- **Multiple simultaneous sessions:** Run multiple `claude --agent dungeonmaster` terminals on unrelated issues
-- **Independent branches:** Each session operates on its own branch, preventing conflicts
-- **Isolated plans:** Each worktree has its own local `plans/` directory
-- **Phase 0 worktree creation:** Automatic at session start (skipped only with `--no-worktree` flag or for trivial tasks)
-- **Phase 5 cleanup:** At completion, choose to create PR, merge to main, or keep the branch for later
-- **Manual cleanup:** `git worktree list`, `git worktree remove .worktrees/{slug}`, `git worktree prune`
-
-For comprehensive usage guide, examples, troubleshooting, and best practices, see [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md).
-
-**Specialist Triggering:**
-- **Riskmancer**: Invoked for auth/jwt/crypto/payment/pii/security-sensitive features
-- **Windwarden**: Invoked for database/query/scale/cache/performance-critical features
-- **Knotcutter**: Invoked for refactor/architecture/abstraction/complexity concerns
-
-**Typical Workflow:**
-1. Clarifies user goal in one sentence
-2. Assesses whether a plan already exists
-3. **Explore-Options Gate** (if `--explore-options` flag present OR request involves architectural decision/technology selection with multiple viable paths):
-   - Invokes Pathfinder with Consensus Mode (2–4 viable options, not an execution plan)
-   - Presents options inline with names, summaries, and recommendations
-   - Waits for explicit user selection
-   - If user selects: re-invokes Pathfinder for execution plan with selected option as context
-   - If user rejects all options: re-invokes Pathfinder in Consensus Mode with feedback as constraints
-   - If user wants to modify an option: re-invokes Pathfinder with modifications as constraints
-4. If no plan exists, delegates to Pathfinder for planning
-5. **Plan Review Gate**: Delegates plan to Ruinor (mandatory baseline reviewer)
-6. If Ruinor flags specialists or user requested them, invokes specialists in parallel (Riskmancer/Windwarden/Knotcutter)
-7. If reviewers identify issues, sends consolidated feedback back to Pathfinder
-8. Once plan approved, converts plan into concrete execution tasks
-9. Delegates each task to appropriate agent
-10. **Intermediate review gates** (Phase 3): After 2 consecutive Bitsmith invocations, runs an intermediate Ruinor review before continuing
-11. **Implementation Review Gate**: Delegates code to Ruinor (mandatory baseline reviewer)
-12. If Ruinor flags specialists or user requested them, invokes specialists in parallel
-13. If Ruinor issues REJECT (not REVISE), requires Bitsmith to produce a written remediation brief before re-review
-14. If issues found, delegates fixes back to Bitsmith and returns to review step
-15. **Completion Phase (Phase 5)** - Three conditional gates executed in order:
-    - **5a: Reservations logging** (mandatory if ACCEPT-WITH-RESERVATIONS issued): Extract reservations from review findings, delegate to Bitsmith to write to `open-questions.md`
-    - **Verification gate** (conditional): If reservations were logged, confirm `open-questions.md` was written successfully before proceeding
-    - **5b: Documentation update** (conditional on planning): Before invoking Quill, cross-reference plan steps against completed delegations to ensure no skipped work; invoke Quill only after verification
-    - **Post-documentation safeguard**: If any Bitsmith work occurs after Quill, that work must re-enter Phase 4 (Implementation Review) before session can complete
-    - **5c: Completion summary**: Confirm outcome, summarize all work, explicitly record reservations logging status (yes/no)
-16. Validates results against plan after all reviews pass and all gates cleared
-17. Before finishing, confirms outcome achieved and summarizes work with risks/follow-ups
-
-**Output Format:**
-- Goal statement
-- Plan status (created, reviewed, approved/revised)
-- Plan review summary (Ruinor verdict + any specialist verdicts)
-- Specialist invocation reason (Ruinor recommendation, user flag, or keyword detection)
-- Execution status
-- Implementation review summary (Ruinor verdict + any specialist verdicts)
-- Final validation
-- Risks and follow-ups
-
-**Important Constraints:**
-- Does not invent plans when Pathfinder should provide them
-- Does not perform large implementation work directly
-- Only declares completion when results match both plan and user request
-- If execution reveals plan is invalid, loops back to planning
-- Minimizes unnecessary back-and-forth with decisive delegation
-- **Intermediate review gates are hard limits:** After 2 consecutive Bitsmith invocations without intervening review, runs an intermediate Ruinor review before proceeding
-- **Everwise is user-facing only:** Never invokes Everwise as an escalation path after review failures or stalled loops; instead suggest it to the user
-- **REJECT verdicts require remediation:** When Ruinor issues REJECT (vs. REVISE), requires a written remediation brief from Bitsmith before re-review invocation
-- **Documentation follows implementation review:** Quill must only be invoked after Phase 4 (Implementation Review) is fully complete; any Bitsmith work after Quill must re-enter Phase 4
-- **Post-Quill review obligation is mandatory:** Quill completion does not end the review obligation. If any Bitsmith invocation occurs after Quill, a Phase 4 Ruinor review of that work is mandatory before declaring session complete
-- **ACCEPT-WITH-RESERVATIONS requires explicit tracking:** When any reviewer issues ACCEPT-WITH-RESERVATIONS, reservations must be logged to `open-questions.md` before progression to completion summary. Session cannot declare complete without this tracking.
-
-**Example Scenarios:**
-
-*Example 1: Multi-step feature*
-- User: "Add OAuth login, update the API, and add tests"
-- Action: Delegates to Pathfinder for decomposition → delegates implementation to Bitsmith → validates against plan → returns status
-
-*Example 2: Trivial task*
-- User: "Rename this variable in one file"
-- Action: Skips Pathfinder → delegates directly to Bitsmith → returns brief summary
-
-*Example 3: Options exploration with architectural decision*
-- User: "We need a background job system for sending emails --explore-options"
-- Action:
-  1. Explore-Options Gate triggers (explicit flag + architectural decision)
-  2. Invokes Pathfinder in Consensus Mode → returns 3 options (in-process queue, Redis+BullMQ, RabbitMQ)
-  3. Presents options with trade-offs (scalability, complexity, operational overhead)
-  4. User selects Option B (Redis + BullMQ)
-  5. Re-invokes Pathfinder for execution plan with selected option as context
-  6. Continues with Plan Review → Execution → Implementation Review as normal
-
-*Example 4: Parallel sessions with git worktree isolation*
-- Terminal A: User: "Add OAuth login"
-  - Session automatically creates worktree at `.worktrees/dm-add-oauth-login/` on branch `dm/add-oauth-login`
-  - Pathfinder creates plan in worktree's `plans/`
-  - Bitsmith implements in worktree
-  - Reviews happen in worktree context
-  - At Phase 5, presents PR/merge/keep options
-- Terminal B (simultaneously): User: "Fix database query performance on issue #42"
-  - Session automatically creates separate worktree at `.worktrees/dm-fix-db-perf-issue-42/` on branch `dm/fix-db-perf-issue-42`
-  - Work proceeds independently without git conflicts
-  - Both sessions can commit, implement, and generate PRs in parallel
-- Result: Two independent feature branches, zero conflicts, true parallel development
-- See [Worktree Isolation Guide](/docs/WORKTREE_ISOLATION.md) for comprehensive details
+**Key constraint:** Does not implement code directly; delegates all planning to Pathfinder and all execution to Bitsmith.
 
 **Best Practice:** Invoke Dungeon Master as the entry point for non-trivial development work. It intelligently routes between planning and execution, ensuring structured progress without requiring you to manually coordinate between agents. Use `--explore-options` explicitly when facing technology/architecture decisions to see trade-offs before committing.
 
 **Configuration File:** `/claude/agents/dungeonmaster.md`
 
 ---
-
 ### Askmaw - Intake and Elaboration Clerk
 
 <img src="avatars/askmaw.png" alt="Askmaw Avatar" width="300">
 
 A half-orc clerk. Competent, direct, not verbose. Gets to the point and asks purposeful questions without padding.
 
-**Core Mission:** Stateless intake clerk that resolves ambiguous user requests through a structured interview loop managed by Dungeon Master. Each invocation receives full context (original request plus all prior Q&A pairs) and returns exactly one output: either a single clarifying question or a completed structured brief. Askmaw has no memory between invocations. Never plans, implements, researches the codebase, or writes files.
+**Core Mission:** Stateless intake clerk that resolves ambiguous user requests through a structured interview loop managed by Dungeon Master.
 
-**Invoke when:**
+**When to invoke:** Invoke when a user request is ambiguous, underspecified, or has multiple plausible interpretations before delegating to Pathfinder for planning.
 
-- A user request is ambiguous, underspecified, or has multiple plausible interpretations
-- The objective is unclear, scope is unbounded, or key trade-offs have not been addressed
-- Dungeon Master detects ambiguity before delegating to Pathfinder
-- Clarification is needed without immediately jumping to planning
-
-**Skip Askmaw when:**
-
-- The user's request is already well-specified (clear objective, bounded scope, stated constraints)
-- The user provides a detailed specification or brief inline
-- The task is trivial and would skip Pathfinder entirely
-
-**Key Capabilities:**
-
-- Stateless one-shot intake processing (full context provided on each invocation)
-- Clarifying question generation (targets objective clarity, scope boundaries, preferences, constraints, success criteria)
-- Structured brief production (objective, scope, constraints, preferences, success criteria, raw request)
-- Fallback handling for "just do it" requests
-- Question discipline (2–5 questions across full loop, hard limit of 5 enforced by DM)
-
-**Available Tools:** None — read-only delegation from Dungeon Master only
-
-**Question Discipline:**
-
-**Questions Askmaw asks:**
-- "What should this feature do when X happens?"
-- "Is Y in scope or out of scope?"
-- "Do you prefer A or B?"
-- "What does done look like?"
-- "Are there any constraints on timeline or technology?"
-
-**Questions Askmaw does NOT ask:**
-- Codebase structure ("Where is the auth code?")
-- File locations ("Which file handles X?")
-- Implementation details ("How is X currently built?")
-
-Those are Pathfinder's domain. Askmaw asks about intent, scope, and preferences — not facts about the existing system.
-
-**Output Contract — Two Modes:**
-
-**Mode A: Question**
-```
-## Intake Question
-
-{Single clarifying question}
-```
-
-**Mode B: Brief**
-```
-## Intake Brief
-
-**Objective:** One-sentence statement of what the user wants to accomplish.
-
-**Scope:**
-- In scope: [bulleted list]
-- Out of scope: [bulleted list, if established]
-
-**Constraints:**
-- [Technical, timeline, or organizational constraints]
-
-**Preferences:**
-- [User-stated preferences on approach, trade-offs, priorities]
-
-**Success Criteria:**
-- [How the user will know this is done]
-
-**Raw Request:** [Original request text, preserved verbatim]
-```
-
-**When to Produce the Brief (Mode B):**
-
-Switch to Mode B when all of the following hold:
-
-- The objective is unambiguous — one clear goal, not multiple plausible interpretations
-- The scope is bounded — what's in and out is clear, or the user has declined to specify
-- Key preferences and constraints are captured, or the user has deferred them
-- No critical decision-blocking ambiguity remains
-
-**Termination Rules:**
-
-When producing the brief (Mode B), stop. Do not continue into planning, implementation notes, or research questions. The brief is the terminal output.
-
-Produce a minimal brief immediately if the user says "just do it," "skip the questions," or any equivalent. Flag unresolved ambiguities for Pathfinder to exercise judgment on.
-
-**Failure Safeguard (Round 6):**
-
-If Dungeon Master instructs Askmaw to produce a brief after 5 questions, produce a best-effort brief immediately and flag any remaining unresolved ambiguities as open questions within the brief. Pathfinder will receive these as flagged items.
-
-**Typical Workflow (DM-Managed Loop):**
-
-1. DM invokes Askmaw (round 1) with raw request and empty Q&A history
-2. If Askmaw returns a question: DM surfaces it to user, collects answer, appends Q&A pair to history, re-invokes Askmaw
-3. If Askmaw returns a brief: DM exits the loop and passes brief to Pathfinder
-4. After 5 rounds without a brief: DM instructs Askmaw to produce a best-effort brief, flagging open questions
-5. DM proceeds to Pathfinder with completed brief as requirements input
-
-**Output Format:** Either a single clarifying question or a structured intake brief — nothing else.
+**Key constraint:** Stateless and tool-less; returns exactly one output per invocation (a question or a brief) and has no memory between calls.
 
 **Best Practice:** Invoke Dungeon Master as the entry point for ambiguous work. DM automatically routes through Askmaw when ambiguity is detected, manages the interview loop, and transitions to Pathfinder once requirements are clarified. Askmaw is stateless by design — DM maintains full context between invocations.
 
 **Configuration File:** `/claude/agents/askmaw.md`
 
 ---
-
 ### Quill - Documentation Specialist
 
 <img src="avatars/quill.png" alt="Quill Avatar" width="300">
@@ -329,47 +83,9 @@ Quill has a single professional rival: documentation written by someone who clea
 
 **Core Mission:** Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
-**Trigger Mechanisms:**
+**When to invoke:** Invoke after implementation is complete to create or update READMEs, API specs, architecture guides, and user manuals; also triggered automatically by Dungeon Master in Phase 5.
 
-1. **Automatic via Dungeon Master (Phase 5)**: Automatically invoked after Pathfinder creates a plan and implementation is completed. Quill receives context from DM: plan file path, list of files changed during implementation, and feature summary.
-
-2. **Manual Invocation**: Explicitly invoke Quill for documentation work not tied to a planning session:
-   - Adding major features or API changes
-   - Onboarding new developers to a project
-   - Documentation is out of sync with code
-   - Creating architecture or design documentation
-   - Generating API specifications
-
-**Key Capabilities:**
-- Gap analysis of existing documentation
-- README generation and updates
-- API specification creation (including OpenAPI/YAML)
-- Architecture guide development
-- User manual creation
-- Technical accuracy validation
-- Code example extraction from tests and implementations
-
-**Available Tools:**
-- File operations: Read, Write, Edit
-- Search: Grep, Glob
-- Bash commands for system tasks
-
-**Typical Workflow (Automatic Invocation via DM):**
-1. Receives plan file path, changed files list, and feature summary from Dungeon Master
-2. Audits existing documentation against changes made during implementation
-3. Identifies gaps, outdated content, and missing sections in scope of the feature
-4. Plans document structure with hierarchical headings
-5. Creates clear Markdown with functional code snippets
-6. Validates technical precision and link integrity
-
-**Typical Workflow (Manual Invocation):**
-1. Audits existing documentation against current codebase
-2. Identifies gaps, outdated content, and missing sections
-3. Plans document structure with hierarchical headings
-4. Creates clear Markdown with functional code snippets
-5. Validates technical precision and link integrity
-
-**Output Format:** Concise change log listing created/modified files with single-line summaries.
+**Key constraint:** Must not be invoked until Phase 4 (Implementation Review) is fully complete; any post-Quill code changes require re-review.
 
 **Best Practice:** Quill runs automatically as part of the Dungeon Master's completion workflow when a plan has been created. For documentation work outside of planning sessions, manually invoke Quill proactively rather than waiting for documentation to become severely outdated.
 
@@ -381,58 +97,11 @@ Quill has a single professional rival: documentation written by someone who clea
 
 <img src="avatars/riskmancer.png" alt="Riskmancer Avatar" width="300">
 
-**Agent Type:** Specialist Reviewer (invoked only when security-sensitive work detected or explicitly requested)
+**Core Mission:** Identify and prioritize vulnerabilities before production deployment, focusing on OWASP Top 10 analysis, secrets detection, input validation, and authentication checks.
 
-**Trigger Conditions:**
-- Ruinor flags security concerns beyond baseline checks, OR
-- User explicitly requests security review (--review-security flag), OR
-- Plan/code contains security keywords (auth, jwt, crypto, payment, pii, oauth, etc.)
+**When to invoke:** Invoke for pre-deployment security reviews of authentication, authorization, cryptography, payment processing, PII handling, or any security-sensitive feature flagged by Ruinor.
 
-**Not invoked for:** Simple UI changes, configuration updates, documentation, or features with no security implications. Ruinor handles baseline security for all reviews.
-
-**Core Mission:** Identify and prioritize vulnerabilities before production deployment, focusing on OWASP Top 10 analysis, secrets detection, input validation, and authentication checks. Provides deep security expertise beyond Ruinor's baseline checks.
-
-**Invoke when:**
-- Conducting pre-deployment security reviews for sensitive features
-- Auditing authentication, authorization, or access control changes
-- Reviewing cryptography, encryption, or key management
-- Checking for exposed secrets or credentials in security-critical contexts
-- Validating input handling for potential injection vectors
-- Reviewing payment processing, PII handling, or sensitive data
-- Running dependency vulnerability checks for security-sensitive features
-
-**Key Capabilities:**
-- STRIDE threat modeling with per-feature analysis (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
-- Trust boundary analysis and data flow validation across system boundaries
-- Authentication architecture deep-dive: token lifecycle, session management, credential storage, OAuth/OIDC flows, PKCE enforcement
-- Cryptographic implementation evaluation: algorithm correctness, IV/nonce handling, AEAD usage, key rotation, no custom crypto
-- Race condition and TOCTOU vulnerability detection: atomicity analysis, double-spend prevention, concurrent permission checks
-- OWASP Top 10 vulnerability systematic evaluation
-- Secrets scanning for hardcoded credentials, API keys, tokens
-- Dependency audit execution (npm, pip, cargo, govulncheck)
-- Vulnerability prioritization by severity × exploitability × blast radius
-- Remediation guidance with secure code examples in source language
-
-**Available Tools:**
-- Read-only access: Read, Grep, ast_grep_search
-- Bash (for dependency audits only)
-- Write/Edit tools are explicitly blocked
-
-**Typical Workflow:**
-1. Identifies scope and technology stack
-2. Scans for exposed secrets and credentials
-3. Runs appropriate dependency vulnerability audits
-4. Evaluates each applicable OWASP Top 10 category systematically
-5. Prioritizes findings by risk level
-6. Delivers actionable remediation guidance
-
-**Output Format:** Security report including:
-- Scope definition
-- Overall risk level assessment
-- Issue summaries by severity
-- Detailed findings with file locations, severity ratings, and remediation steps
-- Security checklists for validation
-- Exploitation pathways and blast radius for each vulnerability
+**Key constraint:** Read-only; Write and Edit tools are explicitly blocked to prevent accidental modifications during audits.
 
 **Best Practice:** Invoke Riskmancer before production deployments or when reviewing security-sensitive code changes. The read-only nature ensures no accidental modifications during security audits.
 
@@ -446,59 +115,9 @@ Quill has a single professional rival: documentation written by someone who clea
 
 **Core Mission:** Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/*.md`.
 
-**Invoke when:**
-- Starting a new feature or major change
-- Need to break down complex work into actionable steps
-- Want structured requirements gathering
-- Creating implementation strategy
-- Need decision-making support (consensus mode)
+**When to invoke:** Invoke when starting a new feature or major change, breaking down complex work into actionable steps, or when structured requirements gathering and decision support are needed.
 
-**Key Capabilities:**
-- Structured interview workflow (one question at a time)
-- Codebase research delegation to explore agents
-- Plan generation with 3-6 actionable steps
-- Consensus mode with RALPLAN-DR (principles, decision drivers, options, ADR)
-- Open questions tracking
-- Verifiable acceptance criteria for each step
-
-**Available Tools:**
-- Research: Read, Grep, Glob
-- Plan creation: Write
-- Investigation: Bash
-- Delegation: Agent (explore agents)
-
-**Typical Workflow:**
-1. Reframes user request as "create a work plan for X"
-2. Delegates codebase research to explore agents
-3. Interviews user one question at a time about preferences/priorities
-4. Synthesizes findings into structured plan
-5. Gets user confirmation before finalizing
-6. Saves plan to `plans/{feature-name}.md`
-
-**Plan Structure:**
-- Context and Objectives
-- Guardrails (Must Have / Must NOT Have)
-- Task Flow (3-6 steps with checkboxes and acceptance criteria)
-- Success Criteria
-
-**Consensus Mode (Options Exploration):**
-Activate automatically via Dungeon Master's `--explore-options` flag, or manually with `--consensus` for enhanced decision support. Pathfinder produces a structured options comparison (not an execution plan) with:
-- 3-5 guiding principles
-- Top 3 decision drivers
-- 2–4 viable options with:
-  - Pros and cons for each approach
-  - Reversibility assessment (Easy/Moderate/Difficult to switch later)
-  - Trade-off analysis against decision drivers
-- Comparison matrix summarizing options across key decision drivers
-- Architecture Decision Record format (Status, Context, Decision, Consequences)
-- Pre-mortem analysis (for high-risk scenarios)
-- Expanded testing strategy (Unit, Integration, E2E, Observability)
-
-Consensus Mode output is presented inline to the user for selection. Once selected, Dungeon Master re-invokes Pathfinder for execution planning with the chosen option as context, avoiding redundant research.
-
-**Output Location:**
-- Plans: `plans/{feature-name}.md`
-- Open questions: `plans/open-questions.md`
+**Key constraint:** Plans only, never implements; produces plans for others to execute.
 
 **Best Practice:** Invoke Pathfinder before starting significant work to ensure clear requirements, structured approach, and stakeholder alignment. The agent explicitly does NOT implement code - it creates plans for others to execute.
 
@@ -510,71 +129,11 @@ Consensus Mode output is presented inline to the user for selection. Once select
 
 <img src="avatars/knotcutter.png" alt="Knotcutter Avatar" width="300">
 
-**Agent Type:** Specialist Reviewer (invoked only when complexity-sensitive work detected or explicitly requested)
+**Core Mission:** Ruthlessly simplify systems by removing non-essential components until only vital elements remain, providing deep complexity analysis beyond Ruinor's baseline checks.
 
-**Trigger Conditions:**
-- Ruinor flags complexity concerns beyond baseline checks, OR
-- User explicitly requests complexity review (--review-complexity flag), OR
-- Plan/code contains complexity keywords (refactor, architecture, abstraction, framework, pattern, redesign, etc.)
+**When to invoke:** Invoke for major refactoring, when new abstractions or frameworks are being introduced, systems feel over-engineered, or complexity concerns are flagged by Ruinor.
 
-**Not invoked for:** Simple features, bug fixes, small changes, or work already following established patterns. Ruinor handles baseline complexity checks (obvious YAGNI violations) for all reviews.
-
-**Core Mission:** Ruthlessly simplify systems by removing non-essential components until only vital elements remain. Operating on the principle that "complexity is the enemy of progress," this agent untangles over-engineered solutions and advocates for minimal viable approaches. Provides deep complexity analysis beyond Ruinor's baseline checks.
-
-**Invoke when:**
-- Major refactoring across multiple files or systems
-- New abstractions, frameworks, or architectural patterns are being introduced
-- Systems feel needlessly complex or over-engineered
-- Need to reduce technical debt through radical simplification
-- Premature optimization or speculative features proliferate
-- Maintenance burden is high due to unjustified complexity
-- Looking to improve code clarity and reduce cognitive load for complex systems
-
-**Key Capabilities:**
-- Complexity metrics with numeric thresholds (cyclomatic complexity, fan-out, abstraction depth, cognitive load)
-- Dependency graph analysis with cycle detection, fan-in/fan-out evaluation, instability index calculation
-- Abstraction fitness evaluation: implementation count, interface leakage, coupling, replacement feasibility
-- Architectural pattern fitness criteria: Factory, Strategy, Observer, Middleware, Repository with justified/not-justified conditions
-- Cognitive load quantification: files to open, indirection levels, concepts to learn, configuration surface
-- Simplification risk assessment with before/after metrics and migration path
-- Systematic complexity cataloging and necessity questioning
-- YAGNI (You Aren't Gonna Need It) enforcement
-- Identification of minimal viable core functionality
-- Aggressive scope reduction (targeting 50%+ reduction)
-
-**Available Tools:**
-- Research: Read, Grep, Glob
-- Simplification: Edit, Write
-- Validation: Bash
-
-**Typical Workflow:**
-1. Catalogs all components, abstractions, dependencies, and features
-2. Questions necessity of each element ("What happens if we remove this?")
-3. Identifies absolute minimum required for core functionality
-4. Applies central question: "What's the simplest thing that could possibly work?"
-5. Proposes measurable reductions with before/after comparison
-6. Documents learnings about actual vs. assumed necessity
-
-**Guiding Principles:**
-- **YAGNI First**: Prove necessity before building
-- **Concrete Over General**: Solve specific problems, not hypothetical ones
-- **Duplication Threshold**: Require 3+ instances before abstracting
-- **Data Over Logic**: Prefer data structures that eliminate complex conditionals
-- **Working Beats Perfect**: Simple and working beats perfect and broken
-
-**Output Format:**
-- Removed components list with elimination rationale
-- Simplified code with reduction explanations
-- Before/after complexity metrics (lines, files, dependencies)
-- "What we learned" section on actual necessity
-- Dependency reduction report
-
-**Success Criteria:**
-- Achieved 50%+ reduction in components/abstractions/features
-- Eliminated unnecessary dependencies
-- Replaced general frameworks with specific solutions
-- Maintained or improved core functionality
-- Reduced cognitive load for maintainers
+**Key constraint:** Targets 50%+ reduction in components/abstractions; treats every removal as a victory over complexity.
 
 **Best Practice:** Invoke Knotcutter when you sense over-engineering or when systems have accumulated complexity through "just in case" additions. The agent treats every removal as a learning opportunity and victory over complexity.
 
@@ -586,48 +145,11 @@ Consensus Mode output is presented inline to the user for selection. Once select
 
 <img src="avatars/ruinor.png" alt="Ruinor Avatar" width="300">
 
-**Agent Type:** Mandatory Baseline Reviewer (always runs for all plan and implementation reviews)
+**Core Mission:** Serve as the mandatory quality gate before plans are executed or code is merged, issuing clear verdicts (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) with baseline coverage of quality, correctness, security, performance, and complexity.
 
-**Core Mission:** Serve as the mandatory quality gate before plans are executed or code is merged. Reviews artifacts through structured multi-perspective analysis and issues clear verdicts (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT). Provides baseline coverage of quality, correctness, basic security, basic performance, and basic complexity. Flags specialists when deeper expertise is needed. Operates under the principle that false approvals cost 10-100x more than false rejections.
+**When to invoke:** Invoke after Pathfinder produces a plan and before execution begins, and again after significant code changes before merging; runs automatically via Dungeon Master orchestration.
 
-**Invoke when:**
-- A plan has been created and needs review before execution (automatic via orchestration)
-- Code changes need quality review before merging (automatic via orchestration)
-- Want a structured go/no-go assessment
-- Need multi-perspective baseline analysis before specialist reviews
-- Suspect systemic quality issues across a body of work
-
-**Key Capabilities:**
-- 6-phase investigation protocol (Pre-commitment, Verification, Multi-perspective review, Gap analysis/Self-Audit/Realist Check, Specialist Assessment, Synthesis)
-- Baseline security checks (obvious injection, exposed secrets, basic OWASP)
-- Baseline performance checks (N+1 queries, obvious inefficiencies, missing indexes)
-- Baseline complexity checks (obvious over-engineering, YAGNI violations)
-- Specialist triage (flags Riskmancer/Windwarden/Knotcutter when deeper review needed)
-- Severity classification (CRITICAL, MAJOR, MINOR) with evidence requirements
-- Adversarial mode escalation on CRITICAL findings, 3+ MAJOR findings, or systemic issues
-- Structured verdicts with actionable, location-specific feedback
-- Self-audit to avoid false positives and unfair criticism
-
-**Available Tools:**
-- Read-only access: Read, Grep, Glob
-- Bash (for verification commands: git log, git diff, linting, tests)
-- Write/Edit tools are explicitly blocked
-
-**Typical Workflow:**
-1. Establishes what is being reviewed and predicts likely problem areas
-2. Verifies factual claims (file paths, function references, stated behaviors)
-3. Evaluates from multiple perspectives (correctness, completeness, performance, maintainability, user impact)
-4. Conducts gap analysis, self-audit, and realist check
-5. Synthesizes findings with severity ratings
-6. Issues verdict with actionable recommendations
-
-**Output Format:** Structured review including:
-- Review summary with verdict and finding counts
-- Pre-commitment predictions vs. actual findings
-- Detailed findings with ID, severity, location, evidence, impact, and recommendation
-- Gap analysis
-- Verdict rationale
-- Adversarial mode flag when escalation is triggered
+**Key constraint:** Read-only; operates under the principle that false approvals cost 10-100x more than false rejections.
 
 **Best Practice:** Invoke Ruinor after Pathfinder produces a plan and before the Dungeon Master begins execution. Also invoke after significant code changes before merging. The read-only nature ensures no accidental modifications during review.
 
@@ -639,93 +161,11 @@ Consensus Mode output is presented inline to the user for selection. Once select
 
 <img src="avatars/windwarden.png" alt="Windwarden Avatar" width="300">
 
-**Agent Type:** Specialist Reviewer (invoked only when performance-critical work detected or explicitly requested)
+**Core Mission:** Hunt performance bottlenecks and scalability issues before they reach production, providing deep performance expertise beyond Ruinor's baseline checks.
 
-**Trigger Conditions:**
-- Ruinor flags performance concerns beyond baseline checks, OR
-- User explicitly requests performance review (--review-performance flag), OR
-- Plan/code contains performance keywords (database, query, scale, cache, index, pagination, algorithm, batch, etc.)
+**When to invoke:** Invoke for database schema changes, query optimization, algorithmic complexity concerns, high-throughput features, or any performance-critical work flagged by Ruinor.
 
-**Not invoked for:** Simple CRUD operations, UI changes, configuration updates, or features with trivial performance implications. Ruinor handles baseline performance checks for all reviews.
-
-**Core Mission:** Hunt performance bottlenecks and scalability issues before they reach production. Review plans for inefficient designs and implementations for actual performance problems. Operate under the principle that performance is a feature, not an afterthought. Provides deep performance expertise beyond Ruinor's baseline checks.
-
-**Invoke when:**
-- Reviewing database schema changes, query optimization, or data-heavy operations
-- Assessing scalability of algorithmic work (sorting, searching large datasets)
-- Detecting algorithmic complexity issues beyond basic checks
-- Validating real-time or high-throughput features
-- Checking for N+1 query patterns or complex joins in performance-critical paths
-- Reviewing caching strategies, background jobs, batch processing
-- Pre-deployment performance validation for scalability-sensitive features
-
-**Key Capabilities:**
-- Amdahl's Law bottleneck identification: pinpointing the single highest-impact component and proving why other optimizations won't help until the bottleneck is addressed
-- Latency budget decomposition: end-to-end target allocation to per-component budgets with variance analysis (P99/P50 ratios)
-- I/O-bound vs CPU-bound classification with appropriate optimization strategies for each
-- Concurrency and contention analysis: connection pool sizing, lock contention, deadlock potential, optimistic vs pessimistic strategy fitness
-- Read-path vs write-path separation with distinct optimization approaches per path
-- Capacity modeling: performance projection as data volume and user count grow, infrastructure cost implications
-- Algorithmic complexity analysis (identifying O(n²) where O(n) is possible)
-- Database performance review (N+1 queries, missing indexes, full table scans)
-- Scalability pattern validation (pagination, rate limiting, backpressure)
-- Caching strategy assessment
-- Resource usage analysis (memory leaks, unnecessary allocations)
-- Performance severity classification (CRITICAL, HIGH, MEDIUM, LOW)
-- Optimization recommendations with before/after comparisons
-
-**Available Tools:**
-- Read-only access: Read, Grep, Glob
-- Bash (for performance analysis: EXPLAIN queries, profiling tools, benchmarks)
-- Write/Edit tools are explicitly blocked
-
-**Review Gates:**
-
-1. **Plan Review Gate** - Before implementation begins
-   - Identifies algorithmic complexity issues in planned approach
-   - Flags potential N+1 query patterns or inefficient data access
-   - Challenges designs that don't scale (unbounded loops, missing pagination)
-   - Assesses caching strategy and load considerations
-   - Spots missing indexing or query optimization steps
-
-2. **Implementation Review Gate** - After code is written
-   - Profiles actual code for performance hotspots
-   - Detects memory leaks, unbounded loops, inefficient queries
-   - Validates database indexing and query performance
-   - Checks for proper pagination, rate limiting, and backpressure
-   - Assesses caching implementation and TTL strategies
-
-**Typical Workflow:**
-1. Identifies performance-critical features and hot paths
-2. Analyzes algorithmic complexity of the approach
-3. Checks for scalability patterns (pagination, caching, indexes)
-4. Profiles execution paths and database queries
-5. Assesses resource usage (memory, CPU, I/O)
-6. Prioritizes findings by user impact
-7. Issues verdict with optimization recommendations
-
-**Output Format:** Performance review including:
-- Performance review summary with verdict and impact level
-- Performance analysis overview
-- Detailed findings with ID, severity, category, location, evidence, impact, and optimization
-- Performance gaps identified
-- Benchmark recommendations
-- Verdict rationale
-
-**Performance Severity Levels:**
-- **CRITICAL**: Will cause system failure or unacceptable UX under expected load (unbounded loops, missing pagination)
-- **HIGH**: Significant performance degradation impacting user experience (N+1 queries, missing indexes)
-- **MEDIUM**: Noticeable but not critical impact (missing caching, inefficient data structures)
-- **LOW**: Minor inefficiency with negligible impact (small allocations in loops)
-
-**Common Anti-Patterns Detected:**
-- N+1 query patterns
-- SELECT * when specific columns suffice
-- Missing database indexes on frequently queried columns
-- Unbounded loops or recursion
-- Synchronous blocking calls in request handlers
-- Large objects loaded entirely when streaming would work
-- Missing connection pooling or resource reuse
+**Key constraint:** Read-only; focuses on user-facing and resource-critical paths, distinguishing premature from necessary optimization.
 
 **Best Practice:** Invoke Windwarden during both plan review (to catch design issues before coding) and implementation review (to catch actual performance problems). The agent focuses on user-facing and resource-critical paths, distinguishing between premature optimization and necessary optimization.
 
@@ -737,71 +177,11 @@ Consensus Mode output is presented inline to the user for selection. Once select
 
 <img src="avatars/truthhammer.png" alt="Truthhammer Avatar" width="300">
 
-**Agent Type:** Specialist Reviewer (invoked only when factual claims about external systems require verification or explicitly requested)
+**Core Mission:** Verify factual claims about external systems (config keys, API signatures, version compatibility, CLI flags, environment variables) against authoritative official documentation.
 
-**Trigger Conditions:**
+**When to invoke:** Invoke when plans or code reference specific config keys, env variables, CLI flags, version-dependent API calls, or migration steps for third-party services.
 
-- Ruinor flags factual verification concerns about external system behavior, OR
-- User explicitly requests factual validation (--verify-facts flag), OR
-- Plan/code contains factual-validation keywords (changelog, breaking change, deprecated, upgrade path, migration guide, compatibility matrix, release notes)
-
-**Not invoked for:** Internal business logic, pure refactoring with no external dependencies, or work that makes no claims about external system behavior. Ruinor handles baseline correctness checks for all reviews.
-
-**Core Mission:** Verify factual claims about external systems (config keys, API signatures, version compatibility, CLI flags, environment variables) against authoritative official documentation. Hallucinated facts about third-party systems are silent killers that pass code review but explode in production. Truthhammer stops them before they propagate.
-
-**Invoke when:**
-
-- Plans or code reference specific config keys, env variables, or CLI flags for third-party services
-- Library/SDK API calls may be version-dependent or have recently changed signatures
-- Version numbers or compatibility claims are made without citation
-- Migration or upgrade steps reference behavior of specific tool versions
-- Ruinor flags factual verification concerns
-- User explicitly requests factual validation (--verify-facts flag)
-
-**Key Capabilities:**
-
-- Config property verification (key names, valid values, defaults for Redis, Kafka, PostgreSQL, etc.)
-- API signature validation (method names, parameter types/order, return types for SDKs)
-- Version compatibility verification (which versions are compatible, breaking changes between versions)
-- Library behavior verification (comparing plan assumptions against actual library documentation)
-- CLI flags and environment variable validation (flag names, accepted values, env var names)
-- Cross-referencing claims across multiple official sources before marking as verified
-- Graceful degradation when web tools are unavailable
-
-**Available Tools:**
-
-- Research: WebSearch, WebFetch (official documentation domains only)
-- Read-only access: Read, Grep, Glob
-- Bash (for read-only verification commands)
-- Write/Edit tools are explicitly blocked
-
-**Security Mitigations (Mandatory):**
-
-1. **Query Sanitization** - Never include internal identifiers, API keys, or proprietary info in search queries
-2. **Untrusted Content Handling** - Treat all fetched web content as untrusted; cross-reference before marking verified
-3. **URL Allowlist** - Only fetch from official documentation domains (docs.python.org, kubernetes.io, aws.amazon.com, etc.)
-4. **Private IP Blocking** - Never fetch from private or internal addresses
-5. **Output Labeling** - Clearly label findings as "corroborated by web sources" not "guaranteed correct"
-
-**Typical Workflow:**
-
-1. Scans plan or code for factual claims about external systems
-2. Categorizes claims by domain (config, API, version, CLI, env var)
-3. Constructs sanitized queries and searches official documentation
-4. Fetches relevant documentation pages (URL allowlist enforced)
-5. Compares claims against official documentation
-6. Classifies findings as VERIFIED, UNVERIFIABLE, or CONTRADICTED
-7. Issues verdict with severity ratings and specific corrections
-
-**Output Format:** Factual validation summary including:
-
-- Artifact reviewed
-- Verdict (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT)
-- Confidence level
-- Claims inventory table with classifications
-- Detailed findings for each CONTRADICTED or UNVERIFIABLE claim
-- Verification coverage summary
-- Verdict rationale with evidence citations
+**Key constraint:** Only fetches from official documentation domains (URL allowlist enforced); treats all web content as untrusted.
 
 **Best Practice:** Invoke Truthhammer when plans or code reference external system behavior that could be wrong or outdated. The read-only nature ensures no accidental modifications during verification. Particularly valuable during version migrations, dependency upgrades, or when using recently-changed APIs.
 
@@ -823,60 +203,9 @@ The plan is the blueprint. The codebase is the existing metalwork. Her job is to
 
 **Core Mission:** Take a plan from Pathfinder and forge it into working code — no more, no less. Implements with precision, minimal diffs, and zero LSP errors. Does not plan, design, or review. Builds.
 
-**Invoke when:**
+**When to invoke:** Invoke when a plan already exists and needs to be executed, making targeted code changes with minimal diff requirements, or incremental verified implementation with build and test validation.
 
-- A plan already exists and needs to be executed
-- Implementing targeted code changes with minimal diff requirements
-- Making surgical edits that must match existing codebase patterns
-- Need incremental, verified implementation with build and test validation
-- Want guaranteed escalation when a problem exceeds scope or attempts
-
-**Key Capabilities:**
-
-- Task complexity classification (trivial / scoped / complex)
-- Codebase pattern discovery before writing a single line
-- Atomic, incremental implementation with per-step verification
-- LSP diagnostics validation across all modified files
-- Full build and test suite execution after every change
-- Escalation to Pathfinder after 3 failed attempts (mandatory)
-- Debug/scaffolding code removal before completion
-- Max 3 concurrent read-only exploration sub-agents
-
-**Available Tools:**
-
-- File operations: Read, Write, Edit
-- Search: Grep, Glob
-- Build/test/verify: Bash
-- Delegation: Agent (read-only exploration sub-agents only)
-
-**Typical Workflow (The Forge Protocol):**
-
-1. **Classify** — Label the task as trivial / scoped / complex
-2. **Identify** — Read the plan; list all target files before touching anything
-3. **Explore** — Discover naming conventions, patterns, utilities, and existing solutions
-4. **Style** — Match indentation, imports, error handling, and test structure exactly
-5. **Plan** — Break work into atomic, ordered, verifiable TodoWrite items
-6. **Implement** — One step at a time; verify with LSP + build + tests after each change
-7. **Verify** — Fresh full build and test suite; confirm zero LSP errors, zero debug code, minimum diff
-
-**Escalation Protocol:**
-
-- After **3 failed attempts** on any issue: escalate to Pathfinder (mandatory, not optional)
-- **Immediate escalation** when: plan requires architecture decisions, task conflicts with surrounding systems, or codebase reality invalidates the plan's approach
-- Report: what was attempted, what failed, what was discovered, what decision is needed
-
-**The Smith's Creed:**
-> "The most common failure mode is doing too much, not too little."
-> "Match the grain of the metal. A foreign alloy introduced carelessly will crack under load."
-> "Three failed strikes means something is wrong with the design. Escalate."
-
-**Failure Patterns Avoided:**
-
-- Over-engineering — adds nothing the plan did not ask for
-- Scope creep — surfaces adjacent problems, does not absorb them
-- Premature completion — always runs fresh verification before declaring done
-- Pattern blindness — new code matches the style of everything around it
-- Rewriting instead of editing — targeted edits over full-file rewrites
+**Key constraint:** Must escalate to Pathfinder after 3 failed attempts on any issue; does not redesign, only executes the plan.
 
 **Best Practice:** Invoke Bitsmith after Pathfinder has produced a plan and the Dungeon Master is ready to execute. Bitsmith is the executor of the party — she turns blueprints into shipped code with the smallest viable change and the highest craft standard.
 
@@ -894,44 +223,13 @@ She does not fight. She does not plan. She does not invent. She reads, she reaso
 
 > *"Every deed deserves its verse."*
 
-**Configuration:** `claude/agents/talekeeper.md`
+**Core Mission:** Talekeeper is a manually-triggered narrator. She reads enriched session chronicle files produced by the Stop hook pipeline, delivers a concise chat summary of all new sessions, and appends structured narrative sections with Mermaid diagrams to `logs/talekeeper-narrative.md`.
 
-**Invoke when:**
+**When to invoke:** Invoke when you want a human-readable summary of past sessions, Mermaid diagrams of agent interaction flows, or a digest after several sessions have accumulated enriched chronicles.
 
-- You want a human-readable summary of one or more past sessions
-- You want Mermaid diagrams of agent interaction flows appended to `logs/talekeeper-narrative.md`
-- After several sessions have accumulated enriched chronicles and you want a digest
+**Key constraint:** Never invoked automatically; only reads already-enriched chronicles produced by shell scripts.
 
-**Core Mission:** Talekeeper is a manually-triggered narrator. She reads enriched session chronicle files produced by the Stop hook pipeline (`talekeeper-enrich.sh`), identifies sessions that have not yet been narrated, and does two things: delivers a concise chat summary of all new sessions directly to the user, and appends structured narrative sections with Mermaid diagrams to `logs/talekeeper-narrative.md`. She tracks processed sessions in `logs/talekeeper-narrated-sessions.json` so she does not repeat herself.
-
-**Important: Talekeeper is never invoked automatically.** She is not wired into any hook. The raw-to-enriched pipeline is handled entirely by shell scripts (`talekeeper-capture.sh` and `talekeeper-enrich.sh`). Talekeeper only reads the already-enriched output and narrates it on demand.
-
-**Timing note:** Only invoke Talekeeper after a session has fully ended and a few seconds have passed for the async `talekeeper-enrich.sh` hook to complete. Invoking too early may result in narrating partial data.
-
-**Key Capabilities:**
-
-- Discovers unnarrated enriched chronicles via `logs/talekeeper-*.jsonl` glob
-- Delivers a one-sentence-per-session chat digest in chronological order
-- Appends structured narrative sections (table + Mermaid graph) to `logs/talekeeper-narrative.md`
-- Applies a 15-node cap with ellipsis for large sessions in Mermaid diagrams
-- Treats all chronicle content as untrusted; derives output from structural metadata only
-- Skips its own invocations (recursion guard via `agent_type: "talekeeper"`)
-
-**Available Tools:** `Glob`, `Read`, `Write` — no Bash, no sub-agents.
-
-**Output Location:**
-
-- Chat: concise multi-session digest
-- `logs/talekeeper-narrative.md`: appended narrative sections (never overwritten)
-- `logs/talekeeper-narrated-sessions.json`: tracking file (append-only, `.json` extension is deliberate)
-
-**What Talekeeper Does NOT Do:**
-
-- Does not run automatically via hooks
-- Does not enrich raw logs (that is `talekeeper-enrich.sh`'s job)
-- Does not capture events during a session (that is `talekeeper-capture.sh`'s job)
-- Does not modify enriched chronicle files
-- Does not mark empty files as narrated (enrichment may still be running)
+**Configuration File:** `/claude/agents/talekeeper.md`
 
 ---
 
@@ -951,70 +249,11 @@ When the data is insufficient, she says so plainly and records a candidate for f
 
 > *"Patterns require patience. Patience is the only virtue I have in abundance."*
 
-**Core Mission:** Study Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems across the agent team. Translate raw observations into structured, minimal, testable configuration recommendations. She does not perform tasks, does not rewrite production configs, and does not produce vague advice. Every recommendation is grounded in observed evidence and paired with a concrete evaluation plan.
+**Core Mission:** Study Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems across the agent team, translating raw observations into structured, minimal, testable configuration recommendations.
 
-**Invoke when:**
+**When to invoke:** Invoke periodically after 5–10 sessions to surface slow-burning patterns, when repeated reviewer rejections or escalations are suspected, or when preparing to tune agent configs based on empirical evidence.
 
-- Wanting to understand why the agent team has been underperforming
-- A pattern of repeated reviewer rejections or escalations is suspected
-- After several sessions of notable failures or inefficiencies
-- Preparing to tune agent configs based on empirical evidence
-- Checking whether a previously applied config change had the expected effect
-
-**Key Capabilities:**
-
-- Chronicle ingestion and timeline reconstruction from `logs/talekeeper-*.jsonl`
-- Problem classification across seven dimensions: persona, skill allocation, routing, handoff contracts, escalation rules, team topology, memory policy
-- Root-cause inference with strict evidence/inference separation
-- Minimal-diff config recommendations (wording before tools, tools before routing, routing before topology)
-- Three-tier lesson lifecycle: candidate (one-run) → recurring (3+ sessions) → validated (confirmed improvement)
-- Confidence scoring (0.0 – 1.0) tied to observation frequency and validation status
-- Evaluation plan generation: what to change, what to observe, what constitutes success
-
-**Available Tools:**
-
-- Read: Session chronicles in `logs/`, agent configs in `claude/agents/`, existing lessons in `lessons/`
-- Grep: Pattern searching across chronicle entries
-- Glob: Chronicle file discovery
-- Write: Appending to `lessons/candidates.jsonl`, `lessons/recurring.jsonl`, `lessons/validated.jsonl` only
-
-**Lesson Lifecycle:**
-
-| Tier | Criteria | File |
-| ------ | -------- | ------ |
-| `candidate` | Single-session observation | `lessons/candidates.jsonl` |
-| `recurring` | Observed across 3+ separate sessions | `lessons/recurring.jsonl` |
-| `validated` | Applied and confirmed beneficial | `lessons/validated.jsonl` |
-
-**Lesson Schema (JSONL):**
-Each lesson record includes: `lesson_id`, `created_at`, `tier`, `problem_type`, `sessions_observed`, `evidence`, `inference`, `affected_agent`, `proposed_change` (with `target_file`, `change_description`, `change_type`), `expected_benefit`, `tradeoffs`, `confidence`, `evaluation_plan`, and `status`.
-
-**Recommendation Priority:**
-
-1. Wording change in agent operational rules
-2. Tool addition or removal
-3. Routing rule clarification
-4. New constraint or guard
-5. Handoff contract revision
-6. New escalation rule
-7. New agent or agent removal (last resort only)
-
-**What Everwise Does NOT Do:**
-
-- Implement changes herself
-- Invoke other agents
-- Produce narrative advice without structured JSON backing
-- Recommend changes based on a single observation
-- Recommend broad rewrites without identifying the exact behavioral failure
-- Modify any file outside `lessons/`
-
-**Invocation Examples:**
-
-- "Review recent session chronicles and identify any recurring coordination issues."
-- "Check whether Bitsmith's escalation rate has improved after last week's config change."
-- "Review candidates.jsonl and determine if any are ready to promote to recurring."
-
-**Output Location:** `lessons/candidates.jsonl`, `lessons/recurring.jsonl`, `lessons/validated.jsonl`
+**Key constraint:** Never invoked automatically by other agents; user-facing only. Does not modify any file outside `lessons/`.
 
 **Best Practice:** Invoke Everwise periodically — after 5–10 sessions — to surface slow-burning patterns that are invisible within a single session. She is the team's institutional memory about what goes wrong and why.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -66,7 +66,7 @@ These mandates are active for every project. Project-level `.claude/CLAUDE.md` f
 
 Agents are specialized AI assistants that help with specific tasks. They are automatically available in Claude Code.
 
-See [docs/AGENTS.md](/docs/AGENTS.md) for the full agent roster and descriptions.
+See [docs/AGENTS.md](/docs/AGENTS.md) for the agent roster and quick reference. For detailed operational specs, tool lists, and workflows, see each agent's config file in `claude/agents/{name}.md`.
 
 **Invoking an agent:**
 Simply @-mention the agent by name (e.g., `@quill` or `@riskmancer`) in your Claude conversation to activate it.

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -526,7 +526,8 @@ Potential improvements to the review workflow:
 
 ## References
 
-- [Agent Reference](/docs/AGENTS.md) - Full agent profiles and capabilities
+- [Agent Reference](/docs/AGENTS.md) - Agent catalog and quick reference
+- [Agent Operational Specs](/claude/agents/) - Detailed operational specs, tool lists, and workflows for each agent
 - [Configuration Guide](/docs/CONFIGURATION.md) - Setup and customization
 - [Dungeon Master Agent](/claude/agents/dungeonmaster.md) - Orchestration logic implementation
 - [Ruinor Agent](/claude/agents/ruinor.md) - Baseline reviewer implementation


### PR DESCRIPTION
\`docs/AGENTS.md\` had grown to 1,010 lines because each agent section was a verbatim copy of its \`claude/agents/{name}.md\` config file, creating a maintenance burden where changes had to be made in two places and the narrative doc provided no value over the source. This PR reduces AGENTS.md to ~260 lines by replacing those copies with compact 8-20 line summaries (Core Mission / When to invoke / Key constraint) plus a blockquote pointer to the authoritative config file. The quick reference table, routing guide, avatar images, fantasy lore paragraphs, Best Practice blurbs, and Configuration File pointers are all preserved. Detailed operational specs, tool lists, and full workflows now live exclusively in \`claude/agents/{name}.md\`. Cross-references in \`docs/CONFIGURATION.md\`, \`docs/adrs/REVIEW_WORKFLOW.md\`, and \`.claude/skills/agent-creator/SKILL.md\` have been updated to reflect this architecture.