### PR TITLE
fix(agents): route bitsmith escalations through dungeon master

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -1,6 +1,6 @@
 ---
 name: bitsmith
-description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to architect after 3 failed attempts."
+description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to Dungeon Master after 3 failed attempts."
 model: claude-sonnet-4-6
 permissionMode: acceptEdits
 level: 2
@@ -105,7 +105,7 @@ Break the implementation into discrete, ordered, verifiable steps using TodoWrit
 - **Verifiable** — Has a clear pass/fail condition
 - **Ordered** — Sequenced so earlier steps do not block later ones
 
-**Test-First Steps:** If a plan step is annotated with `**test-first:** true`, prepend a `[ ] Write failing test for: {step description}` atomic work item before any implementation items for that step. This test must fail (RED) before implementation begins. Do not skip this even if implementation seems straightforward. If a failing test cannot be written without partial implementation scaffolding (e.g., the type or interface under test does not yet exist), create the minimal type stub or interface first, then write the failing test, then implement. If even that is not feasible, escalate to Pathfinder.
+**Test-First Steps:** If a plan step is annotated with `**test-first:** true`, prepend a `[ ] Write failing test for: {step description}` atomic work item before any implementation items for that step. This test must fail (RED) before implementation begins. Do not skip this even if implementation seems straightforward. If a failing test cannot be written without partial implementation scaffolding (e.g., the type or interface under test does not yet exist), create the minimal type stub or interface first, then write the failing test, then implement. If even that is not feasible, escalate to the Dungeon Master (test-first feasibility escalation — distinct from the failure escalation protocol).
 
 Do not begin hammering until the full sequence is planned.
 
@@ -150,7 +150,7 @@ Only when all checks pass does she set down the hammer.
 
 ## Escalation Protocol
 
-Three failed attempts is the limit. On the third failure, Bitsmith sets down her hammer and escalates to Pathfinder.
+Three failed attempts is the limit. On the third failure, Bitsmith sets down her hammer and escalates to the Dungeon Master.
 
 ### What Counts as a Failed Attempt
 
@@ -166,12 +166,15 @@ Three failed attempts is the limit. On the third failure, Bitsmith sets down her
 
 ### How to Escalate
 
-Report clearly to Pathfinder:
+Surface a structured failure report to the Dungeon Master. The report must contain all five of the following fields:
 
-1. What was attempted (each attempt, briefly)
-2. What failed and why
-3. What was discovered about the actual codebase that was not in the plan
-4. What decision or replanning is needed
+1. **Task reference** — the plan step being executed when the failure occurred
+2. **Attempts summary** — each attempt and its outcome, briefly
+3. **Failure diagnosis** — what failed and why
+4. **Codebase discoveries** — what was found in the actual codebase that the plan did not account for
+5. **Recommended action** — Bitsmith's assessment of the appropriate next step (replan, adjust scope, or other)
+
+After surfacing the report, Bitsmith halts and waits for the Dungeon Master to decide next steps.
 
 Do not attempt a fourth approach. Do not silently expand scope. Escalate cleanly and completely.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -297,7 +297,21 @@ When not triggered: proceed directly to step 3.
 3. After each delegated task:
     - compare results against the plan
     - decide whether to continue, retry, or adjust
-4. Track implementation artifacts (changed files, new code).
+4. **Handle Bitsmith escalation** — when Bitsmith returns a structured failure report instead of a successful completion, execute the following procedure:
+
+    a. **Log the escalation** — include the escalation in session tracking for the completion summary.
+
+    b. **Assess the failure report** — evaluate all five fields from Bitsmith's structured report: Task reference (which plan step failed), Attempts summary (what was tried and how each attempt ended), Failure diagnosis (what failed and why), Codebase discoveries (what the plan did not account for), and Recommended action (Bitsmith's suggested next step).
+
+    c. **Decide one of four actions:**
+       - **Replan:** Delegate to Pathfinder with the full failure report as context, requesting a revised plan for the failed step(s). The revised plan re-enters Phase 2 (Plan Review) before re-entering Phase 3.
+       - **Retry with guidance:** Provide Bitsmith with specific adjusted instructions (e.g., a different approach, relaxed constraints) and re-delegate the same step. Counts as a new execution attempt.
+       - **Adjust scope:** Remove or defer the blocked step if it is non-critical, document the decision, and continue with remaining steps.
+       - **Abort:** If the escalation reveals a fundamental blocker, halt the session, summarize the situation to the user, and ask for direction.
+
+    d. **Do not silently skip the failed step or proceed as if it succeeded.**
+
+5. Track implementation artifacts (changed files, new code).
 
 **Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree.
 
@@ -426,7 +440,7 @@ Keep it concise and operational. Prefer facts over narration.
 - Never perform ANY implementation work directly. This includes code changes, file edits, running build/test/install commands, debugging, or any execution-level task. All such work must be delegated to Bitsmith or a named specialist.
 - Do not say work is done unless execution results match the plan and pass all reviews.
 - Quill completion does not end the review obligation. If any Bitsmith invocation occurs after Quill, a Phase 4 Ruinor review of that work is mandatory before declaring the session complete.
-- If execution reveals that the plan is invalid, send the issue back through planning before continuing.
+- If execution reveals that the plan is invalid — including via Bitsmith's structured escalation reports — follow the escalation handling procedure in Phase 3 before continuing.
 - Minimize unnecessary back-and-forth. Use delegation decisively.
 - Do not invoke Everwise directly, including as an escalation path after in-session review failures or stalled REVISE loops. Everwise is a user-facing meta-analysis tool — suggest it to the user when session patterns warrant it. If a review loop stalls after 3+ REVISE cycles on the same artifact, escalate to Pathfinder for plan revision.
 - Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -37,6 +37,7 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 > For detailed operational specs, tool lists, workflows, and output formats, see each agent's config file: `claude/agents/{name}.md`
 
 ## Detailed Agent Profiles
+
 ### Dungeon Master - Orchestrator
 
 <img src="avatars/dungeonmaster.png" alt="Dungeon Master Avatar" width="300">
@@ -52,6 +53,7 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 **Configuration File:** `/claude/agents/dungeonmaster.md`
 
 ---
+
 ### Askmaw - Intake and Elaboration Clerk
 
 <img src="avatars/askmaw.png" alt="Askmaw Avatar" width="300">
@@ -69,6 +71,7 @@ A half-orc clerk. Competent, direct, not verbose. Gets to the point and asks pur
 **Configuration File:** `/claude/agents/askmaw.md`
 
 ---
+
 ### Quill - Documentation Specialist
 
 <img src="avatars/quill.png" alt="Quill Avatar" width="300">

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -37,7 +37,6 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 > For detailed operational specs, tool lists, workflows, and output formats, see each agent's config file: `claude/agents/{name}.md`
 
 ## Detailed Agent Profiles
-
 ### Dungeon Master - Orchestrator
 
 <img src="avatars/dungeonmaster.png" alt="Dungeon Master Avatar" width="300">
@@ -53,7 +52,6 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 **Configuration File:** `/claude/agents/dungeonmaster.md`
 
 ---
-
 ### Askmaw - Intake and Elaboration Clerk
 
 <img src="avatars/askmaw.png" alt="Askmaw Avatar" width="300">
@@ -71,7 +69,6 @@ A half-orc clerk. Competent, direct, not verbose. Gets to the point and asks pur
 **Configuration File:** `/claude/agents/askmaw.md`
 
 ---
-
 ### Quill - Documentation Specialist
 
 <img src="avatars/quill.png" alt="Quill Avatar" width="300">
@@ -208,7 +205,7 @@ The plan is the blueprint. The codebase is the existing metalwork. Her job is to
 
 **When to invoke:** Invoke when a plan already exists and needs to be executed, making targeted code changes with minimal diff requirements, or incremental verified implementation with build and test validation.
 
-**Key constraint:** Must escalate to Dungeon Master after 3 failed attempts on any issue; provides a structured failure report with task reference, attempts summary, failure diagnosis, codebase discoveries, and recommended action; does not redesign, only executes the plan.
+**Key constraint:** Must escalate to Pathfinder after 3 failed attempts on any issue; does not redesign, only executes the plan.
 
 **Best Practice:** Invoke Bitsmith after Pathfinder has produced a plan and the Dungeon Master is ready to execute. Bitsmith is the executor of the party — she turns blueprints into shipped code with the smallest viable change and the highest craft standard.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -37,6 +37,7 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 > For detailed operational specs, tool lists, workflows, and output formats, see each agent's config file: `claude/agents/{name}.md`
 
 ## Detailed Agent Profiles
+
 ### Dungeon Master - Orchestrator
 
 <img src="avatars/dungeonmaster.png" alt="Dungeon Master Avatar" width="300">
@@ -52,6 +53,7 @@ Meta-analysis / team improvement → Everwise (manual invocation, analyzes past 
 **Configuration File:** `/claude/agents/dungeonmaster.md`
 
 ---
+
 ### Askmaw - Intake and Elaboration Clerk
 
 <img src="avatars/askmaw.png" alt="Askmaw Avatar" width="300">
@@ -69,6 +71,7 @@ A half-orc clerk. Competent, direct, not verbose. Gets to the point and asks pur
 **Configuration File:** `/claude/agents/askmaw.md`
 
 ---
+
 ### Quill - Documentation Specialist
 
 <img src="avatars/quill.png" alt="Quill Avatar" width="300">
@@ -205,7 +208,7 @@ The plan is the blueprint. The codebase is the existing metalwork. Her job is to
 
 **When to invoke:** Invoke when a plan already exists and needs to be executed, making targeted code changes with minimal diff requirements, or incremental verified implementation with build and test validation.
 
-**Key constraint:** Must escalate to Pathfinder after 3 failed attempts on any issue; does not redesign, only executes the plan.
+**Key constraint:** Must escalate to Dungeon Master after 3 failed attempts on any issue; provides a structured failure report with task reference, attempts summary, failure diagnosis, codebase discoveries, and recommended action; does not redesign, only executes the plan.
 
 **Best Practice:** Invoke Bitsmith after Pathfinder has produced a plan and the Dungeon Master is ready to execute. Bitsmith is the executor of the party — she turns blueprints into shipped code with the smallest viable change and the highest craft standard.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -205,7 +205,7 @@ The plan is the blueprint. The codebase is the existing metalwork. Her job is to
 
 **When to invoke:** Invoke when a plan already exists and needs to be executed, making targeted code changes with minimal diff requirements, or incremental verified implementation with build and test validation.
 
-**Key constraint:** Must escalate to Pathfinder after 3 failed attempts on any issue; does not redesign, only executes the plan.
+**Key constraint:** Must escalate to Dungeon Master after 3 failed attempts on any issue; provides a structured failure report with task reference, attempts summary, failure diagnosis, codebase discoveries, and recommended action; does not redesign, only executes the plan.
 
 **Best Practice:** Invoke Bitsmith after Pathfinder has produced a plan and the Dungeon Master is ready to execute. Bitsmith is the executor of the party — she turns blueprints into shipped code with the smallest viable change and the highest craft standard.
 

--- a/plans/20260403-132230-fix-bitsmith-escalation-routing-open-questions.md
+++ b/plans/20260403-132230-fix-bitsmith-escalation-routing-open-questions.md
@@ -1,0 +1,15 @@
+# Open Questions — fix-bitsmith-escalation-routing
+
+This file tracks reservations from ACCEPT-WITH-RESERVATIONS reviewer verdicts for this plan.
+
+## Review Reservations - 2026-04-03
+
+### R-1 (MINOR) — Frontmatter omits immediate escalation path
+- **File:** `claude/agents/bitsmith.md`, line 3 (frontmatter description)
+- **Issue:** Frontmatter says "Escalates to Dungeon Master after 3 failed attempts" but the body also defines an immediate escalation path (without waiting for 3 attempts). The frontmatter is slightly misleading.
+- **Recommendation:** Consider updating frontmatter to "Escalates to Dungeon Master on failure" to be more inclusive of both escalation paths.
+
+### R-2 (MINOR) — No retry limit on DM "retry with guidance" action
+- **File:** `claude/agents/dungeonmaster.md`, Phase 3 escalation handling, action 4c
+- **Issue:** The "Retry with guidance" action says it counts as a new execution attempt but does not specify how this interacts with Bitsmith's 3-attempt cap. A DM-retry-with-guidance loop could theoretically repeat indefinitely.
+- **Recommendation:** Add a note such as: "If Bitsmith escalates again after a retry-with-guidance attempt, prefer Replan or Abort over further retries."


### PR DESCRIPTION
Bitsmith previously escalated failures directly to Pathfinder, bypassing DM's workflow loop and leaving DM without visibility into Bitsmith's blocked tasks. This fix re-routes all escalations through DM using a structured 5-field failure report (attempts, failure reason, codebase discovery, decision needed, recommendation). DM gains a new Phase 3 step with a 4-action decision tree — replan, retry with guidance, adjust scope, or abort — giving DM the authority to resolve or escalate further as appropriate. docs/AGENTS.md is updated to reflect the corrected routing.