### PR TITLE
fix(hooks): use ~/.claude/hooks path instead of relative path

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash claude/hooks/talekeeper-capture.sh",
+            "command": "bash ~/.claude/hooks/talekeeper-capture.sh",
             "timeout": 5
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash claude/hooks/talekeeper-enrich.sh",
+            "command": "bash ~/.claude/hooks/talekeeper-enrich.sh",
             "timeout": 60
           }
         ]


### PR DESCRIPTION
## Summary
- Hook commands in `claude/settings.json` used relative paths (`bash claude/hooks/...`) that only resolved when Claude Code ran from the `ai-tpk` repo root
- Running Claude Code from any other repository produced: `Stop hook error: Failed with non-blocking status code: bash: claude/hooks/talekeeper-enrich.sh: No such file or directory`
- Fixed by using `~/.claude/hooks/` which is already symlinked to this repo's `claude/hooks/` directory

## Test plan
- [ ] Start Claude Code from a repo other than `ai-tpk` and confirm no Stop hook errors
- [ ] Verify Talekeeper capture and enrichment still fire correctly from within `ai-tpk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)