### PR TITLE
feat(.claude): add scope clarification guard for artifact creation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,29 @@
+# Project Instructions — ai-tpk
+
+## Scope Clarification (Mandatory)
+
+This repository has two scopes for Claude Code artifacts. Before creating or modifying any of the artifact types listed below, you MUST ask the user which scope they intend:
+
+| Scope | Directory | Effect |
+|-------|-----------|--------|
+| **User scope** | `claude/` | Synced by install.sh to `~/.claude/` -- applies globally across all repos |
+| **Repo scope** | `.claude/` | Applies only to this repository |
+
+### When to ask
+
+Before performing any of these actions, stop and ask: **"Repo scope (`.claude/`) or user scope (`claude/`)?"**
+
+- Creating or modifying an **agent** (user scope: `claude/agents/` vs repo scope: `.claude/agents/` — repo-scope agents directory does not exist yet)
+- Creating or modifying a **skill** (user scope: `claude/skills/` vs repo scope: `.claude/skills/`)
+- Creating or modifying a **command** (user scope: `claude/commands/` vs repo scope: `.claude/commands/` — repo-scope commands directory does not exist yet)
+- Creating or modifying a **hook** (user scope: `claude/hooks/` vs repo scope: `.claude/hooks/` — repo-scope hooks directory does not exist yet)
+- Creating or modifying a **reference** (user scope: `claude/references/` vs repo scope: `.claude/references/` — repo-scope references directory does not exist yet)
+- Modifying **CLAUDE.md** (`claude/CLAUDE.md` is the user-scope source; `.claude/CLAUDE.md` is project-scope)
+- Modifying **settings** (user scope: `claude/settings.json`; project-shared: `.claude/settings.json` — does not exist yet; project-local: `.claude/settings.local.json` — already exists, untracked)
+
+### Rules
+
+1. **Ask first, act second.** Never assume the scope. The question takes five seconds; fixing a misplaced artifact takes much longer.
+2. **Show the concrete paths.** When asking, include the actual directory paths so the user can confirm without needing to remember the mapping.
+3. **For artifact types that only exist in user scope today** (agents, commands, hooks, references): still confirm intent, because the user may want to create a repo-scope equivalent or may be confused about where the artifact will land.
+4. **Do not skip this step** even if the user's request seems to imply a scope. Explicit confirmation prevents mistakes.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ Keep AI tool configurations version-controlled and portable across machines. The
 
 ```
 .
-├── claude/          # Claude Code configs (whitelist: settings.json, CLAUDE.md, skills/, agents/, commands/, references/)
+├── claude/          # User-scope Claude Code configs (synced globally)
 │   ├── CLAUDE.md         # User-global instructions (skill mandates)
 │   ├── settings.json     # Plugin config, hooks, marketplace settings
 │   ├── agents/          # Specialized AI assistants (e.g., Quill for docs)
 │   ├── references/       # Shared reference files loaded by agents at runtime
 │   ├── skills/          # Reusable capabilities
 │   └── commands/        # Slash commands for Claude Code
+├── .claude/         # Project-scope Claude Code config (this repo only)
+│   ├── CLAUDE.md         # Project-level instructions (scope clarification guard)
+│   └── skills/          # Project-scoped skills
 ├── cursor/          # Cursor configurations (coming soon)
 ├── docs/            # Documentation
 │   ├── images/          # Project images and diagrams
@@ -36,7 +39,22 @@ Keep AI tool configurations version-controlled and portable across machines. The
 └── install.sh       # Installation script
 ```
 
+### Scope: User vs. Project
+
+This repository has two scopes for Claude Code artifacts:
+
+| Directory | Scope | Effect |
+|-----------|-------|--------|
+| `claude/` | User | Synced by `install.sh` to `~/.claude/` — applies globally across all repositories |
+| `.claude/` | Project | Applies only to this repository — not synced by installer |
+
+When modifying agents, skills, commands, hooks, references, CLAUDE.md, or settings, consult `.claude/CLAUDE.md` for scope clarification rules. Before creating or modifying any scoped artifact, ask: "Repo scope (`.claude/`) or user scope (`claude/`)?"
+
+### Installation
+
 The installer only installs these paths from `claude/` into `~/.claude/`: `CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, and `references/`. Anything else in the repo or on disk under `~/.claude/` is left untouched except where those destinations are replaced (after a timestamped backup).
+
+The `.claude/` directory is never synced by the installer — it remains project-local.
 
 ### Developer Notes
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,14 +70,29 @@ The `agent_transcript_path` field enables downstream tools (like Everwise Scout)
 - Timeout: 60 seconds
 - Requires `jq`; exits silently if unavailable or raw log is empty
 
-## User-Global Instructions (claude/CLAUDE.md)
+## Instructions: User-Global vs. Project-Level
 
-`CLAUDE.md` is loaded by Claude Code at session start for every project. It mandates two skills that apply globally across all work:
+Claude Code loads instructions at two levels:
+
+### User-Global Instructions (claude/CLAUDE.md)
+
+`claude/CLAUDE.md` is installed to `~/.claude/CLAUDE.md` by the installer and loaded by Claude Code at session start for every project. It mandates three skills that apply globally across all work:
 
 - **`commit-message-guide`** — required for all git commits; conventional commit format is enforced, no exceptions
 - **`open-pull-request`** — required for all pull requests and merge requests; no other PR creation method is allowed
+- **`validate-before-pr`** — runs lint and format checks as a mandatory gate before PR creation; must pass before open-pull-request can be invoked
 
-These mandates are active for every project. Project-level `.claude/CLAUDE.md` files can provide additional instructions; however, skill mandate enforcement depends on Claude Code's instruction precedence behavior.
+### Project-Level Instructions (.claude/CLAUDE.md)
+
+`.claude/CLAUDE.md` is loaded by Claude Code only in this repository. It provides project-scoped instructions that override or supplement user-global directives.
+
+**This repository's project-level guard:** Before creating or modifying agents, skills, commands, hooks, references, CLAUDE.md, or settings, you must clarify which scope is intended:
+- **User scope** (`claude/`) — applied globally across all repositories
+- **Project scope** (`.claude/`) — applied only to this repository
+
+See `.claude/CLAUDE.md` for the full scope clarification rules and trigger cases.
+
+**Note:** Skill mandate enforcement depends on Claude Code's instruction precedence behavior. Project-level mandates are intended to supplement, not override, user-level mandates.
 
 ## Agents (`claude/agents/`)
 


### PR DESCRIPTION
This repo's dual-scope structure (`claude/` synced globally; `.claude/` repo-only) caused frequent misdirected artifact creation. Adds `.claude/CLAUDE.md` as a project-scoped instruction file that enforces scope clarification before creating agents, skills, commands, hooks, references, or modifying CLAUDE.md/settings — seven trigger cases with concrete paths shown.

Also corrects the mandatory skill count in `docs/CONFIGURATION.md` (was two, is three) and documents the dual-scope model in `README.md`.