### PR TITLE
feat(agents): add memory: project to Everwise frontmatter

### DIFF
--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -5,6 +5,7 @@ description: "Use this agent when the user asks for meta-analysis of agent team 
 model: claude-sonnet-4-6
 permissionMode: acceptEdits
 tools: "Read, Grep, Glob, Write"
+memory: user
 ---
 
 # Everwise — The Lorekeeper


### PR DESCRIPTION
Everwise is a cross-session learner agent whose value compounds over time — but only if she can retain what she observes. Adding project-scoped persistent memory means she can carry patterns, lessons, and context forward between invocations without re-reading all chronicles from scratch on every run. This makes her progressively more effective the more a project uses her, rather than starting cold each session.