### PR TITLE
feat(installer): remove symlink mode, add recover and clean-backups scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository maintains user-scope configuration for:
 
 ## Purpose
 
-Keep AI tool configurations version-controlled and portable across machines. These configs are meant to be copied or symlinked to your user home directory (`~/.claude/`, `~/.cursor/`, etc.).
+Keep AI tool configurations version-controlled and portable across machines. These configs are copied to your user home directory (`~/.claude/`, `~/.cursor/`, etc.).
 
 ## Structure
 
@@ -44,9 +44,9 @@ The installation logic is implemented in TypeScript under the `installer/` direc
 
 - `installer/constants.ts` — Single source of truth for whitelisted Claude paths, MCP server definitions, and Node.js version requirements
 - `installer/main.ts` — Main entrypoint; orchestrates the install workflow
-- `installer/cli.ts` — CLI argument parser (handles `--copy`, `--help`/`-h`)
+- `installer/cli.ts` — CLI argument parser (handles `--help`/`-h`)
 - `installer/colors.ts` — ANSI color output helper
-- `installer/fs-utils.ts` — Filesystem utilities (backup, symlink, copy operations)
+- `installer/fs-utils.ts` — Filesystem utilities (backup and copy operations)
 - `installer/claude.ts` — Claude config whitelist installer
 - `installer/mcp.ts` — MCP server setup
 
@@ -103,26 +103,18 @@ cd ai-tpk
 
 Run the installation script:
 
-### Option 1: Symlinks (Recommended)
 ```bash
 ./install.sh
 ```
 
-Creates symbolic links for the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) and for `~/.cursor/` when `cursor/` exists. Changes sync automatically with the repository.
+Copies the whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) into `~/.claude/` and `~/.cursor/` when present.
 
 Alternatively, if you have Node.js installed:
 ```bash
 npm run setup
 ```
 
-### Option 2: Copy Files
-```bash
-./install.sh --copy
-```
-
-Copies the same whitelisted Claude paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) into `~/.claude/` and `~/.cursor/` when present. Manual sync required (see Updating below).
-
-**Note:** The installer automatically backs up any existing configurations with a timestamp.
+**Note:** The installer automatically backs up any existing configurations with a timestamp before overwriting them.
 
 ### Automatic MCP Server Setup
 
@@ -373,10 +365,30 @@ All checks must pass before a PR can be merged. If CI fails, review the error me
 ```bash
 cd ai-tpk
 git pull
+./install.sh
 ```
 
-**With symlinks:** Changes take effect immediately.
-**With copy:** Re-run `./install.sh --copy` after pulling updates.
+Re-running the installer after `git pull` copies the latest configurations into place. Any files already present are backed up with a timestamp before being replaced.
+
+## Recovering Backups
+
+The installer automatically creates timestamped backups (e.g., `settings.json.backup.20260407_143022`) before overwriting any existing files. To browse and restore a backup interactively:
+
+```bash
+./recover.sh
+```
+
+The script scans `~/.claude` and `~/.cursor` for machine-generated backups, lists them newest-first with their original paths and human-readable timestamps, and prompts you to select one by number. If the original path currently exists, it is itself backed up before the selected backup is moved into place.
+
+## Cleaning Up Old Backups
+
+Over time the installer may accumulate multiple timestamped backups for the same file. `clean-backups.sh` removes all but the most recent backup for each original path, keeping your `~/.claude` and `~/.cursor` directories tidy.
+
+```bash
+./clean-backups.sh
+```
+
+The script scans the same directories as `recover.sh` (`~/.claude` and `~/.cursor`), groups backups by their original file path, and shows a summary of everything it would delete before asking for confirmation. Original paths that have only one backup are left untouched. Nothing is deleted unless you explicitly confirm with `y`.
 
 ## Features
 

--- a/clean-backups.sh
+++ b/clean-backups.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+SCAN_DIRS=("$HOME/.claude" "$HOME/.cursor")
+BACKUP_PATTERN='*.backup.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]'
+
+# Collect all backup files sorted ascending (oldest first).
+# Within each original-path group the last entry will be the newest,
+# because the timestamp suffix sorts lexicographically.
+all_backups=()
+while IFS= read -r line; do
+  all_backups+=("$line")
+done < <(
+  for dir in "${SCAN_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+      find "$dir" -maxdepth 2 -name "$BACKUP_PATTERN" 2>/dev/null
+    fi
+  done | sort
+)
+
+if [ "${#all_backups[@]}" -eq 0 ]; then
+  printf "${YELLOW}No backups found in ${SCAN_DIRS[*]}.${NC}\n"
+  exit 0
+fi
+
+# Group files by their original path (strip .backup.YYYYMMDD_HHMMSS suffix).
+# Walk through the sorted list; whenever the original path changes we know
+# the previous group is complete.  Within a group every entry except the
+# last (newest) is a candidate for deletion.
+to_delete=()
+
+current_original=""
+current_group=()
+
+flush_group() {
+  local count="${#current_group[@]}"
+  if [ "$count" -ge 2 ]; then
+    # Keep the last element (newest); mark the rest for deletion.
+    local i
+    for (( i = 0; i < count - 1; i++ )); do
+      to_delete+=("${current_group[$i]}")
+    done
+  fi
+}
+
+for backup in "${all_backups[@]}"; do
+  original="${backup%.backup.*}"
+  if [ "$original" != "$current_original" ]; then
+    # New group — flush the previous one first.
+    if [ -n "$current_original" ]; then
+      flush_group
+    fi
+    current_original="$original"
+    current_group=("$backup")
+  else
+    current_group+=("$backup")
+  fi
+done
+# Flush the final group.
+if [ -n "$current_original" ]; then
+  flush_group
+fi
+
+if [ "${#to_delete[@]}" -eq 0 ]; then
+  printf "${GREEN}Nothing to clean — every original path has at most one backup.${NC}\n"
+  exit 0
+fi
+
+printf "${YELLOW}The following backup files will be deleted (oldest copies only):${NC}\n\n"
+for f in "${to_delete[@]}"; do
+  printf "  %s\n" "$f"
+done
+printf "\n%d file(s) will be deleted.\n\n" "${#to_delete[@]}"
+
+printf "${YELLOW}Proceed? [y/N]:${NC} "
+read -r input || true
+
+case "$input" in
+  y|Y)
+    ;;
+  *)
+    printf "${YELLOW}Aborted. Nothing deleted.${NC}\n"
+    exit 0
+    ;;
+esac
+
+for f in "${to_delete[@]}"; do
+  rm "$f"
+  printf "${GREEN}Deleted:${NC} %s\n" "$f"
+done
+
+printf "\n${GREEN}Done. %d backup file(s) removed.${NC}\n" "${#to_delete[@]}"

--- a/installer/claude.ts
+++ b/installer/claude.ts
@@ -2,12 +2,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { c } from "./colors.js";
-import { backupIfExists, installPath } from "./fs-utils.js";
+import { installPath } from "./fs-utils.js";
 import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from "./constants.js";
 
 export function installClaudeWhitelist(
   scriptDir: string,
-  mode: "symlink" | "copy",
   destRoot: string = os.homedir(),
 ): void {
   const claudeSrc = path.join(scriptDir, "claude");
@@ -31,23 +30,6 @@ export function installClaudeWhitelist(
 
   const dotClaudePath = path.join(destRoot, ".claude");
 
-  // Replace legacy full-tree ~/.claude symlink with a real directory
-  try {
-    const stat = fs.lstatSync(dotClaudePath);
-    if (stat.isSymbolicLink()) {
-      backupIfExists(dotClaudePath);
-    }
-  } catch (err: unknown) {
-    if (
-      !(
-        err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT"
-      )
-    ) {
-      throw err;
-    }
-    // Does not exist — nothing to do before mkdir
-  }
-
   fs.mkdirSync(dotClaudePath, { recursive: true });
 
   // Standalone files
@@ -57,7 +39,7 @@ export function installClaudeWhitelist(
     try {
       const stat = fs.statSync(fileSrc);
       if (stat.isFile()) {
-        installPath(fileSrc, fileDest, mode);
+        installPath(fileSrc, fileDest);
       } else {
         console.log(
           c.yellow(`Skipping claude/${fileName} (not a regular file)`),
@@ -83,7 +65,7 @@ export function installClaudeWhitelist(
     try {
       const subStat = fs.statSync(subSrc);
       if (subStat.isDirectory()) {
-        installPath(subSrc, path.join(dotClaudePath, name), mode);
+        installPath(subSrc, path.join(dotClaudePath, name));
       } else {
         console.log(
           c.yellow(`Skipping claude/${name}/ (not found in repository)`),

--- a/installer/cli.ts
+++ b/installer/cli.ts
@@ -1,6 +1,6 @@
 import { c } from "./colors.js";
 
-const USAGE = `Usage: ./install.sh [--copy]
+const USAGE = `Usage: ./install.sh
 
 Install AI TPK to your home directory.
 
@@ -9,21 +9,11 @@ Claude Code:
   - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
-  --copy    Copy files instead of creating symlinks (default: symlink)
-  --help    Show this help message
+  --help    Show this help message`;
 
-Installation methods:
-  symlink (default): Creates symbolic links. Changes sync automatically.
-  copy:              Copies files. Manual sync required with git pull.`;
-
-export function parseArgs(argv: string[]): { mode: "symlink" | "copy" } {
-  let mode: "symlink" | "copy" = "symlink";
-
+export function parseArgs(argv: string[]): void {
   for (const flag of argv) {
     switch (flag) {
-      case "--copy":
-        mode = "copy";
-        break;
       case "--help":
       case "-h":
         console.log(USAGE);
@@ -37,6 +27,4 @@ export function parseArgs(argv: string[]): { mode: "symlink" | "copy" } {
         process.exit(1);
     }
   }
-
-  return { mode };
 }

--- a/installer/fs-utils.ts
+++ b/installer/fs-utils.ts
@@ -33,28 +33,17 @@ export function backupIfExists(targetPath: string): void {
   fs.renameSync(targetPath, backupPath);
 }
 
-export function installPath(
-  src: string,
-  dest: string,
-  mode: "symlink" | "copy",
-): void {
+export function installPath(src: string, dest: string): void {
   backupIfExists(dest);
 
-  if (mode === "symlink") {
-    const absSrc = path.resolve(src);
-    console.log(c.green(`Creating symlink: ${dest} -> ${src}`));
-    fs.symlinkSync(absSrc, dest);
-  } else {
-    console.log(c.green(`Copying: ${src} -> ${dest}`));
-    fs.cpSync(src, dest, { recursive: true });
-  }
+  console.log(c.green(`Copying: ${src} -> ${dest}`));
+  fs.cpSync(src, dest, { recursive: true });
 }
 
 export function installDir(
   scriptDir: string,
   srcName: string,
   destName: string,
-  mode: "symlink" | "copy",
   destRoot: string = os.homedir(),
 ): void {
   const srcPath = path.join(scriptDir, srcName);
@@ -77,5 +66,5 @@ export function installDir(
     throw err;
   }
 
-  installPath(srcPath, destPath, mode);
+  installPath(srcPath, destPath);
 }

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -13,17 +13,16 @@ const installerDir = path.dirname(__filename);
 const scriptDir = path.dirname(installerDir);
 
 try {
-  const { mode } = parseArgs(process.argv.slice(2));
+  parseArgs(process.argv.slice(2));
 
   console.log(c.blue("AI TPK Installer"));
   console.log(c.blue("====================="));
   console.log("");
-  console.log(`Installation method: ${c.green(mode)}`);
   console.log(`Source directory: ${scriptDir}`);
   console.log("");
 
-  installClaudeWhitelist(scriptDir, mode, os.homedir());
-  installDir(scriptDir, "cursor", ".cursor", mode, os.homedir());
+  installClaudeWhitelist(scriptDir, os.homedir());
+  installDir(scriptDir, "cursor", ".cursor", os.homedir());
 
   console.log("");
   installMcpServers(scriptDir);
@@ -32,15 +31,8 @@ try {
   console.log(c.green("✓ Installation complete!"));
   console.log("");
 
-  if (mode === "symlink") {
-    console.log("Your configurations are now symlinked to this repository.");
-    console.log(`To update: cd ${scriptDir} && git pull`);
-  } else {
-    console.log("Your configurations have been copied from this repository.");
-    console.log(
-      `To update: cd ${scriptDir} && git pull && ./install.sh --copy`,
-    );
-  }
+  console.log("Your configurations have been copied from this repository.");
+  console.log(`To update: cd ${scriptDir} && git pull && ./install.sh`);
 } catch (e: unknown) {
   const msg = e instanceof Error ? e.message : String(e);
   process.stderr.write(`\x1b[0;31mError: ${msg}\x1b[0m\n`);

--- a/installer/test/claude.test.ts
+++ b/installer/test/claude.test.ts
@@ -35,7 +35,7 @@ describe("installClaudeWhitelist", () => {
     const src = path.join(tmpDir, "full-install-src");
     const dest = path.join(tmpDir, "full-install-dest");
     buildFakeClaudeSrc(src);
-    installClaudeWhitelist(src, "symlink", dest);
+    installClaudeWhitelist(src, dest);
     const dotClaude = path.join(dest, ".claude");
     for (const name of CLAUDE_WHITELIST_FILES) {
       assert.ok(
@@ -56,37 +56,10 @@ describe("installClaudeWhitelist", () => {
     const dest = path.join(tmpDir, "partial-install-dest");
     // Only include a subset
     buildFakeClaudeSrc(src, ["settings.json", "skills"]);
-    assert.doesNotThrow(() => installClaudeWhitelist(src, "symlink", dest));
+    assert.doesNotThrow(() => installClaudeWhitelist(src, dest));
     const dotClaude = path.join(dest, ".claude");
     assert.ok(fs.existsSync(path.join(dotClaude, "settings.json")));
     assert.ok(fs.existsSync(path.join(dotClaude, "skills")));
     assert.ok(!fs.existsSync(path.join(dotClaude, "CLAUDE.md")));
-  });
-
-  it("backs up a legacy symlink at destRoot/.claude and replaces with real directory", () => {
-    const src = path.join(tmpDir, "legacy-src");
-    const dest = path.join(tmpDir, "legacy-dest");
-    buildFakeClaudeSrc(src, ["settings.json"]);
-    fs.mkdirSync(dest, { recursive: true });
-    // Create a legacy symlink at dest/.claude pointing somewhere (live target)
-    const legacyTarget = path.join(tmpDir, "legacy-target");
-    fs.mkdirSync(legacyTarget);
-    const dotClaude = path.join(dest, ".claude");
-    fs.symlinkSync(legacyTarget, dotClaude);
-    assert.ok(
-      fs.lstatSync(dotClaude).isSymbolicLink(),
-      "setup: should be a symlink",
-    );
-    installClaudeWhitelist(src, "symlink", dest);
-    // The symlink should have been backed up
-    const backups = fs
-      .readdirSync(dest)
-      .filter((f) => f.startsWith(".claude.backup."));
-    assert.strictEqual(backups.length, 1, "legacy symlink should be backed up");
-    // And replaced with a real directory
-    assert.ok(
-      fs.lstatSync(dotClaude).isDirectory(),
-      "should now be a real directory",
-    );
   });
 });

--- a/installer/test/cli.test.ts
+++ b/installer/test/cli.test.ts
@@ -13,14 +13,8 @@ afterEach(() => {
 });
 
 describe("parseArgs", () => {
-  it("returns symlink mode with no args", () => {
-    const result = parseArgs([]);
-    assert.deepStrictEqual(result, { mode: "symlink" });
-  });
-
-  it("returns copy mode with --copy", () => {
-    const result = parseArgs(["--copy"]);
-    assert.deepStrictEqual(result, { mode: "copy" });
+  it("returns without error when no args given", () => {
+    assert.doesNotThrow(() => parseArgs([]));
   });
 
   it("exits 1 on unknown flag", () => {

--- a/installer/test/fs-utils.test.ts
+++ b/installer/test/fs-utils.test.ts
@@ -39,56 +39,15 @@ describe("backupIfExists", () => {
     assert.doesNotThrow(() => backupIfExists(target));
     assert.ok(!fs.existsSync(target));
   });
-
-  it("silently skips a dangling symlink (known limitation: statSync follows symlinks)", () => {
-    // KNOWN LIMITATION: backupIfExists uses fs.statSync which follows symlinks.
-    // For a dangling symlink (target does not exist), statSync throws ENOENT and
-    // the function returns without backing up or removing the symlink.
-    // A future fix should switch to lstatSync to detect and back up dangling symlinks.
-    const linkPath = path.join(tmpDir, "dangling-link");
-    fs.symlinkSync(path.join(tmpDir, "nonexistent-target"), linkPath);
-    backupIfExists(linkPath);
-    // The dangling symlink should still be present (was not backed up)
-    const lstat = fs.lstatSync(linkPath);
-    assert.ok(
-      lstat.isSymbolicLink(),
-      "dangling symlink should remain untouched",
-    );
-  });
 });
 
-describe("installPath (symlink mode)", () => {
-  it("creates a symlink pointing to the absolute src path", () => {
-    const src = path.join(tmpDir, "src-file.txt");
-    const dest = path.join(tmpDir, "dest-symlink.txt");
-    fs.writeFileSync(src, "content");
-    installPath(src, dest, "symlink");
-    const lstat = fs.lstatSync(dest);
-    assert.ok(lstat.isSymbolicLink());
-    assert.strictEqual(fs.readlinkSync(dest), path.resolve(src));
-  });
-
-  it("backs up existing symlink on second call and creates new one", () => {
-    const src = path.join(tmpDir, "src-for-second-call.txt");
-    const dest = path.join(tmpDir, "dest-second-call.txt");
-    fs.writeFileSync(src, "v2");
-    installPath(src, dest, "symlink");
-    installPath(src, dest, "symlink");
-    const backups = fs
-      .readdirSync(tmpDir)
-      .filter((f) => f.startsWith("dest-second-call.txt.backup."));
-    assert.strictEqual(backups.length, 1);
-    assert.ok(fs.lstatSync(dest).isSymbolicLink());
-  });
-});
-
-describe("installPath (copy mode)", () => {
+describe("installPath", () => {
   it("recursively copies a directory", () => {
     const srcDir = path.join(tmpDir, "copy-src");
     const destDir = path.join(tmpDir, "copy-dest");
     fs.mkdirSync(srcDir);
     fs.writeFileSync(path.join(srcDir, "nested.txt"), "nested");
-    installPath(srcDir, destDir, "copy");
+    installPath(srcDir, destDir);
     assert.ok(fs.existsSync(path.join(destDir, "nested.txt")));
   });
 
@@ -96,8 +55,8 @@ describe("installPath (copy mode)", () => {
     const srcDir = path.join(tmpDir, "copy-src2");
     const destDir = path.join(tmpDir, "copy-dest2");
     fs.mkdirSync(srcDir);
-    installPath(srcDir, destDir, "copy");
-    installPath(srcDir, destDir, "copy");
+    installPath(srcDir, destDir);
+    installPath(srcDir, destDir);
     const backups = fs
       .readdirSync(tmpDir)
       .filter((f) => f.startsWith("copy-dest2.backup."));
@@ -108,13 +67,7 @@ describe("installPath (copy mode)", () => {
 describe("installDir", () => {
   it("skips when source directory does not exist", () => {
     const destPath = path.join(tmpDir, ".nonexistent-dest");
-    installDir(
-      tmpDir,
-      "nonexistent-src",
-      ".nonexistent-dest",
-      "symlink",
-      tmpDir,
-    );
+    installDir(tmpDir, "nonexistent-src", ".nonexistent-dest", tmpDir);
     assert.ok(
       !fs.existsSync(destPath),
       "dest should not be created when src is missing",
@@ -125,8 +78,8 @@ describe("installDir", () => {
     const srcDir = path.join(tmpDir, "real-src");
     fs.mkdirSync(srcDir);
     fs.writeFileSync(path.join(srcDir, "file.txt"), "data");
-    installDir(tmpDir, "real-src", ".real-dest", "symlink", tmpDir);
+    installDir(tmpDir, "real-src", ".real-dest", tmpDir);
     const destPath = path.join(tmpDir, ".real-dest");
-    assert.ok(fs.lstatSync(destPath).isSymbolicLink());
+    assert.ok(fs.statSync(destPath).isDirectory());
   });
 });

--- a/installer/test/reference-help-output.txt
+++ b/installer/test/reference-help-output.txt
@@ -1,4 +1,4 @@
-Usage: ./install.sh [--copy]
+Usage: ./install.sh
 
 Install AI TPK to your home directory.
 
@@ -7,9 +7,4 @@ Claude Code:
   - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
-  --copy    Copy files instead of creating symlinks (default: symlink)
   --help    Show this help message
-
-Installation methods:
-  symlink (default): Creates symbolic links. Changes sync automatically.
-  copy:              Copies files. Manual sync required with git pull.

--- a/recover.sh
+++ b/recover.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCAN_DIRS=("$HOME/.claude" "$HOME/.cursor")
+BACKUP_PATTERN='*.backup.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]'
+
+backups=()
+while IFS= read -r line; do
+  backups+=("$line")
+done < <(
+  for dir in "${SCAN_DIRS[@]}"; do
+    if [ -d "$dir" ]; then
+      find "$dir" -maxdepth 2 -name "$BACKUP_PATTERN" 2>/dev/null
+    fi
+  done | sort -r
+)
+
+if [ "${#backups[@]}" -eq 0 ]; then
+  printf "${YELLOW}No backups found in ${SCAN_DIRS[*]}.${NC}\n"
+  exit 0
+fi
+
+printf "${BLUE}Discovered backups (newest first):${NC}\n\n"
+
+for i in "${!backups[@]}"; do
+  backup="${backups[$i]}"
+  # Strip the .backup.YYYYMMDD_HHmmSS suffix to get the original path
+  original="${backup%.backup.*}"
+  # Extract the timestamp suffix: YYYYMMDD_HHmmSS
+  suffix="${backup##*.backup.}"
+  # Parse: YYYYMMDD_HHmmSS
+  ts_date="${suffix%%_*}"
+  ts_time="${suffix##*_}"
+  YYYY="${ts_date:0:4}"
+  MM="${ts_date:4:2}"
+  DD="${ts_date:6:2}"
+  HH="${ts_time:0:2}"
+  mm="${ts_time:2:2}"
+  SS="${ts_time:4:2}"
+  human_ts="${YYYY}-${MM}-${DD} ${HH}:${mm}:${SS}"
+  printf "  ${GREEN}[%d]${NC} %s\n      Restores to: %s\n      Timestamp:   %s\n\n" \
+    "$((i + 1))" "$backup" "$original" "$human_ts"
+done
+
+printf "${BLUE}Enter the number of the backup to restore (or press Enter to cancel):${NC} "
+read -r input || true
+
+if [ -z "$input" ]; then
+  printf "${YELLOW}No selection made. Exiting.${NC}\n"
+  exit 0
+fi
+
+if ! [[ "$input" =~ ^[0-9]+$ ]] || [ "$input" -lt 1 ] || [ "$input" -gt "${#backups[@]}" ]; then
+  printf "${RED}Invalid selection: %s${NC}\n" "$input"
+  exit 1
+fi
+
+selected_backup="${backups[$((input - 1))]}"
+original_path="${selected_backup%.backup.*}"
+
+printf "\n${BLUE}Restoring:${NC} %s\n${BLUE}       to:${NC} %s\n\n" \
+  "$selected_backup" "$original_path"
+
+if [ -e "$original_path" ] || [ -L "$original_path" ]; then
+  ts_now="$(date '+%Y%m%d_%H%M%S')"
+  current_backup="${original_path}.backup.${ts_now}"
+  printf "${YELLOW}Backing up existing %s to %s${NC}\n" "$original_path" "$current_backup"
+  mv "$original_path" "$current_backup"
+fi
+
+mv "$selected_backup" "$original_path"
+printf "${GREEN}Restored successfully.${NC}\n"


### PR DESCRIPTION
## Problem

Symlink installs were fragile: re-runs could produce broken links, the distinction between source and destination was hard to reason about, and the mode added complexity without benefit. For a repo at maturity, copy-only is simpler, more predictable, and sufficient.

## What changed

The installer now operates in copy-only mode exclusively. The `--copy` flag is removed since it was already the only real mode. Existing install invocations (`./install.sh`) continue to work without change.

## New utility scripts

Two scripts address the timestamped backups the installer has always created:

- **`recover.sh`** — interactively lists available backups and restores the one you select, giving users a safe rollback path for any installed file.
- **`clean-backups.sh`** — prunes stale backups, keeping only the most recent copy per destination path so the backup directory stays tidy across multiple installs.

## Risks

- Existing users who relied on symlink behavior (edits to source files reflecting immediately at the destination) will no longer get that. Copy semantics are now explicit. This is a low-risk change given the `--copy` flag was always available and recommended.
- No changes to the backup format or backup directory location — `recover.sh` and `clean-backups.sh` work against existing backups.