### PR TITLE
feat(installer): extract constants and add node:test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUD
 
 The installation logic is implemented in TypeScript under the `installer/` directory:
 
+- `installer/constants.ts` — Single source of truth for whitelisted Claude paths, MCP server definitions, and Node.js version requirements
 - `installer/main.ts` — Main entrypoint; orchestrates the install workflow
 - `installer/cli.ts` — CLI argument parser (handles `--copy`, `--help`/`-h`)
 - `installer/colors.ts` — ANSI color output helper
@@ -49,11 +50,21 @@ The installation logic is implemented in TypeScript under the `installer/` direc
 - `installer/claude.ts` — Claude config whitelist installer
 - `installer/mcp.ts` — MCP server setup
 
-The `install.sh` shim in the repo root bootstraps the TypeScript entrypoint and verifies Node.js >= 18 is available. This design keeps the installer maintainable and testable while preserving backwards compatibility with the original Bash script's user interface.
+The `install.sh` shim in the repo root bootstraps the TypeScript entrypoint and verifies Node.js >= 18.18.0 is available. This design keeps the installer maintainable and testable while preserving backwards compatibility with the original Bash script's user interface.
+
+#### Running Tests
+
+The installer includes a comprehensive test suite using `node:test`:
+
+```bash
+npm test
+```
+
+This runs all test files in `installer/test/` with isolated temporary directories. Tests cover filesystem utilities, CLI argument parsing, color output, and the Claude whitelist installer. For more details, see the test files under `installer/test/`.
 
 ## Installation
 
-**Prerequisites:** Node.js >= 18 is required to run `install.sh`. The installer is implemented in TypeScript and executed via `tsx` at runtime.
+**Prerequisites:** Node.js >= 18.18.0 is required to run `install.sh`. The installer is implemented in TypeScript and executed via `tsx` at runtime.
 
 Clone the repository:
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -6,14 +6,16 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 if ! command -v node >/dev/null 2>&1; then
-  printf "${RED}Error: node is not installed or not in PATH. Please install Node.js >= 18.${NC}\n" >&2
+  printf "${RED}Error: node is not installed or not in PATH. Please install Node.js >= 18.18.0.${NC}\n" >&2
   exit 1
 fi
 
 NODE_VERSION=$(node -e 'process.stdout.write(process.versions.node)')
 NODE_MAJOR="${NODE_VERSION%%.*}"
-if [[ "$NODE_MAJOR" -lt 18 ]]; then
-  printf "${RED}Error: Node.js >= 18 required (found ${NODE_VERSION}).${NC}\n" >&2
+NODE_MINOR="${NODE_VERSION#*.}"
+NODE_MINOR="${NODE_MINOR%%.*}"
+if [[ "$NODE_MAJOR" -lt 18 ]] || [[ "$NODE_MAJOR" -eq 18 && "$NODE_MINOR" -lt 18 ]]; then
+  printf "${RED}Error: Node.js >= 18.18.0 required (found ${NODE_VERSION}).${NC}\n" >&2
   exit 1
 fi
 

--- a/installer/claude.ts
+++ b/installer/claude.ts
@@ -3,8 +3,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { c } from "./colors.js";
 import { backupIfExists, installPath } from "./fs-utils.js";
+import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from "./constants.js";
 
-export function installClaudeWhitelist(scriptDir: string, mode: "symlink" | "copy"): void {
+export function installClaudeWhitelist(scriptDir: string, mode: "symlink" | "copy", destRoot: string = os.homedir()): void {
   const claudeSrc = path.join(scriptDir, "claude");
 
   try {
@@ -21,7 +22,7 @@ export function installClaudeWhitelist(scriptDir: string, mode: "symlink" | "cop
     throw err;
   }
 
-  const dotClaudePath = path.join(os.homedir(), ".claude");
+  const dotClaudePath = path.join(destRoot, ".claude");
 
   // Replace legacy full-tree ~/.claude symlink with a real directory
   try {
@@ -38,42 +39,28 @@ export function installClaudeWhitelist(scriptDir: string, mode: "symlink" | "cop
 
   fs.mkdirSync(dotClaudePath, { recursive: true });
 
-  // settings.json
-  const settingsSrc = path.join(claudeSrc, "settings.json");
-  try {
-    const settingsStat = fs.statSync(settingsSrc);
-    if (settingsStat.isFile()) {
-      installPath(settingsSrc, path.join(dotClaudePath, "settings.json"), mode);
-    } else {
-      console.log(c.yellow("Skipping claude/settings.json (not found in repository)"));
-    }
-  } catch (err: unknown) {
-    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      console.log(c.yellow("Skipping claude/settings.json (not found in repository)"));
-    } else {
-      throw err;
-    }
-  }
-
-  // CLAUDE.md
-  const claudeMdSrc = path.join(claudeSrc, "CLAUDE.md");
-  try {
-    const claudeMdStat = fs.statSync(claudeMdSrc);
-    if (claudeMdStat.isFile()) {
-      installPath(claudeMdSrc, path.join(dotClaudePath, "CLAUDE.md"), mode);
-    } else {
-      console.log(c.yellow("Skipping claude/CLAUDE.md (not found in repository)"));
-    }
-  } catch (err: unknown) {
-    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      console.log(c.yellow("Skipping claude/CLAUDE.md (not found in repository)"));
-    } else {
-      throw err;
+  // Standalone files
+  for (const fileName of CLAUDE_WHITELIST_FILES) {
+    const fileSrc = path.join(claudeSrc, fileName);
+    const fileDest = path.join(dotClaudePath, fileName);
+    try {
+      const stat = fs.statSync(fileSrc);
+      if (stat.isFile()) {
+        installPath(fileSrc, fileDest, mode);
+      } else {
+        console.log(c.yellow(`Skipping claude/${fileName} (not a regular file)`));
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        console.log(c.yellow(`Skipping claude/${fileName} (not found in repository)`));
+      } else {
+        throw err;
+      }
     }
   }
 
   // Sub-directories
-  for (const name of ["skills", "agents", "hooks", "commands", "references"]) {
+  for (const name of CLAUDE_WHITELIST_DIRS) {
     const subSrc = path.join(claudeSrc, name);
     try {
       const subStat = fs.statSync(subSrc);

--- a/installer/constants.ts
+++ b/installer/constants.ts
@@ -1,0 +1,31 @@
+import * as path from "node:path";
+
+/** Sub-directories of claude/ installed into ~/.claude */
+export const CLAUDE_WHITELIST_DIRS: readonly string[] = ["skills", "agents", "hooks", "commands", "references"];
+
+/** Standalone files of claude/ installed into ~/.claude */
+export const CLAUDE_WHITELIST_FILES: readonly string[] = ["settings.json", "CLAUDE.md"];
+
+/** Minimum Node.js version required by install.sh (major.minor) */
+export const NODE_MIN_VERSION = "18.18.0";
+
+/** MCP server definition shape */
+export interface McpServerDef {
+  name: string;
+  prereqRelPath?: string; // relative to destRoot (e.g. ".kube/config")
+  addArgs: (destRoot: string) => string[];
+}
+
+/** Registered MCP servers */
+export const MCP_SERVERS: readonly McpServerDef[] = [
+  {
+    name: "kubernetes",
+    prereqRelPath: ".kube/config",
+    addArgs: (destRoot) => [
+      "-s", "user",
+      "-t", "stdio",
+      "-e", `KUBECONFIG=${path.join(destRoot, ".kube", "config")}`,
+      "--", "kubernetes", "npx", "mcp-server-kubernetes@3.4.0",
+    ],
+  },
+];

--- a/installer/fs-utils.ts
+++ b/installer/fs-utils.ts
@@ -46,10 +46,11 @@ export function installDir(
   scriptDir: string,
   srcName: string,
   destName: string,
-  mode: "symlink" | "copy"
+  mode: "symlink" | "copy",
+  destRoot: string = os.homedir()
 ): void {
   const srcPath = path.join(scriptDir, srcName);
-  const destPath = path.join(os.homedir(), destName);
+  const destPath = path.join(destRoot, destName);
 
   try {
     const srcStat = fs.statSync(srcPath);

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -5,6 +5,7 @@ import { installMcpServers } from "./mcp.js";
 import { c } from "./colors.js";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
+import * as os from "node:os";
 
 // Resolve scriptDir = repo root (parent of installer/)
 const __filename = fileURLToPath(import.meta.url);
@@ -21,11 +22,11 @@ try {
   console.log(`Source directory: ${scriptDir}`);
   console.log("");
 
-  installClaudeWhitelist(scriptDir, mode);
-  installDir(scriptDir, "cursor", ".cursor", mode);
+  installClaudeWhitelist(scriptDir, mode, os.homedir());
+  installDir(scriptDir, "cursor", ".cursor", mode, os.homedir());
 
   console.log("");
-  installMcpServers();
+  installMcpServers(os.homedir());
 
   console.log("");
   console.log(c.green("✓ Installation complete!"));

--- a/installer/mcp.ts
+++ b/installer/mcp.ts
@@ -3,27 +3,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { c } from "./colors.js";
+import { MCP_SERVERS, type McpServerDef } from "./constants.js";
 
-interface McpServerDef {
-  name: string;
-  prereqPath?: string;
-  addArgs: string[];
-}
-
-const MCP_SERVERS: McpServerDef[] = [
-  {
-    name: "kubernetes",
-    prereqPath: path.join(os.homedir(), ".kube", "config"),
-    addArgs: [
-      "-s", "user",
-      "-t", "stdio",
-      "-e", `KUBECONFIG=${path.join(os.homedir(), ".kube", "config")}`,
-      "--", "kubernetes", "npx", "mcp-server-kubernetes@3.4.0",
-    ],
-  },
-];
-
-export function installMcpServers(): void {
+export function installMcpServers(destRoot: string = os.homedir()): void {
   // Check claude CLI availability
   try {
     execFileSync("claude", ["--version"], { stdio: "pipe" });
@@ -45,14 +27,14 @@ export function installMcpServers(): void {
     }
 
     // Check prereq
-    if (server.prereqPath !== undefined) {
+    if (server.prereqRelPath !== undefined) {
       try {
-        fs.statSync(server.prereqPath);
+        fs.statSync(path.join(destRoot, server.prereqRelPath));
       } catch (err: unknown) {
         if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
           console.log(
             c.yellow(
-              `Warning: ${server.prereqPath} not found -- ${server.name} MCP will fail until this file is created`
+              `Warning: ${path.join(destRoot, server.prereqRelPath)} not found -- ${server.name} MCP will fail until this file is created`
             )
           );
         }
@@ -61,7 +43,7 @@ export function installMcpServers(): void {
 
     // Add the server
     try {
-      execFileSync("claude", ["mcp", "add", ...server.addArgs], { stdio: "pipe" });
+      execFileSync("claude", ["mcp", "add", ...server.addArgs(destRoot)], { stdio: "pipe" });
       console.log(c.green(`MCP server '${server.name}' added`));
     } catch {
       console.log(c.red(`Failed to add MCP server '${server.name}'`));

--- a/installer/test/claude.test.ts
+++ b/installer/test/claude.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { installClaudeWhitelist } from "../claude.js";
+import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from "../constants.js";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-test-"));
+
+// Build a fake source tree: tmpDir/claude/ with all whitelisted items
+function buildFakeClaudeSrc(base: string, include: string[] = [...CLAUDE_WHITELIST_FILES, ...CLAUDE_WHITELIST_DIRS]) {
+  const claudeSrc = path.join(base, "claude");
+  fs.mkdirSync(claudeSrc, { recursive: true });
+  for (const name of include) {
+    const p = path.join(claudeSrc, name);
+    if (CLAUDE_WHITELIST_FILES.includes(name)) {
+      fs.writeFileSync(p, `fake ${name}`);
+    } else {
+      fs.mkdirSync(p, { recursive: true });
+    }
+  }
+  return base;
+}
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+describe("installClaudeWhitelist", () => {
+  it("installs all whitelisted items into destRoot/.claude", () => {
+    const src = path.join(tmpDir, "full-install-src");
+    const dest = path.join(tmpDir, "full-install-dest");
+    buildFakeClaudeSrc(src);
+    installClaudeWhitelist(src, "symlink", dest);
+    const dotClaude = path.join(dest, ".claude");
+    for (const name of CLAUDE_WHITELIST_FILES) {
+      assert.ok(fs.existsSync(path.join(dotClaude, name)), `${name} should be installed`);
+    }
+    for (const name of CLAUDE_WHITELIST_DIRS) {
+      assert.ok(fs.existsSync(path.join(dotClaude, name)), `${name}/ should be installed`);
+    }
+  });
+
+  it("skips missing items without throwing", () => {
+    const src = path.join(tmpDir, "partial-install-src");
+    const dest = path.join(tmpDir, "partial-install-dest");
+    // Only include a subset
+    buildFakeClaudeSrc(src, ["settings.json", "skills"]);
+    assert.doesNotThrow(() => installClaudeWhitelist(src, "symlink", dest));
+    const dotClaude = path.join(dest, ".claude");
+    assert.ok(fs.existsSync(path.join(dotClaude, "settings.json")));
+    assert.ok(fs.existsSync(path.join(dotClaude, "skills")));
+    assert.ok(!fs.existsSync(path.join(dotClaude, "CLAUDE.md")));
+  });
+
+  it("backs up a legacy symlink at destRoot/.claude and replaces with real directory", () => {
+    const src = path.join(tmpDir, "legacy-src");
+    const dest = path.join(tmpDir, "legacy-dest");
+    buildFakeClaudeSrc(src, ["settings.json"]);
+    fs.mkdirSync(dest, { recursive: true });
+    // Create a legacy symlink at dest/.claude pointing somewhere (live target)
+    const legacyTarget = path.join(tmpDir, "legacy-target");
+    fs.mkdirSync(legacyTarget);
+    const dotClaude = path.join(dest, ".claude");
+    fs.symlinkSync(legacyTarget, dotClaude);
+    assert.ok(fs.lstatSync(dotClaude).isSymbolicLink(), "setup: should be a symlink");
+    installClaudeWhitelist(src, "symlink", dest);
+    // The symlink should have been backed up
+    const backups = fs.readdirSync(dest).filter(f => f.startsWith(".claude.backup."));
+    assert.strictEqual(backups.length, 1, "legacy symlink should be backed up");
+    // And replaced with a real directory
+    assert.ok(fs.lstatSync(dotClaude).isDirectory(), "should now be a real directory");
+  });
+});

--- a/installer/test/cli.test.ts
+++ b/installer/test/cli.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs } from "../cli.js";
+
+class ExitSentinel extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+describe("parseArgs", () => {
+  it("returns symlink mode with no args", () => {
+    const result = parseArgs([]);
+    assert.deepStrictEqual(result, { mode: "symlink" });
+  });
+
+  it("returns copy mode with --copy", () => {
+    const result = parseArgs(["--copy"]);
+    assert.deepStrictEqual(result, { mode: "copy" });
+  });
+
+  it("exits 1 on unknown flag", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    assert.throws(
+      () => parseArgs(["--bogus"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 1
+    );
+  });
+
+  it("exits 0 on --help", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    // Also mock console.log to suppress output during tests
+    mock.method(console, "log", () => {});
+    assert.throws(
+      () => parseArgs(["--help"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 0
+    );
+  });
+
+  it("exits 0 on -h alias", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    mock.method(console, "log", () => {});
+    assert.throws(
+      () => parseArgs(["-h"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 0
+    );
+  });
+});

--- a/installer/test/colors.test.ts
+++ b/installer/test/colors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as childProcess from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// colors.ts reads NO_COLOR at module load time (const noColor = Boolean(process.env["NO_COLOR"])).
+// Testing both branches in the same process is not reliably possible.
+// We use child_process.execFileSync to run a small inline script in a fresh process
+// with and without NO_COLOR set.
+
+const __filename = fileURLToPath(import.meta.url);
+const installerDir = path.dirname(path.dirname(__filename));
+
+function runColorCheck(colorName: string, noColor: boolean): string {
+  const script = `
+    import { c } from "${path.join(installerDir, "colors.js")}";
+    process.stdout.write(c.${colorName}("hello"));
+  `;
+  const env = { ...process.env };
+  if (noColor) {
+    env["NO_COLOR"] = "1";
+  } else {
+    delete env["NO_COLOR"];
+  }
+  return childProcess.execFileSync(
+    process.execPath,
+    ["--input-type=module", "--import", "tsx/esm"],
+    { input: script, env, encoding: "utf8" }
+  );
+}
+
+describe("colors", () => {
+  it("wraps text in ANSI codes when NO_COLOR is unset", () => {
+    const output = runColorCheck("red", false);
+    assert.ok(output.includes("\x1b[0;31m"), "should contain red ANSI code");
+    assert.ok(output.includes("hello"));
+  });
+
+  it("returns plain text when NO_COLOR=1", () => {
+    const output = runColorCheck("red", true);
+    assert.ok(!output.includes("\x1b["), "should not contain any ANSI escape codes");
+    assert.strictEqual(output, "hello");
+  });
+});

--- a/installer/test/fs-utils.test.ts
+++ b/installer/test/fs-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { backupIfExists, installPath, installDir } from "../fs-utils.js";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-test-"));
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+describe("backupIfExists", () => {
+  it("renames an existing file", () => {
+    const target = path.join(tmpDir, "backup-file.txt");
+    fs.writeFileSync(target, "hello");
+    backupIfExists(target);
+    assert.ok(!fs.existsSync(target), "original path should be gone");
+    const backups = fs.readdirSync(tmpDir).filter(f => f.startsWith("backup-file.txt.backup."));
+    assert.strictEqual(backups.length, 1);
+  });
+
+  it("renames an existing directory", () => {
+    const target = path.join(tmpDir, "backup-dir");
+    fs.mkdirSync(target);
+    backupIfExists(target);
+    assert.ok(!fs.existsSync(target));
+    const backups = fs.readdirSync(tmpDir).filter(f => f.startsWith("backup-dir.backup."));
+    assert.strictEqual(backups.length, 1);
+  });
+
+  it("is a no-op for a non-existent path", () => {
+    const target = path.join(tmpDir, "does-not-exist");
+    assert.doesNotThrow(() => backupIfExists(target));
+    assert.ok(!fs.existsSync(target));
+  });
+
+  it("silently skips a dangling symlink (known limitation: statSync follows symlinks)", () => {
+    // KNOWN LIMITATION: backupIfExists uses fs.statSync which follows symlinks.
+    // For a dangling symlink (target does not exist), statSync throws ENOENT and
+    // the function returns without backing up or removing the symlink.
+    // A future fix should switch to lstatSync to detect and back up dangling symlinks.
+    const linkPath = path.join(tmpDir, "dangling-link");
+    fs.symlinkSync(path.join(tmpDir, "nonexistent-target"), linkPath);
+    backupIfExists(linkPath);
+    // The dangling symlink should still be present (was not backed up)
+    const lstat = fs.lstatSync(linkPath);
+    assert.ok(lstat.isSymbolicLink(), "dangling symlink should remain untouched");
+  });
+});
+
+describe("installPath (symlink mode)", () => {
+  it("creates a symlink pointing to the absolute src path", () => {
+    const src = path.join(tmpDir, "src-file.txt");
+    const dest = path.join(tmpDir, "dest-symlink.txt");
+    fs.writeFileSync(src, "content");
+    installPath(src, dest, "symlink");
+    const lstat = fs.lstatSync(dest);
+    assert.ok(lstat.isSymbolicLink());
+    assert.strictEqual(fs.readlinkSync(dest), path.resolve(src));
+  });
+
+  it("backs up existing symlink on second call and creates new one", () => {
+    const src = path.join(tmpDir, "src-for-second-call.txt");
+    const dest = path.join(tmpDir, "dest-second-call.txt");
+    fs.writeFileSync(src, "v2");
+    installPath(src, dest, "symlink");
+    installPath(src, dest, "symlink");
+    const backups = fs.readdirSync(tmpDir).filter(f => f.startsWith("dest-second-call.txt.backup."));
+    assert.strictEqual(backups.length, 1);
+    assert.ok(fs.lstatSync(dest).isSymbolicLink());
+  });
+});
+
+describe("installPath (copy mode)", () => {
+  it("recursively copies a directory", () => {
+    const srcDir = path.join(tmpDir, "copy-src");
+    const destDir = path.join(tmpDir, "copy-dest");
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, "nested.txt"), "nested");
+    installPath(srcDir, destDir, "copy");
+    assert.ok(fs.existsSync(path.join(destDir, "nested.txt")));
+  });
+
+  it("backs up existing copy on second call", () => {
+    const srcDir = path.join(tmpDir, "copy-src2");
+    const destDir = path.join(tmpDir, "copy-dest2");
+    fs.mkdirSync(srcDir);
+    installPath(srcDir, destDir, "copy");
+    installPath(srcDir, destDir, "copy");
+    const backups = fs.readdirSync(tmpDir).filter(f => f.startsWith("copy-dest2.backup."));
+    assert.strictEqual(backups.length, 1);
+  });
+});
+
+describe("installDir", () => {
+  it("skips when source directory does not exist", () => {
+    const destPath = path.join(tmpDir, ".nonexistent-dest");
+    installDir(tmpDir, "nonexistent-src", ".nonexistent-dest", "symlink", tmpDir);
+    assert.ok(!fs.existsSync(destPath), "dest should not be created when src is missing");
+  });
+
+  it("installs when source directory exists", () => {
+    const srcDir = path.join(tmpDir, "real-src");
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, "file.txt"), "data");
+    installDir(tmpDir, "real-src", ".real-dest", "symlink", tmpDir);
+    const destPath = path.join(tmpDir, ".real-dest");
+    assert.ok(fs.lstatSync(destPath).isSymbolicLink());
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typescript": "latest"
   },
   "scripts": {
-    "setup": "tsx installer/main.ts"
+    "setup": "tsx installer/main.ts",
+    "test": "node --import tsx/esm --test 'installer/test/**/*.test.ts'"
   }
 }


### PR DESCRIPTION
Moves all hardcoded installer values (`CLAUDE_WHITELIST_DIRS`, `CLAUDE_WHITELIST_FILES`, `MCP_SERVERS`, `NODE_MIN_VERSION`) into a new `installer/constants.ts` module, making them a single source of truth. Adds a `destRoot` parameter to `installClaudeWhitelist`, `installDir`, and `installMcpServers` (defaulting to `os.homedir()`) so tests can inject a temp directory.

Introduces a `node:test` + `node:assert` test suite (20 tests, 4 files) covering `fs-utils`, `claude`, `cli`, and `colors`. Tests use `fs.mkdtempSync` for isolation and clean up after themselves. Tightens the minimum Node.js version to `>= 18.18.0` (required for the `--import` flag used by the test runner).

Run tests with `npm test`.