### PR TITLE
fix(agents): enforce no-compound-commands rule across all bash-capable agents

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -16,5 +16,5 @@ ALL pull requests and merge requests must be created using the `open-pull-reques
 
 ## Bash Command Style
 
-- Never use compound shell commands (`&&`, `;`, `|` chaining).
+- Never chain commands using `&&` or `;`. Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
 - Always issue each command as a separate, standalone Bash call.

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -150,7 +150,7 @@ Only when all checks pass does she set down the hammer.
 | `Read` | Examine existing files before modifying them; understand patterns and conventions |
 | `Edit` | Make targeted, minimal changes to existing files — preferred over Write for modifications |
 | `Write` | Create new files when required by the plan |
-| `Bash` | Run builds, tests, LSP checks, and verification commands |
+| `Bash` | Run builds, tests, LSP checks, and verification commands. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call. |
 | `Grep` | Search for patterns, usages, and conventions across the codebase |
 | `Glob` | Locate files by name or pattern during exploration |
 | `Agent` | Delegate read-only codebase exploration (max 3 concurrent sub-agents) |

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -150,7 +150,7 @@ Only when all checks pass does she set down the hammer.
 | `Read` | Examine existing files before modifying them; understand patterns and conventions |
 | `Edit` | Make targeted, minimal changes to existing files — preferred over Write for modifications |
 | `Write` | Create new files when required by the plan |
-| `Bash` | Run builds, tests, LSP checks, and verification commands. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call. |
+| `Bash` | Run builds, tests, LSP checks, and verification commands. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style. |
 | `Grep` | Search for patterns, usages, and conventions across the codebase |
 | `Glob` | Locate files by name or pattern during exploration |
 | `Agent` | Delegate read-only codebase exploration (max 3 concurrent sub-agents) |

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -478,7 +478,7 @@ Keep it concise and operational. Prefer facts over narration.
 - Minimize unnecessary back-and-forth. Use delegation decisively.
 - Do not invoke Everwise directly, including as an escalation path after in-session review failures or stalled REVISE loops. Everwise is a user-facing meta-analysis tool — suggest it to the user when session patterns warrant it. If a review loop stalls after 3+ REVISE cycles on the same artifact, escalate to Pathfinder for plan revision.
 - Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.
-- The Bash tool is available for read-only orchestration inspection only (e.g., `git status`, `git log`, `git diff`, `ls`). It must never be used to make changes, run tests, install packages, build, compile, or perform any implementation action. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- The Bash tool is available for read-only orchestration inspection only (e.g., `git status`, `git log`, `git diff`, `ls`). It must never be used to make changes, run tests, install packages, build, compile, or perform any implementation action. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 ## Example internal routing behavior
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -478,7 +478,7 @@ Keep it concise and operational. Prefer facts over narration.
 - Minimize unnecessary back-and-forth. Use delegation decisively.
 - Do not invoke Everwise directly, including as an escalation path after in-session review failures or stalled REVISE loops. Everwise is a user-facing meta-analysis tool — suggest it to the user when session patterns warrant it. If a review loop stalls after 3+ REVISE cycles on the same artifact, escalate to Pathfinder for plan revision.
 - Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.
-- The Bash tool is available for read-only orchestration inspection only (e.g., `git status`, `git log`, `git diff`, `ls`). It must never be used to make changes, run tests, install packages, build, compile, or perform any implementation action.
+- The Bash tool is available for read-only orchestration inspection only (e.g., `git status`, `git log`, `git diff`, `ls`). It must never be used to make changes, run tests, install packages, build, compile, or perform any implementation action. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 ## Example internal routing behavior
 

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -214,7 +214,7 @@ When proposing simplifications, report before/after values for each applicable m
 - Read: Study existing code to understand complexity sources
 - Grep: Find actual usage patterns vs. theoretical capabilities
 - Glob: Locate files by name or pattern
-- Bash: Test assumptions about what's actually being used (read-only commands only). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- Bash: Test assumptions about what's actually being used (read-only commands only). **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 **Blocked:**
 - Write: Knotcutter never creates or overwrites files

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -214,7 +214,7 @@ When proposing simplifications, report before/after values for each applicable m
 - Read: Study existing code to understand complexity sources
 - Grep: Find actual usage patterns vs. theoretical capabilities
 - Glob: Locate files by name or pattern
-- Bash: Test assumptions about what's actually being used (read-only commands only)
+- Bash: Test assumptions about what's actually being used (read-only commands only). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 **Blocked:**
 - Write: Knotcutter never creates or overwrites files

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -307,7 +307,7 @@ Before considering a plan complete, verify:
 - `Write`: Create plan files in `plans/` directory
 - `Grep`: Search for patterns in codebase
 - `Glob`: Find files by pattern
-- `Bash`: Supplementary investigation (git history, file stats)
+- `Bash`: Supplementary investigation (git history, file stats). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 - `Agent`: Delegate codebase research to explore agents
 
 **Tool Workflow:**

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -307,7 +307,7 @@ Before considering a plan complete, verify:
 - `Write`: Create plan files in `plans/` directory
 - `Grep`: Search for patterns in codebase
 - `Glob`: Find files by pattern
-- `Bash`: Supplementary investigation (git history, file stats). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- `Bash`: Supplementary investigation (git history, file stats). **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 - `Agent`: Delegate codebase research to explore agents
 
 **Tool Workflow:**

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -57,7 +57,7 @@ Talekeeper is unaffected by worktree isolation. It writes to gitignored session 
 
 ## Tool Usage
 
-- Bash: Run read-only investigation commands (git log, file stats) to support documentation research. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- Bash: Run read-only investigation commands (git log, file stats) to support documentation research. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 ## Documentation Standards
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -57,7 +57,14 @@ Talekeeper is unaffected by worktree isolation. It writes to gitignored session 
 
 ## Tool Usage
 
-- Bash: Run read-only investigation commands (git log, file stats) to support documentation research. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
+| Tool | Purpose |
+|------|---------|
+| `Read` | Examine existing files, source code, and configuration to understand what needs documenting |
+| `Grep` | Search for patterns, function signatures, and usage examples across the codebase |
+| `Glob` | Locate files by name or pattern during documentation gap analysis |
+| `Bash` | Run read-only investigation commands (git log, file stats) to support documentation research. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style. |
+| `Write` | Create new documentation files (README, API specs, architecture guides) |
+| `Edit` | Update existing documentation files with targeted, minimal changes |
 
 ## Documentation Standards
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -55,6 +55,10 @@ Talekeeper is unaffected by worktree isolation. It writes to gitignored session 
 **6. File Generation**
 - Create or modify `README.md`, `docs/api.md`, `docs/architecture.md` using Write/Edit tools
 
+## Tool Usage
+
+- Bash: Run read-only investigation commands (git log, file stats) to support documentation research. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+
 ## Documentation Standards
 
 **Best Practices:**

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -190,7 +190,7 @@ Expand A02 (Cryptographic Failures) with:
    - Provide location-specific fixes with secure code examples
 
 ## Tool Usage
-Permitted tools include Grep for pattern detection, Bash for dependency audits, and Read for code examination.
+Permitted tools include Grep for pattern detection, Bash for dependency audits, and Read for code examination. **Bash style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 **Important:** Return reviews in-memory. Provide verdict and findings directly in your response to Dungeon Master. Do NOT write review files - reviews are ephemeral process artifacts.
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -190,7 +190,7 @@ Expand A02 (Cryptographic Failures) with:
    - Provide location-specific fixes with secure code examples
 
 ## Tool Usage
-Permitted tools include Grep for pattern detection, Bash for dependency audits, and Read for code examination. **Bash style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+Permitted tools include Grep for pattern detection, Bash for dependency audits, and Read for code examination. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 **Important:** Return reviews in-memory. Provide verdict and findings directly in your response to Dungeon Master. Do NOT write review files - reviews are ephemeral process artifacts.
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -249,7 +249,7 @@ Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for th
 - Read: Examine code, plans, documentation, and configuration files
 - Grep: Search for patterns, references, and usage across the codebase
 - Glob: Find files by name or pattern
-- Bash: Run read-only commands (git log, git diff, test execution, linting) to verify claims
+- Bash: Run read-only commands (git log, git diff, test execution, linting) to verify claims. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 **Blocked:**
 - Write: Ruinor never creates or overwrites files

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -249,7 +249,7 @@ Before issuing your verdict, read `claude/references/verdict-taxonomy.md` for th
 - Read: Examine code, plans, documentation, and configuration files
 - Grep: Search for patterns, references, and usage across the codebase
 - Glob: Find files by name or pattern
-- Bash: Run read-only commands (git log, git diff, test execution, linting) to verify claims. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- Bash: Run read-only commands (git log, git diff, test execution, linting) to verify claims. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 **Blocked:**
 - Write: Ruinor never creates or overwrites files

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -178,7 +178,7 @@ Every Truthhammer review must include the following footer disclaimer verbatim:
 - Read: Examine plans, code, configuration files, and documentation
 - Grep: Search for patterns, config references, and API usage across the codebase
 - Glob: Find files by name or pattern
-- Bash: Run read-only commands to understand the codebase
+- Bash: Run read-only commands to understand the codebase. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 **Blocked:**
 - Write: Truthhammer never creates or overwrites files

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -178,7 +178,7 @@ Every Truthhammer review must include the following footer disclaimer verbatim:
 - Read: Examine plans, code, configuration files, and documentation
 - Grep: Search for patterns, config references, and API usage across the codebase
 - Glob: Find files by name or pattern
-- Bash: Run read-only commands to understand the codebase. **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- Bash: Run read-only commands to understand the codebase. **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 **Blocked:**
 - Write: Truthhammer never creates or overwrites files

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -274,7 +274,7 @@ Brief explanation of why this verdict was chosen based on performance impact.
 - Read: Examine code, plans, database schemas, and configuration files
 - Grep: Search for performance anti-patterns across the codebase
 - Glob: Find relevant files (migrations, query files, config)
-- Bash: Run performance analysis commands (EXPLAIN queries, profiling tools, benchmarks)
+- Bash: Run performance analysis commands (EXPLAIN queries, profiling tools, benchmarks). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
 
 **Blocked:**
 - Write: Windwarden never creates or overwrites files

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -274,7 +274,7 @@ Brief explanation of why this verdict was chosen based on performance impact.
 - Read: Examine code, plans, database schemas, and configuration files
 - Grep: Search for performance anti-patterns across the codebase
 - Glob: Find relevant files (migrations, query files, config)
-- Bash: Run performance analysis commands (EXPLAIN queries, profiling tools, benchmarks). **Style constraint:** Never chain commands with `&&`, `;`, or `|`. Issue each command as a separate, standalone Bash call.
+- Bash: Run performance analysis commands (EXPLAIN queries, profiling tools, benchmarks). **Style constraint:** See `claude/references/bash-style.md` for the required Bash command style.
 
 **Blocked:**
 - Write: Windwarden never creates or overwrites files

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -4,9 +4,11 @@ This file defines the required Bash command style for all agents. It is the auth
 
 ## Rule: No Compound Commands
 
-Never chain commands using `&&`, `;`, or `|`. Always issue each command as a separate, standalone Bash call.
+Never chain commands using `&&` or `;` as sequential execution operators. Always issue each command as a separate, standalone Bash call.
 
-**Wrong:**
+Pipes (`|`) are permitted **only for data transformation** (feeding the output of one command into a filter). Do not use pipes as a substitute for sequential control flow.
+
+**Wrong — sequential chaining:**
 ```bash
 mkdir -p foo && cd foo && git init
 ```
@@ -15,6 +17,21 @@ mkdir -p foo && cd foo && git init
 1. `mkdir -p foo`
 2. `cd foo`
 3. `git init`
+
+**Wrong — pipe as control flow:**
+```bash
+git stash && git pull | grep "Already up to date"
+```
+
+**Right:** Separate calls; use tool-native flags where possible:
+1. `git stash`
+2. `git pull`
+3. `git log --oneline -5`  ← prefer `-5` flag over `git log | head -5`
+
+**Acceptable — pipe for data transformation (no tool-native alternative):**
+```bash
+grep "ERROR" app.log | wc -l
+```
 
 ## Rationale
 

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -1,0 +1,28 @@
+# Bash Style — Shared Reference
+
+This file defines the required Bash command style for all agents. It is the authoritative source for this rule. Agents that use the Bash tool must follow these rules without exception.
+
+## Rule: No Compound Commands
+
+Never chain commands using `&&`, `;`, or `|`. Always issue each command as a separate, standalone Bash call.
+
+**Wrong:**
+```bash
+mkdir -p foo && cd foo && git init
+```
+
+**Right:** Three separate Bash calls:
+1. `mkdir -p foo`
+2. `cd foo`
+3. `git init`
+
+## Rationale
+
+Compound commands:
+- Require interactive user approval as a single opaque block
+- Make it harder to diagnose which step failed
+- Violate the project-wide style rule defined in `CLAUDE.md`
+
+## Applies To
+
+All agents with Bash tool access: Ruinor, Riskmancer, Windwarden, Knotcutter, Truthhammer, Quill, Pathfinder, Bitsmith, Dungeonmaster.

--- a/claude/references/worktree-protocol.md
+++ b/claude/references/worktree-protocol.md
@@ -25,7 +25,7 @@ When `WORKING_DIRECTORY:` is present in the delegation prompt:
 ## Bash Command Rules
 
 - Always use absolute paths rooted in `{WORKING_DIRECTORY}`. Do not construct paths relative to an assumed current directory.
-- Never use `cd ... &&` or any compound shell command to simulate a working directory change. This violates the global bash style rule and does not persist the CWD across separate Bash calls.
+- Never use `cd ... &&` or any compound shell command to simulate a working directory change. This violates the Bash style rule defined in `claude/references/bash-style.md` and does not persist the CWD across separate Bash calls.
 - For tools that resolve configuration relative to CWD, use the tool's own directory flag where available (e.g., `npm --prefix {WORKING_DIRECTORY} install`, `make -C {WORKING_DIRECTORY}`).
 - If a tool has no CWD flag and cannot be invoked with an absolute path, surface the limitation rather than resorting to compound command chaining.
 


### PR DESCRIPTION
Sub-agents don't inherit the project-wide CLAUDE.md bash style rule, causing compound shell commands (&&, ;) that trigger user approval prompts. This adds an explicit constraint to all 9 bash-capable agent definitions and extracts it into a canonical shared reference (claude/references/bash-style.md) so the rule has a single source of truth. Also clarifies that pipes are permitted for data transformation but not as control-flow substitutes, and aligns CLAUDE.md accordingly.