### PR TITLE
fix(agents): add path mismatch guard to prevent silent main-tree writes

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -24,6 +24,17 @@ When a delegation prompt contains a `WORKING_DIRECTORY:` context line, read `cla
 
 - **Session worktree setup:** When DM delegates worktree creation, run the exact commands from the DM's prompt (e.g., `git worktree add`, `mkdir -p`) and report `WORKTREE_PATH` and `WORKTREE_BRANCH` back to DM.
 
+### Path Mismatch Guard
+
+Check the workbench before every strike. This is a per-operation invariant — it fires before every Write, Edit, or file-modifying Bash command, not once at task start.
+
+1. **WORKING_DIRECTORY present, path matches** — the target path sits under `WORKING_DIRECTORY`. Proceed normally.
+2. **WORKING_DIRECTORY present, path does not match** — halt immediately. Do not write, edit, or execute the command. Surface a structured report to the Dungeon Master containing: (a) the `WORKING_DIRECTORY` value, (b) the offending path(s) Bitsmith was about to write to, (c) a request for DM to confirm or correct the target paths. Do not proceed until DM responds.
+3. **WORKING_DIRECTORY absent, write-bearing task** — before the first file modification, surface a single confirmation to the Dungeon Master: "No WORKING_DIRECTORY was specified in this delegation. Should I operate in the main working tree?" Do not proceed until confirmed. This fires once per task, not per operation.
+
+Bitsmith does not guess the correct path. She surfaces the conflict.
+
+When `WORKING_DIRECTORY` is absent from the delegation prompt: for read-only tasks, behavior is unchanged — operate in the main working tree as before. For write-bearing tasks (any Write, Edit, or file-modifying Bash command), defer to the Path Mismatch Guard (scenario 3 above).
 ## The Forge's Jurisdiction
 
 ### What Bitsmith Touches

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -226,6 +226,10 @@ Sub-agents respect this context:
 
 You don't need to do anything — the context is automatically propagated by DungeonMaster.
 
+### Bitsmith's Path Mismatch Guard
+
+Bitsmith includes a safeguard that prevents silent writes to the main working tree when a session worktree is active. This **Path Mismatch Guard** fires as a per-operation invariant before every Write, Edit, or file-modifying Bash command. If you (or Bitsmith) accidentally reference a file path outside the active worktree, Bitsmith halts and surfaces the conflict to the Dungeon Master for confirmation rather than proceeding silently. This ensures changes land on the correct branch in the correct worktree, preventing accidental main-tree modifications during isolated sessions.
+
 ## Phase 5 Cleanup Flow
 
 At session completion (Phase 5), DungeonMaster summarizes your work and offers cleanup options:


### PR DESCRIPTION
Bitsmith silently defaulted to the main working tree when a delegation specified paths outside WORKING_DIRECTORY, causing accidental edits on the wrong branch. This was observed and recorded as lesson EVW-2026-04-03-001.

The fix adds a `### Path Mismatch Guard` subsection to Bitsmith's Worktree Awareness section. It operates as a per-operation invariant — halting before any Write, Edit, or file-modifying Bash command if the target path doesn't sit under WORKING_DIRECTORY and surfacing the conflict to DM. When no WORKING_DIRECTORY is specified on a write-bearing task, Bitsmith asks DM to confirm main-tree intent once before proceeding.