### PR TITLE
feat(commands): add sync-pr slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 |---------|---------|
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
+| `/sync-pr` | Rebases the current PR branch onto `origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 
 ## Agent Orchestration Workflow
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | Command | Purpose |
 |---------|---------|
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
-| `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
 | `/sync-pr` | Rebases the current PR branch onto `origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
+| `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
 
 ## Agent Orchestration Workflow
 

--- a/claude/commands/sync-pr.md
+++ b/claude/commands/sync-pr.md
@@ -1,0 +1,70 @@
+---
+description: Rebase the current PR branch onto main and force-push to keep the PR up to date
+---
+
+You are rebasing the current PR branch onto the latest `main` and force-pushing to keep the PR
+in sync. Follow every step below in order. Run each command as a standalone call — do not chain
+commands with `&&`, `;`, or `|`.
+
+## Step 1 — Verify GitHub authentication
+
+Run: `gh auth status`
+
+If the command exits with a non-zero status or prints an error, abort immediately and tell the
+user: "GitHub authentication is required. Run `gh auth login` and try again."
+
+## Step 2 — Detect current branch
+
+Run: `git branch --show-current`
+
+Store the result as `<branch>`. You will use it in later steps.
+
+## Step 3 — Guard against protected branches
+
+If `<branch>` is `main`, `master`, or `develop`, abort immediately and tell the user:
+"Cannot sync a protected branch. Check out your PR branch and run `/sync-pr` again."
+
+## Step 4 — Check for an open PR
+
+Run: `gh pr list --head <branch> --state open --json number,title --limit 1`
+
+If the JSON array is empty, warn the user: "No open PR found for branch `<branch>`." Then ask:
+"Do you want to continue anyway? (yes/no)"
+
+If the user answers anything other than `yes`, abort without making any changes.
+
+If a PR is found, print its number and title as confirmation before continuing.
+
+## Step 5 — Fetch remote refs
+
+Run: `git fetch origin`
+
+This updates remote-tracking refs without modifying the working tree.
+
+## Step 6 — Guard against a dirty working tree
+
+Run: `git status --porcelain`
+
+If the output is non-empty, abort immediately and tell the user: "Working tree is dirty. Commit
+or stash your changes before syncing."
+
+## Step 7 — Rebase onto origin/main
+
+Run: `git rebase origin/main`
+
+If the command exits with a non-zero status (indicating conflicts or another failure), immediately
+run the following as a separate standalone call: `git rebase --abort`
+
+Then abort the entire command and tell the user: "Rebase conflicts detected. The rebase has been
+aborted. Resolve conflicts manually by running `git rebase origin/main`, fixing each conflict, and
+running `git rebase --continue`."
+
+## Step 8 — Force-push and report success
+
+Run: `git push --force-with-lease origin <branch>`
+
+If the push fails (e.g., lease rejected because the remote has new commits), report the error and
+abort: "Force-push failed. The remote has changes not present locally. Run `git fetch origin` and
+retry `/sync-pr`."
+
+If the push succeeds, print: "Branch `<branch>` rebased on `main` and force-pushed. PR is up to date."


### PR DESCRIPTION
## Summary

- Adds a `/sync-pr` slash command that rebases the current PR branch onto `origin/main` and force-pushes with `--force-with-lease`
- Eliminates the need for manual fetch/rebase/push sequences when keeping a PR in sync with main
- Includes guards for dirty working tree, protected branches, missing GitHub auth, and rebase conflicts

## Test plan

- [ ] Run `/sync-pr` on a branch that is behind `main` — verify it rebases and force-pushes cleanly
- [ ] Run `/sync-pr` on a branch with a dirty working tree — verify it aborts with a clear error
- [ ] Run `/sync-pr` on a protected branch (e.g. `main`) — verify it refuses to proceed
- [ ] Simulate a rebase conflict — verify the command surfaces the conflict and aborts cleanly
- [ ] Run `/sync-pr` without GitHub auth — verify the auth guard triggers the appropriate error

Generated with [Claude Code](https://claude.com/claude-code)