### PR TITLE
chore(agents): add color to agent frontmatter

### DIFF
--- a/claude/agents/askmaw.md
+++ b/claude/agents/askmaw.md
@@ -1,5 +1,6 @@
 ---
 name: askmaw
+color: cyan
 description: "Stateless intake and elaboration clerk. Receives an ambiguous user request plus accumulated Q&A history from DM. Returns exactly one output per invocation: either a single clarifying question (Mode A) or a completed structured brief (Mode B). Invoked by DM in a loop before Pathfinder for ambiguous requests."
 model: claude-sonnet-4-6
 permissionMode: acceptEdits

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -1,5 +1,6 @@
 ---
 name: bitsmith
+color: green
 description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to Dungeon Master after 3 failed attempts."
 model: claude-sonnet-4-6
 permissionMode: acceptEdits

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -1,5 +1,6 @@
 ---
 name: dungeonmaster
+color: purple
 description: "Use this agent to coordinate multi-step software development work. It delegates planning to Pathfinder, runs mandatory Ruinor baseline reviews, conditionally invokes specialist reviewers (Riskmancer/Windwarden/Knotcutter/Truthhammer) based on findings or user flags, delegates implementation to Bitsmith, and validates completion against the plan."
 tools: "Task, Read, Grep, Glob, Bash"
 model: claude-sonnet-4-6

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -1,5 +1,6 @@
 ---
 name: everwise
+color: pink
 description: "Use this agent when the user asks for meta-analysis of agent team performance, session chronicle review, or continuous improvement analysis. Learner agent. Analyzes Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems in the agent team. Proposes structured, evidence-based configuration improvements. Never modifies production configs directly — only writes to lessons/ directory."
 model: claude-sonnet-4-6
 permissionMode: acceptEdits

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -1,5 +1,6 @@
 ---
 name: knotcutter
+color: yellow
 description: "Radical simplification specialist. Cuts through complexity by questioning necessity, eliminating over-engineering, and reducing systems to their essential core. Use when codebases are bloated, abstractions proliferate, or solutions feel needlessly complex."
 tools: "Read, Grep, Glob, Bash"
 model: claude-opus-4-6

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -1,5 +1,6 @@
 ---
 name: pathfinder
+color: blue
 description: "Strategic planning consultant with interview workflow"
 model: claude-opus-4-6
 permissionMode: acceptEdits

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -1,5 +1,6 @@
 ---
 name: quill
+color: pink
 description: "MUST BE USED to craft or update project documentation. Use PROACTIVELY after major features, API changes, or when onboarding developers. Produces READMEs, API specs, architecture guides, and user manuals."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
 model: claude-haiku-4-5

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -1,5 +1,6 @@
 ---
 name: riskmancer
+color: orange
 description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
 model: claude-opus-4-6
 permissionMode: auto

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -1,5 +1,6 @@
 ---
 name: ruinor
+color: red
 description: "Final quality gate reviewer. Conducts structured multi-perspective analysis of plans and code, issuing REJECT/REVISE/ACCEPT verdicts. Operates read-only -- never modifies code or plans."
 model: claude-opus-4-6
 permissionMode: auto

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -1,5 +1,6 @@
 ---
 name: talekeeper
+color: cyan
 description: "Manual narrator agent. Reads enriched session chronicle files and produces human-readable narrative summaries. Must ONLY be invoked by the user directly — never by hooks, the Dungeon Master, or any automated system."
 tools: "Read, Write, Glob"
 model: claude-haiku-4-5

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -1,5 +1,6 @@
 ---
 name: truthhammer
+color: orange
 description: "Factual validation specialist. Verifies claims about external systems -- config keys, API signatures, version compatibility, CLI flags, library behavior -- against authoritative sources. Operates read-only."
 model: claude-haiku-4-5
 permissionMode: auto

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -1,5 +1,6 @@
 ---
 name: windwarden
+color: yellow
 description: "Performance and scalability reviewer. Reviews plans and code for performance bottlenecks, inefficient algorithms, scalability issues, and resource optimization opportunities. Operates read-only with blocked write/edit capabilities."
 model: claude-sonnet-4-6
 permissionMode: auto


### PR DESCRIPTION
Agent definitions previously had no visual differentiation in the Claude UI. This adds a `color:` field to the YAML frontmatter of all 12 agent files, giving each agent a distinct color that reflects its role at a glance. Reviewing and gate-keeping agents (ruinor, riskmancer, windwarden, knotcutter, truthhammer) receive alert-like colors (red, orange, yellow) to signal their critical posture. Support and execution agents receive role-matched colors — purple for the orchestrating dungeonmaster, blue for the planning pathfinder, green for the implementing bitsmith, and cyan/pink for the remaining support roles.