### PR TITLE
feat(pathfinder): add pre-submission self-screening checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ flowchart LR
 flowchart TD
     Start([DM: Need Planning?]) --> DelegateP[DM Delegates to<br/>Pathfinder]
     DelegateP --> PF[Pathfinder<br/>Creates Plan]
-    PF --> SavePlan[Save to<br/>plans/*.md]
+    PF --> Checklist[Pre-Submission<br/>Checklist ×8]
+    Checklist --> SavePlan[Save to<br/>plans/*.md]
     SavePlan --> MandatoryR[DM → Ruinor<br/>Mandatory Baseline Review]
 
     MandatoryR --> Decision{Ruinor Flags<br/>Specialists?}

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -95,7 +95,20 @@ Once requirements are clear and research is complete:
 5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly)
 6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created").
 
-### 5. Save Plan
+### 5. Pre-Submission Checklist
+
+Before saving the plan, run through all 8 questions below. If any question reveals a deficiency, correct the plan before proceeding to step 6.
+
+1. **Per-agent specificity:** Are instructions for each affected file/agent distinct where they differ meaningfully?
+2. **File reference accuracy:** Have you verified section names and line numbers by reading the actual files?
+3. **Distinct-case handling:** Where agents have different structures (one has a section, another doesn't), are they handled in separate sub-steps?
+4. **Rollback and recovery:** For steps modifying existing behaviour, is the prior state documented so it can be restored? For additive-only changes, confirm this question is not applicable.
+5. **Behavioural acceptance criteria:** Does the validation step verify that the change achieves its intent (not just that files exist or grep matches pass)?
+6. **Sequencing and dependencies:** Are steps ordered so each prerequisite is satisfied before it is needed?
+7. **Completeness:** Does the plan cover every part of the stated objective with no unexplained gaps?
+8. **Ambiguity test:** Could a careful executor reasonably make a wrong judgement call from any instruction? If yes, rewrite that instruction.
+
+### 6. Save Plan
 
 Write plan to `plans/{feature-name}.md` using Write tool.
 
@@ -285,6 +298,7 @@ Before considering a plan complete, verify:
 4. ✅ **Explicit user confirmation** - User approved plan before finalizing (skipped in revision mode)
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
+7. ✅ **Pre-submission checklist passed** - all 8 questions reviewed and any issues corrected before saving
 
 ## Tool Usage
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -120,7 +120,7 @@ Quill has a single professional rival: documentation written by someone who clea
 
 **When to invoke:** Invoke when starting a new feature or major change, breaking down complex work into actionable steps, or when structured requirements gathering and decision support are needed.
 
-**Key constraint:** Plans only, never implements; produces plans for others to execute.
+**Key constraint:** Plans only, never implements; produces plans for others to execute. Runs an 8-question pre-submission checklist before saving every plan to catch common review failure points (per-agent specificity, file reference accuracy, distinct-case handling, rollback documentation, behavioural acceptance criteria, sequencing, completeness, and ambiguity).
 
 **Best Practice:** Invoke Pathfinder before starting significant work to ensure clear requirements, structured approach, and stakeholder alignment. The agent explicitly does NOT implement code - it creates plans for others to execute.
 


### PR DESCRIPTION
Plans produced by Pathfinder have been failing Ruinor's first review at a recurring rate, causing unnecessary revision loops. This adds a lightweight 8-question self-screening gate between plan generation and saving — covering per-agent specificity, file reference accuracy, distinct-case handling, rollback documentation, behavioural acceptance criteria, sequencing, completeness, and ambiguity. No existing workflow steps are changed; the checklist is purely additive.