### PR TITLE
feat(installer): migrate install.sh logic to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ logs/
 
 # Planning documents (local only, not for version control)
 plans/
+
+# Node.js
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,22 @@ Keep AI tool configurations version-controlled and portable across machines. The
 
 The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, and `references/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
 
+### Developer Notes
+
+The installation logic is implemented in TypeScript under the `installer/` directory:
+
+- `installer/main.ts` — Main entrypoint; orchestrates the install workflow
+- `installer/cli.ts` — CLI argument parser (handles `--copy`, `--help`/`-h`)
+- `installer/colors.ts` — ANSI color output helper
+- `installer/fs-utils.ts` — Filesystem utilities (backup, symlink, copy operations)
+- `installer/claude.ts` — Claude config whitelist installer
+- `installer/mcp.ts` — MCP server setup
+
+The `install.sh` shim in the repo root bootstraps the TypeScript entrypoint and verifies Node.js >= 18 is available. This design keeps the installer maintainable and testable while preserving backwards compatibility with the original Bash script's user interface.
+
 ## Installation
+
+**Prerequisites:** Node.js >= 18 is required to run `install.sh`. The installer is implemented in TypeScript and executed via `tsx` at runtime.
 
 Clone the repository:
 ```bash
@@ -54,6 +69,11 @@ Run the installation script:
 ```
 
 Creates symbolic links for the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
+
+Alternatively, if you have Node.js installed:
+```bash
+npm run setup
+```
 
 ### Option 2: Copy Files
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -2,198 +2,21 @@
 
 set -euo pipefail
 
-# Colors for output
 RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Default installation method
-INSTALL_METHOD="symlink"
+if ! command -v node >/dev/null 2>&1; then
+  printf "${RED}Error: node is not installed or not in PATH. Please install Node.js >= 18.${NC}\n" >&2
+  exit 1
+fi
 
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --copy)
-      INSTALL_METHOD="copy"
-      shift
-      ;;
-    --help|-h)
-      echo "Usage: $0 [--copy]"
-      echo ""
-      echo "Install AI TPK to your home directory."
-      echo ""
-      echo "Claude Code:"
-      echo "  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/"
-      echo "  - MCP servers: kubernetes (user scope, via claude mcp add)"
-      echo ""
-      echo "Options:"
-      echo "  --copy    Copy files instead of creating symlinks (default: symlink)"
-      echo "  --help    Show this help message"
-      echo ""
-      echo "Installation methods:"
-      echo "  symlink (default): Creates symbolic links. Changes sync automatically."
-      echo "  copy:              Copies files. Manual sync required with git pull."
-      exit 0
-      ;;
-    *)
-      echo -e "${RED}Error: Unknown option $1${NC}"
-      echo "Run '$0 --help' for usage information."
-      exit 1
-      ;;
-  esac
-done
+NODE_VERSION=$(node -e 'process.stdout.write(process.versions.node)')
+NODE_MAJOR="${NODE_VERSION%%.*}"
+if [[ "$NODE_MAJOR" -lt 18 ]]; then
+  printf "${RED}Error: Node.js >= 18 required (found ${NODE_VERSION}).${NC}\n" >&2
+  exit 1
+fi
 
-# Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo -e "${BLUE}AI TPK Installer${NC}"
-echo -e "${BLUE}=====================${NC}"
-echo ""
-echo "Installation method: ${GREEN}${INSTALL_METHOD}${NC}"
-echo "Source directory: ${SCRIPT_DIR}"
-echo ""
-
-# Function to backup existing path if present (always returns 0 so set -e is safe)
-backup_if_exists() {
-  local target="$1"
-  if [[ -e "$target" ]]; then
-    local backup="${target}.backup.$(date +%Y%m%d_%H%M%S)"
-    echo -e "${YELLOW}Backing up existing ${target} to ${backup}${NC}"
-    mv "$target" "$backup"
-  fi
-  return 0
-}
-
-# Install a source path to a destination path (file or directory)
-install_path() {
-  local src_path="$1"
-  local dest_path="$2"
-
-  backup_if_exists "$dest_path"
-
-  if [[ "$INSTALL_METHOD" == "symlink" ]]; then
-    echo -e "${GREEN}Creating symlink:${NC} ${dest_path} -> ${src_path}"
-    ln -s "$src_path" "$dest_path"
-  else
-    echo -e "${GREEN}Copying:${NC} ${src_path} -> ${dest_path}"
-    cp -r "$src_path" "$dest_path"
-  fi
-}
-
-# Function to install a top-level directory from the repo into the home directory
-install_dir() {
-  local src_name="$1"
-  local dest_name="$2"
-  local src_path="${SCRIPT_DIR}/${src_name}"
-  local dest_path="${HOME}/${dest_name}"
-
-  if [[ ! -d "$src_path" ]]; then
-    echo -e "${YELLOW}Skipping ${src_name} (not found in repository)${NC}"
-    return
-  fi
-
-  install_path "$src_path" "$dest_path"
-}
-
-# Whitelist only: ~/.claude/settings.json, ~/.claude/CLAUDE.md, ~/.claude/skills/, ~/.claude/agents/
-install_claude_whitelist() {
-  local claude_src="${SCRIPT_DIR}/claude"
-
-  if [[ ! -d "$claude_src" ]]; then
-    echo -e "${YELLOW}Skipping claude/ (not found in repository)${NC}"
-    return
-  fi
-
-  # Replace legacy full-tree ~/.claude symlink with a real directory
-  if [[ -L "${HOME}/.claude" ]]; then
-    backup_if_exists "${HOME}/.claude"
-  fi
-  mkdir -p "${HOME}/.claude"
-
-  local settings_src="${claude_src}/settings.json"
-  if [[ -f "$settings_src" ]]; then
-    install_path "$settings_src" "${HOME}/.claude/settings.json"
-  else
-    echo -e "${YELLOW}Skipping claude/settings.json (not found in repository)${NC}"
-  fi
-
-  local claude_md_src="${claude_src}/CLAUDE.md"
-  if [[ -f "$claude_md_src" ]]; then
-    install_path "$claude_md_src" "${HOME}/.claude/CLAUDE.md"
-  else
-    echo -e "${YELLOW}Skipping claude/CLAUDE.md (not found in repository)${NC}"
-  fi
-
-  local name
-  for name in skills agents hooks commands references; do
-    local sub_src="${claude_src}/${name}"
-    if [[ -d "$sub_src" ]]; then
-      install_path "$sub_src" "${HOME}/.claude/${name}"
-    else
-      echo -e "${YELLOW}Skipping claude/${name}/ (not found in repository)${NC}"
-    fi
-  done
-}
-
-add_mcp_if_missing() {
-  local server_name="$1"
-  local prereq_path="$2"
-  shift 2
-
-  # Defensive: safe to call standalone
-  if ! command -v claude >/dev/null 2>&1; then
-    echo -e "${YELLOW}Warning: claude CLI not found -- skipping MCP server '${server_name}'${NC}"
-    return
-  fi
-
-  if claude mcp get "$server_name" >/dev/null 2>&1; then
-    echo -e "${GREEN}MCP server '${server_name}' already configured, skipping${NC}"
-    return
-  fi
-
-  if [[ -n "$prereq_path" ]] && [[ ! -e "$prereq_path" ]]; then
-    echo -e "${YELLOW}Warning: ${prereq_path} not found -- ${server_name} MCP will fail until this file is created${NC}"
-  fi
-
-  if claude mcp add "$@"; then
-    echo -e "${GREEN}MCP server '${server_name}' added${NC}"
-  else
-    echo -e "${RED}Failed to add MCP server '${server_name}'${NC}"
-    return 0
-  fi
-}
-
-install_mcp_servers() {
-  echo -e "${BLUE}Configuring MCP servers (user scope)...${NC}"
-
-  if ! command -v claude >/dev/null 2>&1; then
-    echo -e "${YELLOW}Skipping MCP server setup (claude CLI not found)${NC}"
-    return
-  fi
-
-  add_mcp_if_missing "kubernetes" \
-    "${HOME}/.kube/config" \
-    -s user -t stdio \
-    -e KUBECONFIG="${HOME}/.kube/config" \
-    -- kubernetes npx mcp-server-kubernetes@3.4.0
-}
-
-install_claude_whitelist
-install_dir "cursor" ".cursor"
-
-echo ""
-install_mcp_servers
-
-echo ""
-echo -e "${GREEN}✓ Installation complete!${NC}"
-echo ""
-
-if [[ "$INSTALL_METHOD" == "symlink" ]]; then
-  echo "Your configurations are now symlinked to this repository."
-  echo "To update: cd ${SCRIPT_DIR} && git pull"
-else
-  echo "Your configurations have been copied from this repository."
-  echo "To update: cd ${SCRIPT_DIR} && git pull && ./install.sh --copy"
-fi
+exec npx tsx "${SCRIPT_DIR}/installer/main.ts" "$@"

--- a/installer/claude.ts
+++ b/installer/claude.ts
@@ -1,0 +1,93 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { c } from "./colors.js";
+import { backupIfExists, installPath } from "./fs-utils.js";
+
+export function installClaudeWhitelist(scriptDir: string, mode: "symlink" | "copy"): void {
+  const claudeSrc = path.join(scriptDir, "claude");
+
+  try {
+    const claudeSrcStat = fs.statSync(claudeSrc);
+    if (!claudeSrcStat.isDirectory()) {
+      console.log(c.yellow("Skipping claude/ (not found in repository)"));
+      return;
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log(c.yellow("Skipping claude/ (not found in repository)"));
+      return;
+    }
+    throw err;
+  }
+
+  const dotClaudePath = path.join(os.homedir(), ".claude");
+
+  // Replace legacy full-tree ~/.claude symlink with a real directory
+  try {
+    const stat = fs.lstatSync(dotClaudePath);
+    if (stat.isSymbolicLink()) {
+      backupIfExists(dotClaudePath);
+    }
+  } catch (err: unknown) {
+    if (!(err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT")) {
+      throw err;
+    }
+    // Does not exist — nothing to do before mkdir
+  }
+
+  fs.mkdirSync(dotClaudePath, { recursive: true });
+
+  // settings.json
+  const settingsSrc = path.join(claudeSrc, "settings.json");
+  try {
+    const settingsStat = fs.statSync(settingsSrc);
+    if (settingsStat.isFile()) {
+      installPath(settingsSrc, path.join(dotClaudePath, "settings.json"), mode);
+    } else {
+      console.log(c.yellow("Skipping claude/settings.json (not found in repository)"));
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log(c.yellow("Skipping claude/settings.json (not found in repository)"));
+    } else {
+      throw err;
+    }
+  }
+
+  // CLAUDE.md
+  const claudeMdSrc = path.join(claudeSrc, "CLAUDE.md");
+  try {
+    const claudeMdStat = fs.statSync(claudeMdSrc);
+    if (claudeMdStat.isFile()) {
+      installPath(claudeMdSrc, path.join(dotClaudePath, "CLAUDE.md"), mode);
+    } else {
+      console.log(c.yellow("Skipping claude/CLAUDE.md (not found in repository)"));
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log(c.yellow("Skipping claude/CLAUDE.md (not found in repository)"));
+    } else {
+      throw err;
+    }
+  }
+
+  // Sub-directories
+  for (const name of ["skills", "agents", "hooks", "commands", "references"]) {
+    const subSrc = path.join(claudeSrc, name);
+    try {
+      const subStat = fs.statSync(subSrc);
+      if (subStat.isDirectory()) {
+        installPath(subSrc, path.join(dotClaudePath, name), mode);
+      } else {
+        console.log(c.yellow(`Skipping claude/${name}/ (not found in repository)`));
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        console.log(c.yellow(`Skipping claude/${name}/ (not found in repository)`));
+      } else {
+        throw err;
+      }
+    }
+  }
+}

--- a/installer/cli.ts
+++ b/installer/cli.ts
@@ -1,0 +1,40 @@
+import { c } from "./colors.js";
+
+const USAGE = `Usage: ./install.sh [--copy]
+
+Install AI TPK to your home directory.
+
+Claude Code:
+  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/
+  - MCP servers: kubernetes (user scope, via claude mcp add)
+
+Options:
+  --copy    Copy files instead of creating symlinks (default: symlink)
+  --help    Show this help message
+
+Installation methods:
+  symlink (default): Creates symbolic links. Changes sync automatically.
+  copy:              Copies files. Manual sync required with git pull.`;
+
+export function parseArgs(argv: string[]): { mode: "symlink" | "copy" } {
+  let mode: "symlink" | "copy" = "symlink";
+
+  for (const flag of argv) {
+    switch (flag) {
+      case "--copy":
+        mode = "copy";
+        break;
+      case "--help":
+      case "-h":
+        console.log(USAGE);
+        process.exit(0);
+        break;
+      default:
+        process.stderr.write(`${c.red(`Error: Unknown option ${flag}`)}\n`);
+        process.stderr.write("Run './install.sh --help' for usage information.\n");
+        process.exit(1);
+    }
+  }
+
+  return { mode };
+}

--- a/installer/colors.ts
+++ b/installer/colors.ts
@@ -1,0 +1,15 @@
+const noColor = Boolean(process.env["NO_COLOR"]);
+
+function wrap(code: string, msg: string): string {
+  if (noColor) return msg;
+  return `${code}${msg}\x1b[0m`;
+}
+
+export const c = {
+  red: (msg: string) => wrap("\x1b[0;31m", msg),
+  green: (msg: string) => wrap("\x1b[0;32m", msg),
+  yellow: (msg: string) => wrap("\x1b[1;33m", msg),
+  blue: (msg: string) => wrap("\x1b[0;34m", msg),
+};
+
+export const nc = "\x1b[0m";

--- a/installer/fs-utils.ts
+++ b/installer/fs-utils.ts
@@ -1,0 +1,69 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { c } from "./colors.js";
+
+function timestamp(): string {
+  const now = new Date();
+  const pad = (n: number, len = 2) => String(n).padStart(len, "0");
+  const YYYY = now.getFullYear();
+  const MM = pad(now.getMonth() + 1);
+  const DD = pad(now.getDate());
+  const HH = pad(now.getHours());
+  const mm = pad(now.getMinutes());
+  const SS = pad(now.getSeconds());
+  return `${YYYY}${MM}${DD}_${HH}${mm}${SS}`;
+}
+
+export function backupIfExists(targetPath: string): void {
+  try {
+    fs.statSync(targetPath);
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+  const backupPath = `${targetPath}.backup.${timestamp()}`;
+  console.log(c.yellow(`Backing up existing ${targetPath} to ${backupPath}`));
+  fs.renameSync(targetPath, backupPath);
+}
+
+export function installPath(src: string, dest: string, mode: "symlink" | "copy"): void {
+  backupIfExists(dest);
+
+  if (mode === "symlink") {
+    const absSrc = path.resolve(src);
+    console.log(c.green(`Creating symlink: ${dest} -> ${src}`));
+    fs.symlinkSync(absSrc, dest);
+  } else {
+    console.log(c.green(`Copying: ${src} -> ${dest}`));
+    fs.cpSync(src, dest, { recursive: true });
+  }
+}
+
+export function installDir(
+  scriptDir: string,
+  srcName: string,
+  destName: string,
+  mode: "symlink" | "copy"
+): void {
+  const srcPath = path.join(scriptDir, srcName);
+  const destPath = path.join(os.homedir(), destName);
+
+  try {
+    const srcStat = fs.statSync(srcPath);
+    if (!srcStat.isDirectory()) {
+      console.log(c.yellow(`Skipping ${srcName} (not found in repository)`));
+      return;
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log(c.yellow(`Skipping ${srcName} (not found in repository)`));
+      return;
+    }
+    throw err;
+  }
+
+  installPath(srcPath, destPath, mode);
+}

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -1,0 +1,45 @@
+import { parseArgs } from "./cli.js";
+import { installDir } from "./fs-utils.js";
+import { installClaudeWhitelist } from "./claude.js";
+import { installMcpServers } from "./mcp.js";
+import { c } from "./colors.js";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+// Resolve scriptDir = repo root (parent of installer/)
+const __filename = fileURLToPath(import.meta.url);
+const installerDir = path.dirname(__filename);
+const scriptDir = path.dirname(installerDir);
+
+try {
+  const { mode } = parseArgs(process.argv.slice(2));
+
+  console.log(c.blue("AI TPK Installer"));
+  console.log(c.blue("====================="));
+  console.log("");
+  console.log(`Installation method: ${c.green(mode)}`);
+  console.log(`Source directory: ${scriptDir}`);
+  console.log("");
+
+  installClaudeWhitelist(scriptDir, mode);
+  installDir(scriptDir, "cursor", ".cursor", mode);
+
+  console.log("");
+  installMcpServers();
+
+  console.log("");
+  console.log(c.green("✓ Installation complete!"));
+  console.log("");
+
+  if (mode === "symlink") {
+    console.log("Your configurations are now symlinked to this repository.");
+    console.log(`To update: cd ${scriptDir} && git pull`);
+  } else {
+    console.log("Your configurations have been copied from this repository.");
+    console.log(`To update: cd ${scriptDir} && git pull && ./install.sh --copy`);
+  }
+} catch (e: unknown) {
+  const msg = e instanceof Error ? e.message : String(e);
+  process.stderr.write(`\x1b[0;31mError: ${msg}\x1b[0m\n`);
+  process.exit(1);
+}

--- a/installer/mcp.ts
+++ b/installer/mcp.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { c } from "./colors.js";
+
+interface McpServerDef {
+  name: string;
+  prereqPath?: string;
+  addArgs: string[];
+}
+
+const MCP_SERVERS: McpServerDef[] = [
+  {
+    name: "kubernetes",
+    prereqPath: path.join(os.homedir(), ".kube", "config"),
+    addArgs: [
+      "-s", "user",
+      "-t", "stdio",
+      "-e", `KUBECONFIG=${path.join(os.homedir(), ".kube", "config")}`,
+      "--", "kubernetes", "npx", "mcp-server-kubernetes@3.4.0",
+    ],
+  },
+];
+
+export function installMcpServers(): void {
+  // Check claude CLI availability
+  try {
+    execFileSync("claude", ["--version"], { stdio: "pipe" });
+  } catch {
+    console.log(c.yellow("Skipping MCP server setup (claude CLI not found)"));
+    return;
+  }
+
+  console.log(c.blue("Configuring MCP servers (user scope)..."));
+
+  for (const server of MCP_SERVERS) {
+    // Check if already configured
+    try {
+      execFileSync("claude", ["mcp", "get", server.name], { stdio: "pipe" });
+      console.log(c.green(`MCP server '${server.name}' already configured, skipping`));
+      continue;
+    } catch {
+      // Not yet configured — proceed
+    }
+
+    // Check prereq
+    if (server.prereqPath !== undefined) {
+      try {
+        fs.statSync(server.prereqPath);
+      } catch (err: unknown) {
+        if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+          console.log(
+            c.yellow(
+              `Warning: ${server.prereqPath} not found -- ${server.name} MCP will fail until this file is created`
+            )
+          );
+        }
+      }
+    }
+
+    // Add the server
+    try {
+      execFileSync("claude", ["mcp", "add", ...server.addArgs], { stdio: "pipe" });
+      console.log(c.green(`MCP server '${server.name}' added`));
+    } catch {
+      console.log(c.red(`Failed to add MCP server '${server.name}'`));
+    }
+  }
+}

--- a/installer/test/reference-help-output.txt
+++ b/installer/test/reference-help-output.txt
@@ -1,0 +1,15 @@
+Usage: ./install.sh [--copy]
+
+Install AI TPK to your home directory.
+
+Claude Code:
+  - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/
+  - MCP servers: kubernetes (user scope, via claude mcp add)
+
+Options:
+  --copy    Copy files instead of creating symlinks (default: symlink)
+  --help    Show this help message
+
+Installation methods:
+  symlink (default): Creates symbolic links. Changes sync automatically.
+  copy:              Copies files. Manual sync required with git pull.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,588 @@
+{
+  "name": "ai-tpk",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-tpk",
+      "devDependencies": {
+        "@types/node": "^25.5.2",
+        "tsx": "latest",
+        "typescript": "latest"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-tpk",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "tsx": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "setup": "tsx installer/main.ts"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["installer/**/*.ts"]
+}


### PR DESCRIPTION
Replaces the ~200-line Bash installer with a thin shim that delegates to a TypeScript implementation (`installer/`). All user-facing behaviour is preserved: `--copy`, `--help`, coloured output, backup semantics, and MCP server setup.

Node.js >= 18 is now required. The shim checks this at startup and exits with a clear error if not met. No runtime npm dependencies are introduced — only `tsx` and `typescript` as devDependencies.

**Known follow-ups (tracked in `plans/*-open-questions.md`):**
- Dangling `~/.claude` symlink edge case crashes installer (fix: use `renameSync` directly in `claude.ts`)
- `hooks/` and `commands/` missing from `--help` whitelist display (pre-existing from original script)