### PR TITLE
refactor(agents): extract shared verdict taxonomy and worktree protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ claude/**
 !claude/hooks/**
 !claude/commands/
 !claude/commands/**
+!claude/references/
+!claude/references/**
 
 # Git worktrees
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Keep AI tool configurations version-controlled and portable across machines. The
 
 ```
 .
-├── claude/          # Claude Code configs (whitelist: settings.json, CLAUDE.md, skills/, agents/, commands/)
+├── claude/          # Claude Code configs (whitelist: settings.json, CLAUDE.md, skills/, agents/, commands/, references/)
 │   ├── CLAUDE.md         # User-global instructions (skill mandates)
 │   ├── settings.json     # Plugin config, hooks, marketplace settings
 │   ├── agents/          # Specialized AI assistants (e.g., Quill for docs)
+│   ├── references/       # Shared reference files loaded by agents at runtime
 │   ├── skills/          # Reusable capabilities
 │   └── commands/        # Slash commands for Claude Code
 ├── cursor/          # Cursor configurations (coming soon)
@@ -35,7 +36,7 @@ Keep AI tool configurations version-controlled and portable across machines. The
 └── install.sh       # Installation script
 ```
 
-The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, `agents/`, and `commands/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
+The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, and `references/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
 
 ## Installation
 
@@ -52,14 +53,14 @@ Run the installation script:
 ./install.sh
 ```
 
-Creates symbolic links for the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
+Creates symbolic links for the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
 
 ### Option 2: Copy Files
 ```bash
 ./install.sh --copy
 ```
 
-Copies the same whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`) into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
+Copies the same whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
 
 **Note:** The installer automatically backs up any existing configurations with a timestamp.
 
@@ -288,6 +289,15 @@ When updating configurations:
 4. Pull on other machines to sync
 
 When adding new hooks, agents, or skills, update the relevant documentation in `/docs/CONFIGURATION.md`.
+
+### Shared Agent References
+
+Agent definitions can reference shared behavioral vocabulary defined in `claude/references/`. This eliminates duplication across multiple agents:
+
+- **`claude/references/verdict-taxonomy.md`** — Shared verdict labels (REJECT, REVISE, ACCEPT-WITH-RESERVATIONS, ACCEPT) and severity scales. Agents load this reference when issuing verdicts to ensure consistent evaluation vocabulary.
+- **`claude/references/worktree-protocol.md`** — Shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. Agents load this reference when operating in isolated worktrees to ensure consistent path handling.
+
+When modifying the verdict taxonomy or worktree protocol, update the reference file — changes apply automatically to all agents that load it.
 
 ## License
 

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -18,14 +18,11 @@ Bitsmith is the implementor. She takes the plan laid out by the architect and tu
 
 ## Worktree Awareness
 
-When a delegation prompt contains a `WORKING_DIRECTORY:` context line, Bitsmith scopes ALL operations to that directory:
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line, read `claude/references/worktree-protocol.md` immediately and apply its rules for the remainder of this task.
 
-- **Bash commands:** Always use absolute paths rooted in `{WORKING_DIRECTORY}`. Never use `cd ... &&` or any compound shell command — this violates the global bash style rule and does not persist CWD across separate Bash calls. For tools that resolve config relative to CWD (e.g., `npm install`, `make`), use the tool's own directory flag where available (e.g., `npm --prefix {WORKING_DIRECTORY} install`, `make -C {WORKING_DIRECTORY}`). If a tool has no CWD flag, note the limitation and surface it rather than resorting to `&&` chaining.
-- **File operations (Read/Write/Edit/Grep/Glob):** Use absolute paths under `{WORKING_DIRECTORY}`. Never use relative paths.
-- **Git commands** (commit, branch, status, diff): Automatically operate on the worktree's branch when Bash runs within `{WORKING_DIRECTORY}`. No special handling needed.
+### Bitsmith-Specific Worktree Rules
+
 - **Session worktree setup:** When DM delegates worktree creation, run the exact commands from the DM's prompt (e.g., `git worktree add`, `mkdir -p`) and report `WORKTREE_PATH` and `WORKTREE_BRANCH` back to DM.
-
-When `WORKING_DIRECTORY` is absent from the delegation prompt, behavior is unchanged — operate in the main working tree as before.
 
 ## The Forge's Jurisdiction
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -108,6 +108,8 @@ Workflow flags control how the DM routes work through the pipeline. They are dis
 
 ### Worktree Context Block
 
+See `claude/references/worktree-protocol.md` for the shared protocol that sub-agents follow when this block is present.
+
 When a session worktree is active, prepend the following block to every Pathfinder, Bitsmith, and Quill delegation prompt:
 
 ```

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -222,6 +222,10 @@ When proposing simplifications, report before/after values for each applicable m
 
 Knotcutter operates read-only and returns all findings in-memory. Recommendations are surfaced as review output to Dungeon Master — implementation is delegated to Bitsmith.
 
+## Verdict and Severity Reference
+
+Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for the shared verdict labels (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) and severity scale definitions. Apply them through the lens of your complexity review.
+
 ## Output Standards
 
 **For plan reviews:**

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -16,12 +16,13 @@ Interview users to gather requirements, research codebases via agents, and produ
 
 ## Worktree Awareness
 
-When a delegation prompt contains a `WORKING_DIRECTORY:` context line:
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line, read `claude/references/worktree-protocol.md` immediately and apply its rules for the remainder of this task.
+
+### Pathfinder-Specific Worktree Rules
 
 - Write all plan files to `{WORKING_DIRECTORY}/plans/{name}.md` instead of `plans/{name}.md`
 - Write `open-questions.md` to `{WORKING_DIRECTORY}/plans/open-questions.md`
 - All codebase research (Grep, Glob, Read, Bash) should target `{WORKING_DIRECTORY}` as the search root
-- When `WORKING_DIRECTORY` is absent, behavior is unchanged — write to `plans/{name}.md` as before
 
 ## Key Responsibilities
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -14,13 +14,14 @@ Transform intricate codebases and system designs into accessible documentation t
 
 ## Worktree Awareness
 
-When a delegation prompt contains a `WORKING_DIRECTORY:` context line:
+When a delegation prompt contains a `WORKING_DIRECTORY:` context line, read `claude/references/worktree-protocol.md` immediately and apply its rules for the remainder of this task.
+
+### Quill-Specific Worktree Rules
 
 - All documentation reads and writes are relative to `{WORKING_DIRECTORY}`
 - File generation targets `{WORKING_DIRECTORY}/README.md`, `{WORKING_DIRECTORY}/docs/`, etc.
-- When `WORKING_DIRECTORY` is absent, behavior is unchanged — operate in the main working tree as before
 
-**Note:** Talekeeper is unaffected by worktree isolation. It writes to gitignored session logs (not to the working tree) and is user-invoked only.
+Talekeeper is unaffected by worktree isolation. It writes to gitignored session logs (not to the working tree) and is user-invoked only.
 
 ## Operational Workflow
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -254,12 +254,9 @@ For each vulnerability:
 ### Verdict Rationale
 Why this verdict was chosen based on security posture.
 
-## Verdict Definitions
+## Verdict and Severity Reference
 
-- **REJECT**: Critical security flaws that make this unsafe for production. Issued when CRITICAL vulnerabilities exist.
-- **REVISE**: Significant security issues that must be fixed before deployment. Issued when HIGH vulnerabilities exist.
-- **ACCEPT-WITH-RESERVATIONS**: Acceptable to proceed with noted security improvements. Issued when only MEDIUM/LOW findings exist.
-- **ACCEPT**: No material security issues found. Issued when security posture is sound.
+Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for the shared verdict labels (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) and severity scale definitions. Apply them through the lens of your security review.
 
 ## Success Criteria
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -172,32 +172,6 @@ After completing the multi-perspective review, assess whether specialist-level c
 - Determine overall verdict
 - Write clear, actionable feedback for each finding
 
-## Severity Levels
-
-**CRITICAL** -- Blocks execution. The artifact has a fundamental flaw that will cause failure, data loss, security breach, or renders the work unachievable. Examples:
-- Logic that produces incorrect results
-- Missing error handling that will crash in production
-- Plan steps that are impossible given the codebase
-- Circular dependencies or deadlocks
-
-All CRITICAL findings require concrete evidence: `file:line` citations for code, backtick-quoted excerpts for plans.
-
-**MAJOR** -- Requires significant rework. The artifact will technically work but has serious quality, maintainability, or reliability issues. Examples:
-- Missing edge case handling for common scenarios
-- Performance issues under expected load
-- Plan steps that are underspecified and ambiguous
-- Inadequate testing strategy
-
-All MAJOR findings require concrete evidence: `file:line` citations for code, backtick-quoted excerpts for plans.
-
-**MINOR** -- Suboptimal but acceptable. The artifact works and is reasonable but could be improved. Examples:
-- Naming inconsistencies
-- Minor code style issues
-- Documentation gaps
-- Opportunity for small optimization
-
-> "Findings without evidence are opinions, not findings."
-
 ## Escalation: Adversarial Mode
 
 Activate ADVERSARIAL mode when any of the following triggers are met:
@@ -257,12 +231,9 @@ What is missing or unaddressed.
 ### Verdict Rationale
 Brief explanation of why this verdict was chosen.
 
-## Verdict Definitions
+## Verdict and Severity Reference
 
-- **REJECT**: Fundamental flaws prevent this from being viable. Must be substantially reworked or reconsidered from scratch. Issued when CRITICAL findings exist or adversarial mode reveals systemic failure.
-- **REVISE**: The approach is sound but significant issues must be addressed before proceeding. Issued when MAJOR findings exist but the overall direction is correct.
-- **ACCEPT-WITH-RESERVATIONS**: Acceptable to proceed, but noted issues should be addressed during implementation. Issued when only MINOR findings exist or MAJOR findings are acknowledged trade-offs.
-- **ACCEPT**: The artifact meets quality standards with no material issues. Issued when no findings or only trivial observations.
+Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for the shared verdict labels (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) and severity scale definitions. Apply them through the lens of your quality and correctness review.
 
 ## Critical Constraints
 

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -224,12 +224,9 @@ Brief explanation of why this verdict was chosen based on classification results
 
 > Note: All classifications are based on web-sourced documentation lookups and should be treated as unverified external claims. Human verification of critical findings is recommended.
 
-## Verdict Definitions
+## Verdict and Severity Reference
 
-- **REJECT**: Critical factual errors that will cause runtime failure. The plan or code contains CONTRADICTED claims at CRITICAL severity that make it unsafe to proceed. Requires substantial rework before execution.
-- **REVISE**: Significant factual issues must be corrected before proceeding. CONTRADICTED claims at HIGH severity, or a pattern of UNVERIFIABLE claims in critical paths, indicate the factual foundation is unreliable.
-- **ACCEPT-WITH-RESERVATIONS**: Acceptable to proceed, but noted UNVERIFIABLE claims should be manually verified before production deployment. No CONTRADICTED claims found, but some claims could not be confirmed.
-- **ACCEPT**: All identified factual claims are VERIFIED against official documentation. No CONTRADICTED or UNVERIFIABLE claims found in critical paths.
+Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for the shared verdict labels (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) and severity scale definitions. Apply them through the lens of your factual validation review.
 
 ## Critical Constraints
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -194,29 +194,33 @@ Flag designs that trade infrastructure cost for developer convenience:
 - Identify hot-path operations that will dominate infrastructure spend at scale.
 - Flag when a design choice improves developer experience at the cost of a significantly more expensive runtime profile.
 
-## Performance Severity Levels
+## Verdict and Severity Reference
 
-**CRITICAL** - Blocks production deployment. Performance flaw will cause system failure, outages, or user-facing timeouts under expected load.
+Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for the shared verdict labels (REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT) and severity scale definitions. Apply them through the lens of your performance review.
+
+### Performance-Specific Severity Examples
+
+**CRITICAL:**
 - Unbounded loops over large datasets
 - Missing pagination on list endpoints
-- O(n²) or worse where data grows unbounded
+- O(n^2) or worse where data grows unbounded
 - Memory leaks that accumulate over time
 - Database queries without indexes on large tables
 
-**HIGH** - Requires immediate optimization. Significant performance degradation under normal load that impacts user experience.
+**HIGH:**
 - N+1 query patterns
 - Missing database indexes on frequently queried columns
 - Synchronous API calls in request path
-- Inefficient algorithms (O(n²) where O(n log n) possible)
+- Inefficient algorithms (O(n^2) where O(n log n) possible)
 - Large objects loaded when only subset needed
 
-**MEDIUM** - Optimization opportunity. Noticeable but not critical performance impact.
+**MEDIUM:**
 - Missing caching on expensive operations
 - Inefficient data structures
 - Redundant computations
 - Suboptimal serialization
 
-**LOW** - Minor inefficiency. Measurable but negligible impact on user experience.
+**LOW:**
 - Small allocations in loops
 - Minor query inefficiencies
 - Opportunity for micro-optimization
@@ -254,13 +258,6 @@ Suggested performance tests or metrics to validate the fix.
 
 ### Verdict Rationale
 Brief explanation of why this verdict was chosen based on performance impact.
-
-## Verdict Definitions
-
-- **REJECT**: Critical performance flaws that will cause system failure or unacceptable user experience under expected load. Requires fundamental redesign.
-- **REVISE**: Significant performance issues that must be optimized before deployment. Approach is viable but needs optimization work.
-- **ACCEPT-WITH-RESERVATIONS**: Acceptable to proceed with noted performance improvements recommended for future iterations.
-- **ACCEPT**: Performance characteristics are sound. No material performance issues identified.
 
 ## Critical Constraints
 
@@ -310,4 +307,3 @@ Brief explanation of why this verdict was chosen based on performance impact.
 - Performance gaps are identified with concrete remediation steps
 - Benchmark recommendations help validate improvements
 - False approval rate is minimized (don't let performance issues slip through)
-

--- a/claude/references/verdict-taxonomy.md
+++ b/claude/references/verdict-taxonomy.md
@@ -1,0 +1,63 @@
+# Verdict and Severity Taxonomy — Shared Reference
+
+This file defines the shared vocabulary for verdicts and severity levels used across all reviewer agents. It is the authoritative source for these labels. Each agent applies them through the lens of its own domain.
+
+## Verdict Definitions
+
+These four verdicts are used by all reviewer agents. The shared meaning is defined here; domain-specific application is defined per-agent.
+
+- **REJECT**: Fundamental flaws prevent this from being viable. Must be substantially reworked or reconsidered. Issued when critical, blocking problems exist that make the artifact unsafe or unexecutable to proceed with.
+- **REVISE**: The approach is sound but significant issues must be addressed before proceeding. Issued when serious problems exist but the overall direction is correct.
+- **ACCEPT-WITH-RESERVATIONS**: Acceptable to proceed, but noted issues should be addressed. Issued when only minor or acknowledged trade-off findings exist.
+- **ACCEPT**: The artifact meets the relevant standards with no material issues. Issued when no findings or only trivial observations exist.
+
+## Severity Scales
+
+Two severity scales are in use across the system. Which scale an agent uses is determined by that agent's role.
+
+### Scale A — Ruinor's Quality Review Scale (CRITICAL / MAJOR / MINOR)
+
+Used by Ruinor for baseline quality gate reviews of plans and code.
+
+**CRITICAL** — Blocks execution. The artifact has a fundamental flaw that will cause failure, data loss, security breach, or renders the work unachievable.
+
+All CRITICAL findings require concrete evidence: `file:line` citations for code, backtick-quoted excerpts for plans.
+
+**MAJOR** — Requires significant rework. The artifact will technically work but has serious quality, maintainability, or reliability issues.
+
+All MAJOR findings require concrete evidence: `file:line` citations for code, backtick-quoted excerpts for plans.
+
+**MINOR** — Suboptimal but acceptable. The artifact works and is reasonable but could be improved.
+
+### Scale B — Specialist Scale (CRITICAL / HIGH / MEDIUM / LOW)
+
+Used by specialist reviewers (Riskmancer, Windwarden, Knotcutter, Truthhammer) for domain-specific analysis.
+
+**CRITICAL** — Blocks production. A flaw that will cause system failure, security breach, runtime error, or complete unacceptability under expected conditions.
+
+**HIGH** — Requires immediate attention before deployment. Significant degradation or risk under normal conditions.
+
+**MEDIUM** — Optimization or risk opportunity. Noticeable but not immediately critical impact.
+
+**LOW** — Minor inefficiency or low-confidence concern. Measurable but negligible real-world impact.
+
+## Evidence Doctrine
+
+> "Findings without evidence are opinions, not findings."
+
+All CRITICAL and MAJOR/HIGH findings must include concrete citations. For code: `file:line` references. For plans: backtick-quoted excerpts from the relevant plan step. A finding without a citation is not a finding — it is speculation and must be removed or downgraded.
+
+## Domain-Specific Application
+
+This reference defines the shared vocabulary. It does not define what each severity level means in each domain — that is each agent's responsibility.
+
+For example:
+- Ruinor applies CRITICAL to logic errors and impossible plan steps.
+- Riskmancer applies CRITICAL to vulnerabilities that make a system unsafe for production.
+- Windwarden applies CRITICAL to performance flaws that will cause outages under expected load.
+- Knotcutter uses CRITICAL/HIGH/MEDIUM/LOW to classify complexity concerns proportional to their architectural impact.
+- Truthhammer applies CRITICAL to CONTRADICTED claims that will cause runtime failure.
+
+**Truthhammer's claim classification system** (VERIFIED / UNVERIFIABLE / CONTRADICTED) is a separate taxonomy entirely. It describes the epistemic status of factual claims about external systems. This classification system maps onto the shared CRITICAL/HIGH/MEDIUM/LOW severity scale — the severity label describes the consequence of the claim being wrong, while the classification describes whether the claim was confirmed. Both concepts coexist within Truthhammer's domain-specific output.
+
+Each agent defines what its severity levels mean in the context of its domain. This file defines the labels; the agents define the meaning.

--- a/claude/references/worktree-protocol.md
+++ b/claude/references/worktree-protocol.md
@@ -1,0 +1,38 @@
+# Worktree Protocol — Shared Reference
+
+This file defines the shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. All agents that receive this block must follow these rules. Role-specific additions are defined per-agent.
+
+## The WORKING_DIRECTORY Context Block
+
+When the Dungeon Master activates a session worktree, it prepends the following block to delegation prompts:
+
+```
+WORKING_DIRECTORY: /absolute/path/to/.worktrees/dm-slug
+WORKTREE_BRANCH: feat/feature-name
+All file operations and Bash commands must use this directory as the working root.
+```
+
+This block signals that all work for this task must be scoped to the specified directory. It is not a suggestion — it is a hard scope boundary.
+
+## File Operation Rules
+
+When `WORKING_DIRECTORY:` is present in the delegation prompt:
+
+- **Scope all file operations to absolute paths under `{WORKING_DIRECTORY}`.** This applies to Read, Write, Edit, Grep, and Glob tool calls.
+- **Never use relative paths.** Relative paths resolve against an unpredictable working directory and must not be used.
+- **When `WORKING_DIRECTORY` is absent, behavior is unchanged** — operate in the main working tree as before.
+
+## Bash Command Rules
+
+- Always use absolute paths rooted in `{WORKING_DIRECTORY}`. Do not construct paths relative to an assumed current directory.
+- Never use `cd ... &&` or any compound shell command to simulate a working directory change. This violates the global bash style rule and does not persist the CWD across separate Bash calls.
+- For tools that resolve configuration relative to CWD, use the tool's own directory flag where available (e.g., `npm --prefix {WORKING_DIRECTORY} install`, `make -C {WORKING_DIRECTORY}`).
+- If a tool has no CWD flag and cannot be invoked with an absolute path, surface the limitation rather than resorting to compound command chaining.
+
+## Git Command Behavior
+
+Git commands (commit, branch, status, diff, log) automatically operate on the worktree's branch when Bash is run within `{WORKING_DIRECTORY}`. No special handling is required — the worktree's branch is the active branch for the duration of the task.
+
+## Role-Specific Additions
+
+Each agent that receives the `WORKING_DIRECTORY:` block may define additional rules governing how the protocol applies to its specific responsibilities (e.g., where plan files are written, where documentation targets are set, how worktree creation is handled). Those additions are defined inline in each agent's definition and complement — but do not override — the shared rules above.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,6 +71,18 @@ See [docs/AGENTS.md](/docs/AGENTS.md) for the agent roster and quick reference. 
 **Invoking an agent:**
 Simply @-mention the agent by name (e.g., `@quill` or `@riskmancer`) in your Claude conversation to activate it.
 
+## References (`claude/references/`)
+
+Reference files contain shared behavioral vocabulary loaded by agents at runtime. These files eliminate duplication across multiple agent definitions and ensure consistency in how agents apply shared concepts.
+
+### Available References
+
+- **`verdict-taxonomy.md`** — Shared verdict labels (REJECT, REVISE, ACCEPT-WITH-RESERVATIONS, ACCEPT) and severity scales (Ruinor's CRITICAL/MAJOR/MINOR and Specialist CRITICAL/HIGH/MEDIUM/LOW). Reviewer agents load this reference when issuing verdicts. Defines shared vocabulary while noting that domain-specific application is defined per-agent.
+
+- **`worktree-protocol.md`** — Shared rules for interpreting the `WORKING_DIRECTORY:` context block. Agents that operate in isolated git worktrees load this reference to ensure consistent path handling across all file operations and bash commands.
+
+When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
+
 ## Skills (`claude/skills/`)
 
 Skills are reusable capabilities that enhance Claude's functionality.

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
       echo "Install AI TPK to your home directory."
       echo ""
       echo "Claude Code:"
-      echo "  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/"
+      echo "  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/"
       echo ""
       echo "Options:"
       echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
@@ -126,7 +126,7 @@ install_claude_whitelist() {
   fi
 
   local name
-  for name in skills agents hooks commands; do
+  for name in skills agents hooks commands references; do
     local sub_src="${claude_src}/${name}"
     if [[ -d "$sub_src" ]]; then
       install_path "$sub_src" "${HOME}/.claude/${name}"


### PR DESCRIPTION
Verdict definitions and worktree handling instructions were duplicated verbatim across 9 agent definitions — any change required editing up to 5 files simultaneously and risked drift. This PR introduces `claude/references/` with two shared files that agents load at runtime: `verdict-taxonomy.md` (shared REJECT/REVISE/ACCEPT vocabulary and severity scales) and `worktree-protocol.md` (shared WORKING_DIRECTORY handling rules). Agent-specific content stays inline; only the shared vocabulary moves. `install.sh` and `.gitignore` are updated to include the new directory.

## Test plan

- [ ] Verify `claude/references/verdict-taxonomy.md` and `claude/references/worktree-protocol.md` are present after `install.sh` runs
- [ ] Confirm `.gitignore` whitelist includes `claude/references/`
- [ ] Spot-check updated agents to confirm shared vocabulary sections are replaced with reference pointers and no agent-specific content was lost
- [ ] Confirm `docs/CONFIGURATION.md` reflects the new directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)