### PR TITLE
chore(mcp): add grafana mcp server entry

### DIFF
--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -20,6 +20,17 @@
       },
       "command": "uvx",
       "args": ["awslabs.cloudwatch-mcp-server@0.0.19"]
+    },
+    {
+      "name": "grafana",
+      "scope": "user",
+      "transport": "stdio",
+      "env": {
+        "GRAFANA_URL": "$GRAFANA_URL",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "$GRAFANA_SERVICE_ACCOUNT_TOKEN"
+      },
+      "command": "uvx",
+      "args": ["mcp-grafana"]
     }
   ]
 }


### PR DESCRIPTION
Adds the official `mcp-grafana` server to `mcp-servers.json`, enabling Claude to query Grafana dashboards, datasources, and alerts via MCP.

The Grafana instance URL and service account token are read from `$GRAFANA_URL` and `$GRAFANA_SERVICE_ACCOUNT_TOKEN` environment variables, so users can switch between self-hosted instances without touching the config file.