### PR TITLE
feat(hooks): add dim session banner at start, compact, and stop events

### DIFF
--- a/claude/hooks/session-banner.sh
+++ b/claude/hooks/session-banner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# session-banner.sh — dim session name reminder at natural pause points
+
+SESSIONS_DIR="$HOME/.claude/sessions"
+
+# Read hook payload from stdin
+STDIN_DATA=""
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+[ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
+
+# Extract session_id
+SESSION_ID=""
+if command -v jq &>/dev/null; then
+  SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+fi
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+
+# Look up session name
+NAME="unnamed"
+if [ -f "$SESSIONS_DIR/$SESSION_ID" ]; then
+  NAME=$(cat "$SESSIONS_DIR/$SESSION_ID")
+fi
+
+# Print dim banner to terminal
+printf '\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
+
+exit 0

--- a/claude/hooks/session-banner.sh
+++ b/claude/hooks/session-banner.sh
@@ -14,11 +14,13 @@ if command -v jq &>/dev/null; then
   SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
 fi
 [ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+SESSION_ID="${SESSION_ID//[\/.]/_}"
 
 # Look up session name
 NAME="unnamed"
 if [ -f "$SESSIONS_DIR/$SESSION_ID" ]; then
   NAME=$(cat "$SESSIONS_DIR/$SESSION_ID")
+  NAME=$(printf '%s' "$NAME" | tr -cd '[:print:]')
 fi
 
 # Print dim banner to terminal

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# session-start.sh — fired on SessionStart
+# Saves session name and prints a dim banner to identify the terminal
+
+SESSIONS_DIR="$HOME/.claude/sessions"
+mkdir -p "$SESSIONS_DIR"
+
+# Read hook payload from stdin
+STDIN_DATA=""
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+[ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
+
+# Extract session_id
+SESSION_ID=""
+if command -v jq &>/dev/null; then
+  SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+fi
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+
+# Persist session name (from env var set at launch: SESSION_NAME=dm-1 claude ...)
+NAME="${SESSION_NAME:-unnamed}"
+echo "$NAME" > "$SESSIONS_DIR/$SESSION_ID"
+
+# Print dim banner to terminal
+printf '\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
+
+exit 0

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -16,9 +16,11 @@ if command -v jq &>/dev/null; then
   SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
 fi
 [ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+SESSION_ID="${SESSION_ID//[\/.]/_}"
 
 # Persist session name (from env var set at launch: SESSION_NAME=dm-1 claude ...)
 NAME="${SESSION_NAME:-unnamed}"
+NAME=$(printf '%s' "$NAME" | tr -cd '[:print:]')
 echo "$NAME" > "$SESSIONS_DIR/$SESSION_ID"
 
 # Print dim banner to terminal

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -65,12 +65,34 @@
     "mcp__kubernetes__ping"
   ],
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash claude/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/talekeeper-capture.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash claude/hooks/session-banner.sh",
             "timeout": 5
           }
         ]
@@ -84,6 +106,15 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/talekeeper-enrich.sh",
             "timeout": 60
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash claude/hooks/session-banner.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
Adds two project-local hook scripts that print a faint ANSI session name banner at natural pause points (session start, context compaction, session end) to help distinguish concurrent Claude terminal sessions.\n\nLaunch with `SESSION_NAME=dm-1 claude --agent dungeonmaster` — the name persists per session_id so multiple concurrent sessions do not interfere with each other. Session ID and name are sanitized before use.