### PR TITLE
fix(agents): remove cd && fallback from bitsmith worktree bash guidance

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -19,7 +19,7 @@ Bitsmith is the implementor. She takes the plan laid out by the architect and tu
 
 When a delegation prompt contains a `WORKING_DIRECTORY:` context line, Bitsmith scopes ALL operations to that directory:
 
-- **Bash commands:** Use absolute paths rooted in `{WORKING_DIRECTORY}` as the primary approach. Use `cd {WORKING_DIRECTORY} &&` as a fallback only for commands that require a specific CWD (e.g., `npm install`, `make`, or tools that resolve config relative to CWD).
+- **Bash commands:** Always use absolute paths rooted in `{WORKING_DIRECTORY}`. Never use `cd ... &&` or any compound shell command — this violates the global bash style rule and does not persist CWD across separate Bash calls. For tools that resolve config relative to CWD (e.g., `npm install`, `make`), use the tool's own directory flag where available (e.g., `npm --prefix {WORKING_DIRECTORY} install`, `make -C {WORKING_DIRECTORY}`). If a tool has no CWD flag, note the limitation and surface it rather than resorting to `&&` chaining.
 - **File operations (Read/Write/Edit/Grep/Glob):** Use absolute paths under `{WORKING_DIRECTORY}`. Never use relative paths.
 - **Git commands** (commit, branch, status, diff): Automatically operate on the worktree's branch when Bash runs within `{WORKING_DIRECTORY}`. No special handling needed.
 - **Session worktree setup:** When DM delegates worktree creation, run the exact commands from the DM's prompt (e.g., `git worktree add`, `mkdir -p`) and report `WORKTREE_PATH` and `WORKTREE_BRANCH` back to DM.


### PR DESCRIPTION
Removes the \`cd {WORKING_DIRECTORY} &&\` fallback from Bitsmith's Worktree Awareness section, which directly violated the global bash style rule (no \`&&\` chaining) and was ineffective anyway since \`cd\` does not persist across separate Bash tool calls.

Replaces it with an unconditional absolute-path requirement for all Bash commands, plus guidance to use tool-native CWD flags (\`npm --prefix\`, \`make -C\`) for tools that resolve config relative to CWD. When no CWD flag exists, Bitsmith is instructed to surface the limitation rather than reach for chaining.