### PR TITLE
fix(agents): skip user confirmation in Pathfinder during revision rounds

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -285,10 +285,41 @@ When not triggered: proceed directly to step 3.
    - If Ruinor and all invoked specialists issue ACCEPT or ACCEPT-WITH-RESERVATIONS: Proceed to execution
 
 4. If revision needed:
-   - Provide Pathfinder with **consolidated feedback from Ruinor and all invoked specialists**
+   - Provide Pathfinder with **consolidated feedback from Ruinor and all invoked specialists** using the delegation template below
    - Wait for Pathfinder to revise the plan file
    - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations)
    - Continue this review-revise loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS
+
+   **Revision delegation template** (use this every time DM re-delegates to Pathfinder from Phase 2 step 4, including subsequent revision rounds after repeated REVISE/REJECT verdicts — every iteration of the review-revise loop uses this same template with updated feedback):
+   ```
+   REVISION_MODE: true
+   WORKING_DIRECTORY: {WORKTREE_PATH}
+   WORKTREE_BRANCH: {WORKTREE_BRANCH}
+   All file operations and Bash commands must use this directory as the working root.
+
+   ## Plan to Revise
+   {WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}.md
+
+   ## Reviewer Feedback
+
+   **Reviewer:** {reviewer name}
+   **Verdict:** {REVISE | REJECT}
+
+   ### F-1 ({severity}) -- {finding summary}
+   {finding body}
+
+   ### F-2 ({severity}) -- {finding summary}
+   {finding body}
+
+   **Reviewer:** {reviewer name}
+   **Verdict:** {REVISE | REJECT}
+
+   ### F-1 ({severity}) -- {finding summary}
+   {finding body}
+
+   ## Instructions
+   Revise the plan at the path listed above to address all reviewer findings. Overwrite the existing file when done. Do not re-interview the user — the reviewer feedback above is your requirements input for this revision.
+   ```
 
 ### Phase 3: Execution
 
@@ -459,8 +490,8 @@ Action:
   - Plan contains "OAuth" keyword → confirms security-sensitive
   - Invoke Riskmancer for deep security review
   - Ruinor: ACCEPT-WITH-RESERVATIONS, Riskmancer: REVISE (missing CSRF, token expiry too long)
-  - Send consolidated feedback to Pathfinder
-  - Pathfinder revises plan
+  - Delegate to Pathfinder with `REVISION_MODE: true` and consolidated feedback
+  - Pathfinder revises plan (skips user confirmation, overwrites plan file directly)
   - Re-run Ruinor + Riskmancer → both ACCEPT
 - Once plan approved, delegate implementation steps to Bitsmith
 - **Implementation Review Gate:**

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -51,7 +51,13 @@ Agent(subagent_type="Explore", prompt="Find all authentication-related files")
 
 ### 3. Interview User
 
-**First: check for an Askmaw intake brief in the delegation prompt.**
+**First: check for `REVISION_MODE: true` in the delegation prompt.**
+
+If `REVISION_MODE: true` is present:
+- Skip this section (section 3) entirely — the revision context and reviewer feedback supplied in DM's delegation prompt serve as the requirements input
+- Proceed directly to section 4 (Generate Plan)
+
+**Otherwise: check for an Askmaw intake brief in the delegation prompt.**
 
 If the delegation prompt contains an `## Intake Brief` section:
 - Treat its fields (Objective, Scope, Constraints, Preferences, Success Criteria) as pre-answered interview responses
@@ -84,7 +90,7 @@ Once requirements are clear and research is complete:
 2. Create 3-6 actionable steps with verifiable acceptance criteria
 3. Avoid over-specification (not 30 micro-steps)
 4. Avoid vagueness (not "step 1: implement")
-5. Get explicit user confirmation before finalizing
+5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly)
 6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created").
 
 ### 5. Save Plan
@@ -274,7 +280,7 @@ Before considering a plan complete, verify:
 1. ✅ **One question at a time** - Never overwhelmed user with multiple questions
 2. ✅ **Codebase research delegated** - All factual investigation via explore agents
 3. ✅ **3-6 actionable steps** - Not too granular, not too vague
-4. ✅ **Explicit user confirmation** - User approved plan before finalizing
+4. ✅ **Explicit user confirmation** - User approved plan before finalizing (skipped in revision mode)
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
 


### PR DESCRIPTION
During review-driven replanning, Pathfinder was prompting the user for confirmation before proceeding, breaking the automated revision flow. This fix introduces a REVISION_MODE flag that Pathfinder checks to bypass the confirmation step when it has been re-invoked by the Dungeon Master after a review cycle. The benefit is that automated revision rounds now complete without stalling for human input that is not meaningful in that context. No behavioral change occurs during initial planning runs where confirmation remains in place.