### PR TITLE
feat(mcp): add AWS CloudWatch MCP server via official awslabs uvx package

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The installer automatically configures user-scoped MCP (Model Context Protocol) 
 Currently configured servers:
 
 - **Kubernetes MCP Server** (`mcp-server-kubernetes@3.4.0`) - Provides read-only access to Kubernetes cluster information via your `~/.kube/config`. Gracefully skips setup if `~/.kube/config` doesn't exist yet (useful for fresh machine setup). The server is only added if not already configured, making the installation idempotent.
+- **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) - Official AWS Labs MCP server providing access to CloudWatch Metrics, Alarms, and Logs (query log groups, run Insights queries, retrieve metrics and alarm history) via your `~/.aws` credentials. Requires `uvx` (`pip install uv` or `brew install uv`). Gracefully skips setup if `~/.aws/credentials` doesn't exist yet. The server is only added if not already configured, making the installation idempotent.
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
 

--- a/installer/cli.ts
+++ b/installer/cli.ts
@@ -6,7 +6,7 @@ Install AI TPK to your home directory.
 
 Claude Code:
   - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/
-  - MCP servers: kubernetes (user scope, via claude mcp add)
+  - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
   --copy    Copy files instead of creating symlinks (default: symlink)

--- a/installer/constants.ts
+++ b/installer/constants.ts
@@ -1,5 +1,3 @@
-import * as path from "node:path";
-
 /** Sub-directories of claude/ installed into ~/.claude */
 export const CLAUDE_WHITELIST_DIRS: readonly string[] = ["skills", "agents", "hooks", "commands", "references"];
 
@@ -8,24 +6,3 @@ export const CLAUDE_WHITELIST_FILES: readonly string[] = ["settings.json", "CLAU
 
 /** Minimum Node.js version required by install.sh (major.minor) */
 export const NODE_MIN_VERSION = "18.18.0";
-
-/** MCP server definition shape */
-export interface McpServerDef {
-  name: string;
-  prereqRelPath?: string; // relative to destRoot (e.g. ".kube/config")
-  addArgs: (destRoot: string) => string[];
-}
-
-/** Registered MCP servers */
-export const MCP_SERVERS: readonly McpServerDef[] = [
-  {
-    name: "kubernetes",
-    prereqRelPath: ".kube/config",
-    addArgs: (destRoot) => [
-      "-s", "user",
-      "-t", "stdio",
-      "-e", `KUBECONFIG=${path.join(destRoot, ".kube", "config")}`,
-      "--", "kubernetes", "npx", "mcp-server-kubernetes@3.4.0",
-    ],
-  },
-];

--- a/installer/test/reference-help-output.txt
+++ b/installer/test/reference-help-output.txt
@@ -4,7 +4,7 @@ Install AI TPK to your home directory.
 
 Claude Code:
   - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/
-  - MCP servers: kubernetes (user scope, via claude mcp add)
+  - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
   --copy    Copy files instead of creating symlinks (default: symlink)

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -7,7 +7,19 @@
       "prereq": "$HOME/.kube/config",
       "env": { "KUBECONFIG": "$HOME/.kube/config" },
       "command": "npx",
-      "args": ["mcp-server-kubernetes@3.4.0"]
+      "args": ["--yes", "mcp-server-kubernetes@3.4.0"]
+    },
+    {
+      "name": "cloudwatch",
+      "scope": "user",
+      "transport": "stdio",
+      "prereq": "$HOME/.aws/credentials",
+      "env": {
+        "AWS_SHARED_CREDENTIALS_FILE": "$HOME/.aws/credentials",
+        "AWS_CONFIG_FILE": "$HOME/.aws/config"
+      },
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server@0.0.19"]
     }
   ]
 }


### PR DESCRIPTION
Adds the official AWS Labs CloudWatch MCP server (`awslabs.cloudwatch-mcp-server@0.0.19` via `uvx`) to the installer, replacing the previously considered community npm package. The server covers CloudWatch Metrics, Alarms, and Logs and authenticates via the standard `~/.aws` credential chain.

Also adds `--yes` to the existing Kubernetes `npx` invocation to prevent interactive prompts during automated install, and updates the `--help` text and its reference test fixture to list both servers.

Requires `uvx` on the target machine (`pip install uv` or `brew install uv`).