### PR TITLE
fix(hooks): use ~/.claude/hooks path for all hook scripts to work across repos

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash claude/hooks/session-start.sh",
+            "command": "bash ~/.claude/hooks/session-start.sh",
             "timeout": 5
           }
         ]
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash claude/hooks/session-banner.sh",
+            "command": "bash ~/.claude/hooks/session-banner.sh",
             "timeout": 5
           }
         ]
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash claude/hooks/session-banner.sh",
+            "command": "bash ~/.claude/hooks/session-banner.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
Hook commands in `claude/settings.json` used project-relative paths (`claude/hooks/<script>`), which silently break when Claude Code runs from any other repository. All three affected hooks (`session-start.sh`, `session-banner.sh` in PostCompact, `session-banner.sh` in Stop) are updated to reference `~/.claude/hooks/<script>` — consistent with the two hooks that were already correct.