### PR TITLE
fix(commands): improve /merged with session context and remote-gone detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
-| `/merged` | Cleans up after a merged PR: auto-identifies the merged branch when invoked from an active worktree session, removes the worktree, deletes the local branch, checks out main, and pulls the latest. Confirms all destructive actions with the user. |
+| `/merged` | Cleans up after a merged PR: uses session context or remote-gone detection to auto-select the target branch, removes the worktree, deletes the local branch, checks out main, and pulls the latest. Confirms all destructive actions with the user. |
 
 ## Agent Orchestration Workflow
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
-| `/merged` | Cleans up after a merged PR: removes the active worktree, deletes the local branch, checks out main, and pulls the latest. Confirms all destructive actions with the user. |
+| `/merged` | Cleans up after a merged PR: auto-identifies the merged branch when invoked from an active worktree session, removes the worktree, deletes the local branch, checks out main, and pulls the latest. Confirms all destructive actions with the user. |
 
 ## Agent Orchestration Workflow
 

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -9,6 +9,25 @@ in order. Run each command as a standalone call — do not chain commands with `
 **Note for DM:** Steps that perform write operations (destructive git commands) must be
 delegated to Bitsmith per the DM delegation policy. Those steps are marked below.
 
+## Step 0 — Check session context
+
+Before running any discovery logic, check whether `WORKTREE_PATH` and `WORKTREE_BRANCH` are
+both present in the current session context (i.e., you already know them from the active
+worktree session).
+
+**If both are set:**
+Print: `"Using session context: <WORKTREE_PATH> (<WORKTREE_BRANCH>)"`
+Ask the user to confirm before proceeding.
+
+If the user confirms: set `<worktree-path>` to `WORKTREE_PATH` and `<branch>` to
+`WORKTREE_BRANCH`. Proceed through Steps 1 and 2 (to identify `<main-path>` and verify the
+worktree exists), then skip directly to Step 6.
+
+If the user does not confirm: abort without making any changes.
+
+**If not both set:**
+Proceed to Step 1 (full discovery flow).
+
 ## Step 1 — Enumerate all worktrees
 
 Run: `git worktree list --porcelain`
@@ -25,6 +44,11 @@ which directory the command is invoked from. Extract its path as `<main-path>`.
 
 Do **not** use `git rev-parse --show-toplevel` for this purpose — it returns the worktree
 path when run from inside a worktree, which would produce incorrect results.
+
+**If arriving from Step 0 (session-context path):** Verify that `<worktree-path>` appears
+as a worktree path in the porcelain output. If it does not, tell the user: "Session context
+worktree not found in `git worktree list` output. Aborting." and stop. If it does, proceed
+to Step 6.
 
 ## Step 3 — Build the candidate list
 
@@ -43,7 +67,39 @@ by applying these filters in order:
 
 Each candidate entry contains a path and a branch name (or `(detached HEAD)`).
 
-## Step 4 — Branch on candidate count
+## Step 4 — Check for remote-gone signal
+
+Run: `git fetch --prune`
+
+This is a non-destructive network operation that updates remote tracking refs and prunes
+refs for branches deleted on the remote. It modifies local tracking refs but not local
+branches or the working tree. No Bitsmith delegation is required.
+
+If `git fetch --prune` fails (e.g., network error, authentication failure), warn the user
+that remote-gone detection is unavailable and fall through to Step 5 (the manual picker).
+
+Run: `git branch -vv`
+
+Parse the output for lines whose tracking-ref information contains `: gone]` — for example,
+a line like `  fix/my-branch  abc1234 [origin/fix/my-branch: gone] commit message` indicates
+that `origin/fix/my-branch` was deleted on the remote.
+
+Cross-reference the gone branches with the candidate list from Step 3. A candidate matches
+if its branch name equals the local branch name shown in a gone line. Candidates with
+`(detached HEAD)` as their branch cannot match and are ignored in this cross-reference.
+
+**If exactly one candidate has a `[gone]` upstream:**
+Auto-select it. Print: `"Identified merged branch via remote deletion: <branch> at <path>. Remove it? (yes/no)"`
+
+If the user answers `yes`: store the candidate's path as `<worktree-path>` and branch as
+`<branch>`, then proceed to Step 6.
+
+If the user answers anything other than `yes`: fall through to Step 5 (the manual picker).
+
+**If zero or multiple candidates have `[gone]` upstream:**
+Fall through to Step 5 (the manual picker).
+
+## Step 5 — Branch on candidate count
 
 **If zero candidates:**
 Tell the user: "No worktrees found to clean up." Stop here — do not continue to later steps.
@@ -62,15 +118,15 @@ If the user answers `none` or provides an invalid selection, abort without makin
 
 Store the selected candidate's path as `<worktree-path>` and branch as `<branch>`.
 
-## Step 5 — Change to the main repo directory
+## Step 6 — Change to the main repo directory
 
 Before any destructive operations, change the working directory to `<main-path>` (from
 Step 2). This is critical: if the current shell is inside `<worktree-path>`, removing that
 worktree will destroy the cwd and cause all subsequent commands to fail.
 
-All remaining steps (6 through 9) must execute with `<main-path>` as the working directory.
+All remaining steps (7 through 10) must execute with `<main-path>` as the working directory.
 
-## Step 6 — Remove the worktree [write operation — delegate to Bitsmith]
+## Step 7 — Remove the worktree [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git worktree remove --force <worktree-path>`
 
@@ -81,7 +137,7 @@ in the worktree are expendable.
 
 If the command fails, report the error to the user and abort. Do not continue to later steps.
 
-## Step 7 — Delete the local branch [write operation — delegate to Bitsmith]
+## Step 8 — Delete the local branch [write operation — delegate to Bitsmith]
 
 **If `<branch>` is `(detached HEAD)`:** Skip this step entirely. There is no branch to delete.
 Print: "Skipping branch deletion — worktree was in detached HEAD state."
@@ -91,9 +147,9 @@ Print: "Skipping branch deletion — worktree was in detached HEAD state."
 (Per DM delegation policy, write operations must not be executed directly by the DM.)
 
 If the command fails (e.g., the branch was already deleted or does not exist locally), report
-the failure as a warning but do not abort — continue to Step 8.
+the failure as a warning but do not abort — continue to Step 9.
 
-## Step 8 — Checkout main [write operation — delegate to Bitsmith]
+## Step 9 — Checkout main [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git checkout main`
 
@@ -101,7 +157,7 @@ Delegate to Bitsmith to run (from `<main-path>`): `git checkout main`
 
 If this fails, report the error and abort.
 
-## Step 9 — Pull latest from origin [write operation — delegate to Bitsmith]
+## Step 10 — Pull latest from origin [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git pull origin main`
 
@@ -110,9 +166,9 @@ Delegate to Bitsmith to run (from `<main-path>`): `git pull origin main`
 If this fails, report the error but do not treat it as fatal — the local checkout is already
 on `main`.
 
-## Step 10 — Report final summary
+## Step 11 — Report final summary
 
 Print a summary:
 - **Worktree removed:** `<worktree-path>`
-- **Branch deleted:** `<branch>` (or "skipped — detached HEAD" or "skipped — see warning above" if Step 7 was skipped or failed)
+- **Branch deleted:** `<branch>` (or "skipped — detached HEAD" or "skipped — see warning above" if Step 8 was skipped or failed)
 - **Current branch:** main (up to date)


### PR DESCRIPTION
Two improvements to eliminate the manual worktree picker in the common case.

Step 0 short-circuits discovery when `WORKTREE_PATH`/`WORKTREE_BRANCH` are already in the active DM session context — no enumeration needed. Step 4 runs `git fetch --prune` then inspects `[gone]` upstream tracking refs to auto-select the merged branch when exactly one candidate matches. Declining the auto-selection now falls through to the manual picker rather than aborting, so the user is never left without a path forward.