### PR TITLE
fix(sync-pr): use fully-qualified refs/remotes/origin/main refspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | Command | Purpose |
 |---------|---------|
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
-| `/sync-pr` | Rebases the current PR branch onto `origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
+| `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
 
 ## Agent Orchestration Workflow

--- a/claude/commands/sync-pr.md
+++ b/claude/commands/sync-pr.md
@@ -51,9 +51,11 @@ Run: `git status --porcelain`
 If the output is non-empty, abort immediately and tell the user: "Working tree is dirty. Commit
 or stash your changes before syncing."
 
-## Step 7 — Rebase onto origin/main [write operation — delegate to Bitsmith]
+## Step 7 — Rebase onto refs/remotes/origin/main [write operation — delegate to Bitsmith]
 
-Delegate to Bitsmith to run: `git rebase origin/main`
+Delegate to Bitsmith to run: `git rebase refs/remotes/origin/main`
+
+(`refs/remotes/origin/main` is used instead of the `origin/main` shorthand to avoid resolution ambiguity when a local branch named `main` exists.)
 
 (Per DM delegation policy, write operations must not be executed directly by the DM.)
 
@@ -61,7 +63,7 @@ If the rebase exits with a non-zero status (indicating conflicts or another fail
 Bitsmith to run the following as a separate standalone call: `git rebase --abort`
 
 Then abort the entire command and tell the user: "Rebase conflicts detected. The rebase has been
-aborted. Resolve conflicts manually by running `git rebase origin/main`, fixing each conflict, and
+aborted. Resolve conflicts manually by running `git rebase refs/remotes/origin/main`, fixing each conflict, and
 running `git rebase --continue`."
 
 ## Step 8 — Force-push and report success [write operation — delegate to Bitsmith]


### PR DESCRIPTION
The `origin/main` shorthand in the rebase step resolves through git's ref lookup order and can be shadowed by a local branch named `main`, causing the rebase to use a stale ref even after `git fetch`. Replacing it with `refs/remotes/origin/main` makes the refspec fully-qualified and unambiguous. Updates the step heading, git command, inline explanation, user-facing conflict message, and README description.