### PR TITLE
fix(mcp): replace env var expansion with bash wrapper script approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Currently configured servers:
 
 - **Kubernetes MCP Server** (`mcp-server-kubernetes@3.4.0`) - Provides read-only access to Kubernetes cluster information via your `~/.kube/config`. Gracefully skips setup if `~/.kube/config` doesn't exist yet (useful for fresh machine setup). The server is only added if not already configured, making the installation idempotent.
 - **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) - Official AWS Labs MCP server providing access to CloudWatch Metrics, Alarms, and Logs (query log groups, run Insights queries, retrieve metrics and alarm history) via your `~/.aws` credentials. Requires `uvx` (`pip install uv` or `brew install uv`). Gracefully skips setup if `~/.aws/credentials` doesn't exist yet. The server is only added if not already configured, making the installation idempotent.
+- **Grafana MCP Server** (`mcp-grafana`) - Access to Grafana dashboards, datasources, metrics, logs, incidents, and more. Uses a wrapper script (`wrappers/mcp-grafana.sh`) that requires `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` to be exported in your shell environment. Self-healing re-registration: the installer removes and re-adds this server each invocation to fix any prior broken configurations.
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
 
@@ -140,6 +141,8 @@ MCP servers are available in all repositories once configured. For detailed info
 Server definitions are stored in `/mcp-servers.json` (repository root) using a declarative JSON schema. This allows configuration changes without modifying the installer code.
 
 ##### JSON Schema
+
+**Command-based server example:**
 
 ```json
 {
@@ -151,7 +154,22 @@ Server definitions are stored in `/mcp-servers.json` (repository root) using a d
       "prereq": "$HOME/.kube/config",
       "env": { "KUBECONFIG": "$HOME/.kube/config" },
       "command": "npx",
-      "args": ["mcp-server-kubernetes@3.4.0"]
+      "args": ["--yes", "mcp-server-kubernetes@3.4.0"]
+    }
+  ]
+}
+```
+
+**Wrapper-based server example:**
+
+```json
+{
+  "servers": [
+    {
+      "name": "grafana",
+      "scope": "user",
+      "transport": "stdio",
+      "wrapper": "wrappers/mcp-grafana.sh"
     }
   ]
 }
@@ -161,13 +179,16 @@ Server definitions are stored in `/mcp-servers.json` (repository root) using a d
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Unique server identifier (e.g., `"kubernetes"`) |
+| `name` | string | Yes | Unique server identifier (e.g., `"kubernetes"`, `"grafana"`) |
 | `scope` | string | Yes | Installation scope; must be `"user"` or `"project"` |
 | `transport` | string | Yes | Communication protocol; must be one of: `"stdio"`, `"sse"`, `"streamable-http"` |
 | `prereq` | string | No | Path to check before installation (e.g., `"$HOME/.kube/config"`); advisory warning only—installation proceeds if missing |
-| `env` | object | No | Environment variables passed to the MCP server (keys and values support variable expansion) |
-| `command` | string | Yes | Executable name (e.g., `"npx"`, `"node"`) |
-| `args` | array | No | Command arguments passed to the executable (each element supports variable expansion) |
+| `command` | string | Conditional | Executable name (e.g., `"npx"`, `"node"`). Required if `wrapper` is not present; mutually exclusive with `wrapper` |
+| `args` | array | No | Command arguments passed to the executable (each element supports variable expansion). Only used with `command` |
+| `env` | object | No | Environment variables passed to the MCP server (keys and values support variable expansion). Only used with `command` |
+| `wrapper` | string | Conditional | Relative path to a shell script (e.g., `"wrappers/mcp-grafana.sh"`) that wraps the server command and resolves runtime environment variables. Required if `command` is not present; mutually exclusive with `command` |
+
+**Key constraint:** A server must have exactly one of `command` or `wrapper`, never both.
 
 ##### Variable Expansion
 
@@ -178,10 +199,92 @@ Server definitions are stored in `/mcp-servers.json` (repository root) using a d
 
 This applies to:
 - `prereq` paths: `"$HOME/.kube/config"` → `/Users/alice/.kube/config`
-- `env` values: `"KUBECONFIG=$HOME/.kube/config"` → `"KUBECONFIG=/Users/alice/.kube/config"`
-- `args` elements: `["mcp-server-$USER"]` → `["mcp-server-alice"]`
+- `env` values (command-based servers only): `"KUBECONFIG=$HOME/.kube/config"` → `"KUBECONFIG=/Users/alice/.kube/config"`
+- `args` elements (command-based servers only): `["mcp-server-$USER"]` → `["mcp-server-alice"]`
+
+**Note:** Wrapper scripts resolve their own environment variables at runtime using bash variable syntax (e.g., `${VAR:?}`), not the installer's `expandVars` function.
+
+##### Command-Based Servers vs. Wrapper-Based Servers
+
+**Command-based servers** use the `command` and `args` fields to directly invoke an executable with environment variables passed via `-e` flags:
+
+```json
+{
+  "name": "kubernetes",
+  "scope": "user",
+  "transport": "stdio",
+  "command": "npx",
+  "args": ["--yes", "mcp-server-kubernetes@3.4.0"],
+  "env": { "KUBECONFIG": "$HOME/.kube/config" }
+}
+```
+
+**Wrapper-based servers** use a shell script (`wrapper` field) that resolves runtime environment variables at invocation time. This is necessary when environment variables contain user-specific values (like API keys or service URLs) that cannot be determined at install time:
+
+```json
+{
+  "name": "grafana",
+  "scope": "user",
+  "transport": "stdio",
+  "wrapper": "wrappers/mcp-grafana.sh"
+}
+```
+
+**When to use a wrapper:**
+- The MCP server requires environment variables that depend on user configuration (e.g., `GRAFANA_URL`, API tokens)
+- Variables must be resolved from the shell environment at MCP invocation time, not at installer time
+- The `command` and `wrapper` fields are mutually exclusive—a server must use one or the other, never both
+
+##### Wrapper Script Convention
+
+Wrapper scripts live in the `wrappers/` directory and follow this pattern:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate required environment variables with clear error messages
+: "${REQUIRED_VAR:?Error: REQUIRED_VAR is not set}"
+
+# Execute the real MCP server command, preserving stdin/stdout/stderr
+exec uvx mcp-server-name "$@"
+```
+
+**Key requirements:**
+- **Shebang:** `#!/usr/bin/env bash` (required for `claude mcp add` to recognize it as executable)
+- **Strict mode:** `set -euo pipefail` (fail fast on errors or undefined variables)
+- **Variable validation:** Use `${VAR:?Error message}` syntax to validate required variables exist and provide clear failure messages
+- **Exec:** Use `exec` to replace the shell process (required for stdio transport to work correctly)
+- **Arguments:** Preserve `"$@"` to forward any arguments from `claude mcp add` to the wrapped command
+- **Executable bit:** Preserved in git via `git update-index --chmod=+x` or by committing from a Unix system
+
+**Example: Grafana MCP Server**
+
+The `wrappers/mcp-grafana.sh` script validates `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` at runtime:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GRAFANA_URL:?Error: GRAFANA_URL is not set}"
+: "${GRAFANA_SERVICE_ACCOUNT_TOKEN:?Error: GRAFANA_SERVICE_ACCOUNT_TOKEN is not set}"
+
+exec uvx mcp-grafana "$@"
+```
+
+Users must export these variables in their shell before invoking Claude:
+
+```bash
+export GRAFANA_URL="https://grafana.example.com"
+export GRAFANA_SERVICE_ACCOUNT_TOKEN="glsa_xxxxxxxxxxxx"
+claude
+```
+
+If either variable is missing, the wrapper fails immediately with a clear error message.
 
 ##### Adding a New MCP Server
+
+**For command-based servers:**
 
 1. Edit `/mcp-servers.json` and add a new entry to the `servers` array:
 
@@ -202,6 +305,45 @@ This applies to:
    ```
 
    The new server is added to `~/.claude.json` if the `claude` CLI is available. If the server is already configured, it is skipped (idempotent operation).
+
+**For wrapper-based servers:**
+
+1. Create a wrapper script in `wrappers/{server-name}.sh`:
+
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+
+   : "${REQUIRED_VAR:?Error: REQUIRED_VAR is not set}"
+
+   exec uvx {server-package} "$@"
+   ```
+
+2. Make the script executable:
+
+   ```bash
+   chmod +x wrappers/{server-name}.sh
+   git update-index --chmod=+x wrappers/{server-name}.sh  # Preserve executable bit in git
+   ```
+
+3. Add an entry to `/mcp-servers.json`:
+
+   ```json
+   {
+     "name": "{server-name}",
+     "scope": "user",
+     "transport": "stdio",
+     "wrapper": "wrappers/{server-name}.sh"
+   }
+   ```
+
+4. Re-run the installer:
+
+   ```bash
+   ./install.sh
+   ```
+
+   For wrapper-based servers, the installer removes and re-adds the server each time (self-healing), so users with prior broken registrations are automatically fixed.
 
 ##### Graceful Degradation
 

--- a/installer/mcp.ts
+++ b/installer/mcp.ts
@@ -10,8 +10,9 @@ interface McpServerConfig {
   transport: "stdio" | "sse" | "streamable-http";
   prereq?: string;
   env?: Record<string, string>;
-  command: string;
+  command?: string;
   args?: string[];
+  wrapper?: string;
 }
 
 interface McpServersFile {
@@ -108,12 +109,22 @@ export function loadMcpServers(repoRoot: string): McpServerConfig[] {
       );
     }
 
-    if (
-      typeof server["command"] !== "string" ||
-      server["command"].trim() === ""
-    ) {
+    const hasWrapper =
+      typeof server["wrapper"] === "string" &&
+      (server["wrapper"] as string).trim() !== "";
+    const hasCommand =
+      typeof server["command"] === "string" &&
+      (server["command"] as string).trim() !== "";
+
+    if (hasWrapper && hasCommand) {
       throw new Error(
-        `mcp-servers.json: server '${name}' missing required non-empty 'command' field`,
+        `mcp-servers.json: server '${name}' must not have both 'wrapper' and 'command' fields`,
+      );
+    }
+
+    if (!hasWrapper && !hasCommand) {
+      throw new Error(
+        `mcp-servers.json: server '${name}' must have either 'wrapper' or 'command' field`,
       );
     }
   }
@@ -124,12 +135,50 @@ export function loadMcpServers(repoRoot: string): McpServerConfig[] {
 /**
  * Constructs the argument array for `claude mcp add` from a structured server
  * config. Variable expansion is applied to env values and args entries.
+ *
+ * For wrapper-based servers, the wrapper script path is resolved to an absolute
+ * path and validated to exist on disk. No `-e` flags are emitted.
  */
-export function buildAddArgs(server: McpServerConfig): string[] {
+export function buildAddArgs(
+  server: McpServerConfig,
+  repoRoot: string,
+): string[] {
+  if (server.wrapper !== undefined) {
+    const absoluteWrapperPath = path.join(repoRoot, server.wrapper);
+    try {
+      fs.statSync(absoluteWrapperPath);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        throw new Error(
+          `Wrapper script not found: ${absoluteWrapperPath} (defined in server '${server.name}')`,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+    return [
+      "-s",
+      server.scope,
+      "-t",
+      server.transport,
+      "--",
+      server.name,
+      absoluteWrapperPath,
+    ];
+  }
+
   const result: string[] = ["-s", server.scope, "-t", server.transport];
 
   for (const [key, value] of Object.entries(server.env ?? {})) {
     result.push("-e", `${key}=${expandVars(value)}`);
+  }
+
+  if (!server.command) {
+    // Should not be reachable: loadMcpServers ensures exactly one of wrapper/command is set.
+    throw new Error(`Server '${server.name}' has no command or wrapper field`);
   }
 
   result.push("--", server.name, server.command);
@@ -153,15 +202,27 @@ export function installMcpServers(repoRoot: string): void {
   console.log(c.blue("Configuring MCP servers (user scope)..."));
 
   for (const server of loadMcpServers(repoRoot)) {
-    // Check if already configured
-    try {
-      execFileSync("claude", ["mcp", "get", server.name], { stdio: "pipe" });
-      console.log(
-        c.green(`MCP server '${server.name}' already configured, skipping`),
-      );
-      continue;
-    } catch {
-      // Not yet configured — proceed
+    if (server.wrapper !== undefined) {
+      // Wrapper-based servers: always remove and re-add to self-heal any prior
+      // broken registration (e.g. from when env vars were passed via -e flags).
+      try {
+        execFileSync("claude", ["mcp", "remove", server.name], {
+          stdio: "pipe",
+        });
+      } catch {
+        // Server was not registered — that is fine, proceed to add
+      }
+    } else {
+      // Command-based servers: skip if already configured
+      try {
+        execFileSync("claude", ["mcp", "get", server.name], { stdio: "pipe" });
+        console.log(
+          c.green(`MCP server '${server.name}' already configured, skipping`),
+        );
+        continue;
+      } catch {
+        // Not yet configured — proceed
+      }
     }
 
     // Check prereq
@@ -185,9 +246,13 @@ export function installMcpServers(repoRoot: string): void {
 
     // Add the server
     try {
-      execFileSync("claude", ["mcp", "add", ...buildAddArgs(server)], {
-        stdio: "pipe",
-      });
+      execFileSync(
+        "claude",
+        ["mcp", "add", ...buildAddArgs(server, repoRoot)],
+        {
+          stdio: "pipe",
+        },
+      );
       console.log(c.green(`MCP server '${server.name}' added`));
     } catch {
       console.log(c.red(`Failed to add MCP server '${server.name}'`));

--- a/installer/test/mcp.test.ts
+++ b/installer/test/mcp.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { expandVars, loadMcpServers, buildAddArgs } from "../mcp.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-mcp-test-"));
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write a minimal mcp-servers.json to a temp repo root and return the
+// path to that root directory.
+// ---------------------------------------------------------------------------
+
+function writeMcpFile(servers: unknown[]): string {
+  const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-"));
+  fs.writeFileSync(
+    path.join(repoRoot, "mcp-servers.json"),
+    JSON.stringify({ servers }),
+    "utf8",
+  );
+  return repoRoot;
+}
+
+// ---------------------------------------------------------------------------
+// expandVars
+// ---------------------------------------------------------------------------
+
+describe("expandVars", () => {
+  it("expands $HOME", () => {
+    const home = os.homedir();
+    assert.strictEqual(expandVars("$HOME/.config"), `${home}/.config`);
+  });
+
+  it("expands ${HOME}", () => {
+    const home = os.homedir();
+    assert.strictEqual(expandVars("${HOME}/.config"), `${home}/.config`);
+  });
+
+  it("expands $USER", () => {
+    const user = os.userInfo().username;
+    assert.strictEqual(expandVars("hello-$USER"), `hello-${user}`);
+  });
+
+  it("expands ${USER}", () => {
+    const user = os.userInfo().username;
+    assert.strictEqual(expandVars("${USER}-name"), `${user}-name`);
+  });
+
+  it("does not expand arbitrary env vars like $GRAFANA_URL", () => {
+    const original = "$GRAFANA_URL";
+    assert.strictEqual(expandVars(original), original);
+  });
+
+  it("leaves a string with no vars unchanged", () => {
+    assert.strictEqual(expandVars("no-vars-here"), "no-vars-here");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadMcpServers — validation
+// ---------------------------------------------------------------------------
+
+describe("loadMcpServers", () => {
+  it("returns [] when mcp-servers.json does not exist", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-empty-"));
+    const result = loadMcpServers(repoRoot);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it("loads a valid command-based entry (no wrapper)", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "kubernetes",
+        scope: "user",
+        transport: "stdio",
+        command: "kubectl",
+        args: ["mcp", "serve"],
+      },
+    ]);
+    const servers = loadMcpServers(repoRoot);
+    assert.strictEqual(servers.length, 1);
+    assert.strictEqual(servers[0]?.name, "kubernetes");
+  });
+
+  it("loads a valid wrapper-based entry (no command)", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "grafana",
+        scope: "user",
+        transport: "stdio",
+        wrapper: "wrappers/mcp-grafana.sh",
+      },
+    ]);
+    const servers = loadMcpServers(repoRoot);
+    assert.strictEqual(servers.length, 1);
+    assert.strictEqual(servers[0]?.name, "grafana");
+  });
+
+  it("throws when entry has both wrapper and command", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "bad-server",
+        scope: "user",
+        transport: "stdio",
+        command: "some-cmd",
+        wrapper: "wrappers/some.sh",
+      },
+    ]);
+    assert.throws(
+      () => loadMcpServers(repoRoot),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("must not have both"),
+    );
+  });
+
+  it("throws when entry has neither wrapper nor command", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "bad-server",
+        scope: "user",
+        transport: "stdio",
+      },
+    ]);
+    assert.throws(
+      () => loadMcpServers(repoRoot),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("must have either"),
+    );
+  });
+
+  it("throws on invalid scope", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "bad-scope",
+        scope: "global",
+        transport: "stdio",
+        command: "some-cmd",
+      },
+    ]);
+    assert.throws(
+      () => loadMcpServers(repoRoot),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("invalid scope"),
+    );
+  });
+
+  it("throws on invalid transport", () => {
+    const repoRoot = writeMcpFile([
+      {
+        name: "bad-transport",
+        scope: "user",
+        transport: "websocket",
+        command: "some-cmd",
+      },
+    ]);
+    assert.throws(
+      () => loadMcpServers(repoRoot),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("invalid transport"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAddArgs — wrapper-based servers
+// ---------------------------------------------------------------------------
+
+describe("buildAddArgs — wrapper-based server", () => {
+  it("returns correct args with absolute wrapper path and no -e flags when wrapper file exists", () => {
+    // Create a real wrapper file so statSync succeeds
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-wrapper-"));
+    const wrappersDir = path.join(repoRoot, "wrappers");
+    fs.mkdirSync(wrappersDir);
+    const wrapperFile = path.join(wrappersDir, "mcp-grafana.sh");
+    fs.writeFileSync(
+      wrapperFile,
+      "#!/usr/bin/env bash\nexec uvx mcp-grafana\n",
+    );
+
+    const server = {
+      name: "grafana",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      wrapper: "wrappers/mcp-grafana.sh",
+    };
+
+    const args = buildAddArgs(server, repoRoot);
+
+    const expectedWrapperPath = path.join(repoRoot, "wrappers/mcp-grafana.sh");
+    assert.deepStrictEqual(args, [
+      "-s",
+      "user",
+      "-t",
+      "stdio",
+      "--",
+      "grafana",
+      expectedWrapperPath,
+    ]);
+
+    // Must not contain any -e flags
+    assert.ok(
+      !args.includes("-e"),
+      "wrapper-based args must not contain -e flags",
+    );
+  });
+
+  it("throws with descriptive error when wrapper file does not exist", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-missing-"));
+
+    const server = {
+      name: "grafana",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      wrapper: "wrappers/mcp-grafana.sh",
+    };
+
+    assert.throws(
+      () => buildAddArgs(server, repoRoot),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          err.message.includes("Wrapper script not found"),
+          `expected "Wrapper script not found" in: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes("grafana"),
+          `expected server name "grafana" in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAddArgs — command-based servers
+// ---------------------------------------------------------------------------
+
+describe("buildAddArgs — command-based server", () => {
+  it("returns correct args with -e flags and command", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-cmd-"));
+
+    const server = {
+      name: "kubernetes",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      command: "kubectl",
+      args: ["mcp", "serve"],
+      env: {
+        KUBECONFIG: "/home/user/.kube/config",
+      },
+    };
+
+    const args = buildAddArgs(server, repoRoot);
+
+    assert.deepStrictEqual(args, [
+      "-s",
+      "user",
+      "-t",
+      "stdio",
+      "-e",
+      "KUBECONFIG=/home/user/.kube/config",
+      "--",
+      "kubernetes",
+      "kubectl",
+      "mcp",
+      "serve",
+    ]);
+  });
+
+  it("expands $HOME in env values", () => {
+    const home = os.homedir();
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-home-"));
+
+    const server = {
+      name: "mytool",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      command: "mytool",
+      env: {
+        CONFIG: "$HOME/.config/mytool",
+      },
+    };
+
+    const args = buildAddArgs(server, repoRoot);
+
+    const envFlag = args.find((a) => a.startsWith("CONFIG="));
+    assert.ok(envFlag !== undefined, "should have CONFIG= env flag");
+    assert.strictEqual(envFlag, `CONFIG=${home}/.config/mytool`);
+  });
+
+  it("appends args after the command", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-args-"));
+
+    const server = {
+      name: "cloudwatch",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      command: "uvx",
+      args: ["awslabs.amazon-cloudwatch-mcp-server@latest"],
+    };
+
+    const args = buildAddArgs(server, repoRoot);
+
+    // Command and args appear after "--"
+    const separatorIndex = args.indexOf("--");
+    assert.ok(separatorIndex !== -1, 'args must contain "--" separator');
+    const afterSep = args.slice(separatorIndex + 1);
+    assert.deepStrictEqual(afterSep, [
+      "cloudwatch",
+      "uvx",
+      "awslabs.amazon-cloudwatch-mcp-server@latest",
+    ]);
+  });
+
+  it("handles a server with no env and no args", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-noenv-"));
+
+    const server = {
+      name: "simple",
+      scope: "project" as const,
+      transport: "sse" as const,
+      command: "simple-cmd",
+    };
+
+    const args = buildAddArgs(server, repoRoot);
+
+    assert.deepStrictEqual(args, [
+      "-s",
+      "project",
+      "-t",
+      "sse",
+      "--",
+      "simple",
+      "simple-cmd",
+    ]);
+  });
+});

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -25,12 +25,7 @@
       "name": "grafana",
       "scope": "user",
       "transport": "stdio",
-      "env": {
-        "GRAFANA_URL": "$GRAFANA_URL",
-        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "$GRAFANA_SERVICE_ACCOUNT_TOKEN"
-      },
-      "command": "uvx",
-      "args": ["mcp-grafana"]
+      "wrapper": "wrappers/mcp-grafana.sh"
     }
   ]
 }

--- a/wrappers/mcp-grafana.sh
+++ b/wrappers/mcp-grafana.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GRAFANA_URL:?Error: GRAFANA_URL is not set}"
+: "${GRAFANA_SERVICE_ACCOUNT_TOKEN:?Error: GRAFANA_SERVICE_ACCOUNT_TOKEN is not set}"
+
+exec uvx mcp-grafana "$@"


### PR DESCRIPTION
Runtime env vars like `$GRAFANA_URL` were silently passed as literal strings to `claude mcp add -e` because `expandVars` only knew about `$HOME` and `$USER`. This broke the Grafana MCP server for all users.

Replaces the broken env passthrough with a bash wrapper script (`wrappers/mcp-grafana.sh`) that resolves env vars from the shell environment at MCP server invocation time. Secrets stay out of Claude's config, token rotation works without re-running the installer, and the wrapper uses `${VAR:?}` for clear fail-fast errors when vars are unset.

The installer now supports a `wrapper` field in `mcp-servers.json` (mutually exclusive with `command`), validates wrapper file existence at install time, and self-heals existing broken registrations by removing and re-adding wrapper-based servers automatically.