### PR TITLE
refactor(installer): extract mcp server config to mcp-servers.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,93 @@ Copies the same whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/
 
 ### Automatic MCP Server Setup
 
-The installer automatically configures user-scoped MCP (Model Context Protocol) servers in `~/.claude.json` when the `claude` CLI is available. Currently, it sets up:
+The installer automatically configures user-scoped MCP (Model Context Protocol) servers in `~/.claude.json` when the `claude` CLI is available. Server definitions are read from a declarative `mcp-servers.json` file at the repository root, allowing you to add or modify servers without editing TypeScript code.
+
+Currently configured servers:
 
 - **Kubernetes MCP Server** (`mcp-server-kubernetes@3.4.0`) - Provides read-only access to Kubernetes cluster information via your `~/.kube/config`. Gracefully skips setup if `~/.kube/config` doesn't exist yet (useful for fresh machine setup). The server is only added if not already configured, making the installation idempotent.
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
+
+#### MCP Server Configuration Format
+
+Server definitions are stored in `/mcp-servers.json` (repository root) using a declarative JSON schema. This allows configuration changes without modifying the installer code.
+
+##### JSON Schema
+
+```json
+{
+  "servers": [
+    {
+      "name": "kubernetes",
+      "scope": "user",
+      "transport": "stdio",
+      "prereq": "$HOME/.kube/config",
+      "env": { "KUBECONFIG": "$HOME/.kube/config" },
+      "command": "npx",
+      "args": ["mcp-server-kubernetes@3.4.0"]
+    }
+  ]
+}
+```
+
+**Field Reference:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique server identifier (e.g., `"kubernetes"`) |
+| `scope` | string | Yes | Installation scope; must be `"user"` or `"project"` |
+| `transport` | string | Yes | Communication protocol; must be one of: `"stdio"`, `"sse"`, `"streamable-http"` |
+| `prereq` | string | No | Path to check before installation (e.g., `"$HOME/.kube/config"`); advisory warning only—installation proceeds if missing |
+| `env` | object | No | Environment variables passed to the MCP server (keys and values support variable expansion) |
+| `command` | string | Yes | Executable name (e.g., `"npx"`, `"node"`) |
+| `args` | array | No | Command arguments passed to the executable (each element supports variable expansion) |
+
+##### Variable Expansion
+
+`$HOME`, `${HOME}`, `$USER`, and `${USER}` are automatically expanded using safe string replacement (no shell evaluation):
+
+- `$HOME` and `${HOME}` expand to the user's home directory
+- `$USER` and `${USER}` expand to the current system username
+
+This applies to:
+- `prereq` paths: `"$HOME/.kube/config"` → `/Users/alice/.kube/config`
+- `env` values: `"KUBECONFIG=$HOME/.kube/config"` → `"KUBECONFIG=/Users/alice/.kube/config"`
+- `args` elements: `["mcp-server-$USER"]` → `["mcp-server-alice"]`
+
+##### Adding a New MCP Server
+
+1. Edit `/mcp-servers.json` and add a new entry to the `servers` array:
+
+   ```json
+   {
+     "name": "my-server",
+     "scope": "user",
+     "transport": "stdio",
+     "command": "my-server",
+     "args": ["--flag"]
+   }
+   ```
+
+2. Re-run the installer:
+
+   ```bash
+   ./install.sh
+   ```
+
+   The new server is added to `~/.claude.json` if the `claude` CLI is available. If the server is already configured, it is skipped (idempotent operation).
+
+##### Graceful Degradation
+
+If `/mcp-servers.json` is missing from the repository:
+- The installer logs a yellow warning: `"Warning: mcp-servers.json not found -- skipping MCP server setup"`
+- No error is raised
+- Installation continues normally
+
+If the file exists but contains malformed JSON or schema violations:
+- A clear error message is logged, including the invalid field and server name
+- Installation stops with a non-zero exit code
+- Examples: `"scope" must be 'user' or 'project'`, `"transport" must be 'stdio', 'sse', or 'streamable-http'`
 
 ## Updating
 

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -26,7 +26,7 @@ try {
   installDir(scriptDir, "cursor", ".cursor", mode, os.homedir());
 
   console.log("");
-  installMcpServers(os.homedir());
+  installMcpServers(scriptDir);
 
   console.log("");
   console.log(c.green("✓ Installation complete!"));

--- a/installer/mcp.ts
+++ b/installer/mcp.ts
@@ -3,9 +3,131 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { c } from "./colors.js";
-import { MCP_SERVERS, type McpServerDef } from "./constants.js";
 
-export function installMcpServers(destRoot: string = os.homedir()): void {
+interface McpServerConfig {
+  name: string;
+  scope: "user" | "project";
+  transport: "stdio" | "sse" | "streamable-http";
+  prereq?: string;
+  env?: Record<string, string>;
+  command: string;
+  args?: string[];
+}
+
+interface McpServersFile {
+  servers: McpServerConfig[];
+}
+
+/**
+ * Expands $HOME and ${HOME} and $USER and ${USER} in a string value using
+ * os.homedir() and os.userInfo().username respectively. No eval or shell
+ * is used.
+ */
+export function expandVars(value: string): string {
+  const home = os.homedir();
+  const user = os.userInfo().username;
+  return value
+    .replace(/\$\{HOME\}|\$HOME(?!\w)/g, home)
+    .replace(/\$\{USER\}|\$USER(?!\w)/g, user);
+}
+
+/**
+ * Reads and validates mcp-servers.json from the given repo root directory.
+ * - Returns [] if the file does not exist (graceful degradation).
+ * - Throws on malformed JSON or schema violations.
+ */
+export function loadMcpServers(repoRoot: string): McpServerConfig[] {
+  const filePath = path.join(repoRoot, "mcp-servers.json");
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log(c.yellow("Warning: mcp-servers.json not found -- skipping MCP server setup"));
+      return [];
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`mcp-servers.json: invalid JSON in ${filePath}`);
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("servers" in parsed)
+  ) {
+    throw new Error("mcp-servers.json: missing top-level 'servers' field");
+  }
+
+  const { servers } = parsed as McpServersFile;
+
+  if (!Array.isArray(servers)) {
+    throw new Error("mcp-servers.json: 'servers' must be an array");
+  }
+
+  const validScopes = ["user", "project"] as const;
+  const validTransports = ["stdio", "sse", "streamable-http"] as const;
+
+  for (const entry of (servers as unknown[])) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error("mcp-servers.json: each server entry must be an object");
+    }
+    const server = entry as Record<string, unknown>;
+
+    if (typeof server["name"] !== "string" || server["name"].trim() === "") {
+      throw new Error("mcp-servers.json: server entry missing required non-empty 'name' field");
+    }
+    const name = server["name"] as string;
+
+    if (!validScopes.includes(server["scope"] as (typeof validScopes)[number])) {
+      throw new Error(
+        `mcp-servers.json: server '${name}' has invalid scope '${String(server["scope"])}' -- must be 'user' or 'project'`
+      );
+    }
+
+    if (!validTransports.includes(server["transport"] as (typeof validTransports)[number])) {
+      throw new Error(
+        `mcp-servers.json: server '${name}' has invalid transport '${String(server["transport"])}' -- must be 'stdio', 'sse', or 'streamable-http'`
+      );
+    }
+
+    if (typeof server["command"] !== "string" || server["command"].trim() === "") {
+      throw new Error(
+        `mcp-servers.json: server '${name}' missing required non-empty 'command' field`
+      );
+    }
+  }
+
+  return servers as McpServerConfig[];
+}
+
+/**
+ * Constructs the argument array for `claude mcp add` from a structured server
+ * config. Variable expansion is applied to env values and args entries.
+ */
+export function buildAddArgs(server: McpServerConfig): string[] {
+  const result: string[] = ["-s", server.scope, "-t", server.transport];
+
+  for (const [key, value] of Object.entries(server.env ?? {})) {
+    result.push("-e", `${key}=${expandVars(value)}`);
+  }
+
+  result.push("--", server.name, server.command);
+
+  for (const arg of server.args ?? []) {
+    result.push(expandVars(arg));
+  }
+
+  return result;
+}
+
+export function installMcpServers(repoRoot: string): void {
   // Check claude CLI availability
   try {
     execFileSync("claude", ["--version"], { stdio: "pipe" });
@@ -16,7 +138,7 @@ export function installMcpServers(destRoot: string = os.homedir()): void {
 
   console.log(c.blue("Configuring MCP servers (user scope)..."));
 
-  for (const server of MCP_SERVERS) {
+  for (const server of loadMcpServers(repoRoot)) {
     // Check if already configured
     try {
       execFileSync("claude", ["mcp", "get", server.name], { stdio: "pipe" });
@@ -27,14 +149,15 @@ export function installMcpServers(destRoot: string = os.homedir()): void {
     }
 
     // Check prereq
-    if (server.prereqRelPath !== undefined) {
+    if (server.prereq !== undefined) {
       try {
-        fs.statSync(path.join(destRoot, server.prereqRelPath));
+        fs.statSync(expandVars(server.prereq));
       } catch (err: unknown) {
         if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+          // prereq check is advisory: warn if missing, but always proceed to add
           console.log(
             c.yellow(
-              `Warning: ${path.join(destRoot, server.prereqRelPath)} not found -- ${server.name} MCP will fail until this file is created`
+              `Warning: ${expandVars(server.prereq)} not found -- ${server.name} MCP will fail until this file is created`
             )
           );
         }
@@ -43,7 +166,7 @@ export function installMcpServers(destRoot: string = os.homedir()): void {
 
     // Add the server
     try {
-      execFileSync("claude", ["mcp", "add", ...server.addArgs(destRoot)], { stdio: "pipe" });
+      execFileSync("claude", ["mcp", "add", ...buildAddArgs(server)], { stdio: "pipe" });
       console.log(c.green(`MCP server '${server.name}' added`));
     } catch {
       console.log(c.red(`Failed to add MCP server '${server.name}'`));

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -1,0 +1,13 @@
+{
+  "servers": [
+    {
+      "name": "kubernetes",
+      "scope": "user",
+      "transport": "stdio",
+      "prereq": "$HOME/.kube/config",
+      "env": { "KUBECONFIG": "$HOME/.kube/config" },
+      "command": "npx",
+      "args": ["mcp-server-kubernetes@3.4.0"]
+    }
+  ]
+}


### PR DESCRIPTION
The MCP server list was hardcoded inside `mcp.ts`, making it impossible to add, remove, or adjust servers without editing TypeScript source. This PR moves that configuration to a declarative `mcp-servers.json` file that the installer reads at runtime, with `$HOME`/`$USER` variable expansion baked in. Any server entry the installer does not recognise is skipped gracefully rather than causing a hard failure, so the file can evolve without coordinating installer releases. The net effect is that operators can customise their MCP server set by editing JSON rather than touching the installer source.