### PR TITLE
fix(hooks): add leading newline to session banner printf

### DIFF
--- a/claude/hooks/session-banner.sh
+++ b/claude/hooks/session-banner.sh
@@ -24,6 +24,6 @@ if [ -f "$SESSIONS_DIR/$SESSION_ID" ]; then
 fi
 
 # Print dim banner to terminal
-printf '\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
+printf '\n\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
 
 exit 0

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -24,6 +24,6 @@ NAME=$(printf '%s' "$NAME" | tr -cd '[:print:]')
 echo "$NAME" > "$SESSIONS_DIR/$SESSION_ID"
 
 # Print dim banner to terminal
-printf '\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
+printf '\n\033[2m── session: %s ──\033[0m\n' "$NAME" >> /dev/tty 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
Session banner `printf` writes to `/dev/tty` without a leading newline. On `Stop` and `PostCompact` hook events, readline already has the prompt drawn — the banner injects at the current cursor position and gets overwritten when readline repaints, breaking the prompt line and making the banner appear to vanish.

Fix: prepend `\n` to the `printf` format string in both `session-start.sh` and `session-banner.sh` so the banner always starts on a fresh line.