### PR TITLE
feat(hooks): add lefthook pre-push validation and validate-before-pr skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ plans/
 # Node.js
 node_modules/
 dist/
+
+# Lefthook local overrides (machine-specific, not for version control)
+lefthook-local.yml

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Configuration files:
 - `.oxlintrc.json` — Linting rules (correctness and suspicious errors denied, perf warnings)
 - `.oxfmtrc.json` — Formatting options (2 spaces, double quotes, semicolons)
 
+**Pre-Push Hook:**
+
+The project uses **Lefthook** to automatically validate code quality before pushing. When you run `npm install`, the `prepare` script installs git hooks that run on every push (if JS/TS files have changed):
+
+- `npm run lint` — Checks for code quality issues
+- `npm run format:check` — Verifies code formatting
+
+If either check fails, the push is blocked. Run `npm run format` to auto-fix formatting issues, then try pushing again. These same checks are enforced in CI on all pull requests.
+
+Lefthook config: `lefthook.yml` (glob patterns scope checks to JS/TS files only)
+
 ## Installation
 
 **Prerequisites:** Node.js >= 18.18.0 is required to run `install.sh`. The installer is implemented in TypeScript and executed via `tsx` at runtime.
@@ -262,7 +273,11 @@ See [docs/AGENTS.md](/docs/AGENTS.md) for the complete agent catalog, [docs/WORK
 Everwise now includes Scout, a selective transcript analysis capability. When chronicle analysis identifies specific anomalies—REJECT verdicts, repeated REVISE loops (3+), rapid re-invocations (<60 seconds), unresolved escalations, or anomalous agent routing—Everwise can dynamically discover and read raw Claude Code subagent JSONL transcripts to understand what actually happened beyond the chronicle's metadata. Scout uses a two-pass reading algorithm with a 20-line cap per transcript and a 3-transcript budget per session, keeping context consumption bounded while providing ground-truth behavioral evidence. This capability works in full graceful degradation mode when `~/.claude/` data is unavailable.
 
 ### Skills Library
-Reusable capabilities including skill creation, commit message generation, and pull request automation. The `commit-message-guide` and `open-pull-request` skills are mandated globally via `CLAUDE.md` for all projects.
+Reusable capabilities including skill creation, commit message generation, and pull request automation. Three mandatory global skills via `CLAUDE.md`:
+
+- **`commit-message-guide`** — Enforces conventional commit format for all git commits
+- **`validate-before-pr`** — Runs lint and format checks before opening a PR; gates PR creation on passing checks
+- **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation
 
 ### Slash Commands
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -14,6 +14,10 @@ ALL git commits must follow the `commit-message-guide` skill. Conventional commi
 
 ALL pull requests and merge requests must be created using the `open-pull-request` skill. No other PR creation method is allowed.
 
+### Validate Before PR
+
+The `validate-before-pr` skill MUST be invoked before any PR creation. It runs lint and format checks as a mandatory gate. Only after both checks pass may the `open-pull-request` skill be invoked. No exceptions.
+
 ## Bash Command Style
 
 - Never chain commands using `&&` or `;`. Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.

--- a/claude/skills/validate-before-pr/SKILL.md
+++ b/claude/skills/validate-before-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: validate-before-pr
+description: REQUIRED before opening any pull request. Always invoke when about to open a PR, create a merge request, push for review, or run pre-PR checks. Runs lint and format checks as a gate before PR creation.
+TRIGGER: user asks to open a PR or merge request, asks to push for review, mentions pre-PR validation, or calls the open-pull-request skill.
+DO NOT SKIP: applies to all PR creation regardless of repository or context.
+---
+
+# Validate Before PR
+
+This skill is a mandatory gate that runs lint and format checks before any pull request is opened. It must be invoked before the `open-pull-request` skill. If either check fails, the PR must not be opened until the failures are resolved.
+
+## IMPORTANT: When This Skill Applies
+
+This skill is **mandatory** for:
+- Any request to open, create, or draft a pull request or merge request
+- Any workflow that leads to invoking the `open-pull-request` skill
+- Requests to "push for review" or "push and open a PR"
+- Pre-PR validation checks requested explicitly
+
+**Do not** open a PR through any means without running this skill first.
+
+## Steps
+
+Each check must be run as a **separate, standalone Bash call**. Do not chain commands with `&&` or `;` — this is required by the bash-style rule.
+
+### Step 1 — Run lint
+
+Run the following as a standalone Bash call:
+
+```
+npm run lint
+```
+
+- If lint **passes** (exit code 0): proceed to Step 2.
+- If lint **fails** (non-zero exit): stop immediately. Do not proceed to format check or PR creation. Report the full lint output to the user and request that the errors be fixed before retrying.
+
+### Step 2 — Run format check
+
+Run the following as a standalone Bash call:
+
+```
+npm run format:check
+```
+
+- If format check **passes** (exit code 0): proceed to Step 3.
+- If format check **fails** (non-zero exit): stop immediately. Do not open the PR. Report the full output to the user. Suggest running `npm run format` to auto-fix formatting issues, then re-running `npm run format:check` to confirm.
+
+### Step 3 — Proceed to open-pull-request
+
+Only after **both** Step 1 and Step 2 pass may you proceed to the `open-pull-request` skill to create the pull request.
+
+## Fail-Fast Behavior
+
+- Stop on the first failure. Do not run Step 2 if Step 1 failed.
+- Report which check failed and include its full output so the user can act on it.
+- Do not attempt to open the PR until all checks pass.
+
+## Relationship to Other Skills
+
+- **open-pull-request**: This skill gates entry to `open-pull-request`. It must always be invoked first. After both lint and format:check pass, hand off to `open-pull-request` to complete the PR workflow.
+- **commit-message-guide**: Commits must follow conventional commit format. This skill does not replace that requirement — it adds a validation layer on top of it.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-push:
+  commands:
+    lint:
+      glob: "**/*.{js,jsx,ts,tsx,mjs,cjs}"
+      run: npm run lint
+    format-check:
+      glob: "**/*.{js,jsx,ts,tsx,mjs,cjs}"
+      run: npm run format:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "ai-tpk",
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "lefthook": "^2.1.4",
         "oxfmt": "^0.43.0",
         "oxlint": "^1.58.0",
         "tsx": "latest",
@@ -1180,6 +1181,169 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.4.tgz",
+      "integrity": "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.4",
+        "lefthook-darwin-x64": "2.1.4",
+        "lefthook-freebsd-arm64": "2.1.4",
+        "lefthook-freebsd-x64": "2.1.4",
+        "lefthook-linux-arm64": "2.1.4",
+        "lefthook-linux-x64": "2.1.4",
+        "lefthook-openbsd-arm64": "2.1.4",
+        "lefthook-openbsd-x64": "2.1.4",
+        "lefthook-windows-arm64": "2.1.4",
+        "lefthook-windows-x64": "2.1.4"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.4.tgz",
+      "integrity": "sha512-BUAAE9+rUrjr39a+wH/1zHmGrDdwUQ2Yq/z6BQbM/yUb9qtXBRcQ5eOXxApqWW177VhGBpX31aqIlfAZ5Q7wzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.4.tgz",
+      "integrity": "sha512-K1ncIMEe84fe+ss1hQNO7rIvqiKy2TJvTFpkypvqFodT7mJXZn7GLKYTIXdIuyPAYthRa9DwFnx5uMoHwD2F1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.4.tgz",
+      "integrity": "sha512-PVUhjOhVN71YaYsVdQyNbFZ4a2jFB2Tg5hKrrn9kaWpx64aLz/XivLjwr8sEuTaP1GRlEWBpW6Bhrcsyo39qFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.4.tgz",
+      "integrity": "sha512-ZWV9o/LeyWNEBoVO+BhLqxH3rGTba05nkm5NvMjEFSj7LbUNUDbQmupZwtHl1OMGJO66eZP0CalzRfUH6GhBxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.4.tgz",
+      "integrity": "sha512-iWN0pGnTjrIvNIcSI1vQBJXUbybTqJ5CLMniPA0olabMXQfPDrdMKVQe+mgdwHK+E3/Y0H0ZNL3lnOj6Sk6szA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.4.tgz",
+      "integrity": "sha512-96bTBE/JdYgqWYAJDh+/e/0MaxJ25XTOAk7iy/fKoZ1ugf6S0W9bEFbnCFNooXOcxNVTan5xWKfcjJmPIKtsJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.4.tgz",
+      "integrity": "sha512-oYUoK6AIJNEr9lUSpIMj6g7sWzotvtc3ryw7yoOyQM6uqmEduw73URV/qGoUcm4nqqmR93ZalZwR2r3Gd61zvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.4.tgz",
+      "integrity": "sha512-i/Dv9Jcm68y9cggr1PhyUhOabBGP9+hzQPoiyOhKks7y9qrJl79A8XfG6LHekSuYc2VpiSu5wdnnrE1cj2nfTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.4.tgz",
+      "integrity": "sha512-hSww7z+QX4YMnw2lK7DMrs3+w7NtxksuMKOkCKGyxUAC/0m1LAICo0ZbtdDtZ7agxRQQQ/SEbzFRhU5ysNcbjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.4.tgz",
+      "integrity": "sha512-eE68LwnogxwcPgGsbVGPGxmghyMGmU9SdGwcc+uhGnUxPz1jL89oECMWJNc36zjVK24umNeDAzB5KA3lw1MuWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/oxfmt": {
       "version": "0.43.0",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "type": "module",
   "devDependencies": {
     "@types/node": "^25.5.2",
+    "lefthook": "^2.1.4",
     "oxfmt": "^0.43.0",
     "oxlint": "^1.58.0",
     "tsx": "latest",
     "typescript": "latest"
   },
   "scripts": {
+    "prepare": "lefthook install",
     "setup": "tsx installer/main.ts",
     "test": "node --import tsx/esm --test 'installer/test/**/*.test.ts'",
     "lint": "oxlint installer/",


### PR DESCRIPTION
Adds a Lefthook pre-push hook that gates every push on lint and format:check passing, so broken code cannot reach the remote. The validate-before-pr Claude skill is introduced as a mandatory gate before PR creation, ensuring both checks are verified in CI-equivalent conditions. Contributors gain Lefthook automatically via the new `prepare` npm script on install. README is updated to document both the hook and the skill for new contributors.