### PR TITLE
feat(mcp): add AWS CloudWatch profile-selection wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The installer automatically configures user-scoped MCP (Model Context Protocol) 
 Currently configured servers:
 
 - **Kubernetes MCP Server** (`mcp-server-kubernetes@3.4.0`) - Provides read-only access to Kubernetes cluster information via your `~/.kube/config`. Gracefully skips setup if `~/.kube/config` doesn't exist yet (useful for fresh machine setup). The server is only added if not already configured, making the installation idempotent.
-- **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) - Official AWS Labs MCP server providing access to CloudWatch Metrics, Alarms, and Logs (query log groups, run Insights queries, retrieve metrics and alarm history) via your `~/.aws` credentials. Requires `uvx` (`pip install uv` or `brew install uv`). Gracefully skips setup if `~/.aws/credentials` doesn't exist yet. The server is only added if not already configured, making the installation idempotent.
+- **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) - Official AWS Labs MCP server providing access to CloudWatch Metrics, Alarms, and Logs (query log groups, run Insights queries, retrieve metrics and alarm history) via your `~/.aws` credentials. Uses a wrapper script (`wrappers/mcp-cloudwatch.sh`) to support dynamic AWS profile selection. Select your active AWS profile by running `/set-aws-profile` in Claude Code—the profile is stored in `~/.claude/.current-aws-profile` and read at MCP startup. Requires `uvx` (`pip install uv` or `brew install uv`). Gracefully skips setup if `~/.aws/credentials` doesn't exist yet. The server is only added if not already configured, making the installation idempotent.
 - **Grafana MCP Server** (`mcp-grafana`) - Access to Grafana dashboards, datasources, metrics, logs, incidents, and more. Uses a wrapper script (`wrappers/mcp-grafana.sh`) that requires `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` to be exported in your shell environment. Self-healing re-registration: the installer removes and re-adds this server each invocation to fix any prior broken configurations.
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
@@ -291,6 +291,53 @@ claude
 ```
 
 If either variable is missing, the wrapper fails immediately with a clear error message.
+
+**Example: AWS CloudWatch MCP Server**
+
+The `wrappers/mcp-cloudwatch.sh` script resolves an AWS profile from a dotfile (`~/.claude/.current-aws-profile`) with a fallback to the `$AWS_PROFILE` environment variable:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve AWS profile: dotfile takes priority over env var
+DOTFILE="$HOME/.claude/.current-aws-profile"
+if [[ -f "$DOTFILE" ]] && [[ -s "$DOTFILE" ]]; then
+  IFS= read -r AWS_PROFILE < "$DOTFILE"
+  # Trim whitespace...
+fi
+
+# Validate profile name and fail helpfully if missing
+if [[ -n "${AWS_PROFILE:-}" ]]; then
+  if [[ ! "$AWS_PROFILE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    printf 'Error: invalid AWS profile name "%s" -- must match [a-zA-Z0-9_-]+\n' "$AWS_PROFILE" >&2
+    exit 1
+  fi
+  export AWS_PROFILE
+  echo "CloudWatch MCP: using AWS profile '$AWS_PROFILE'" >&2
+  exec uvx awslabs.cloudwatch-mcp-server@0.0.19 "$@"
+fi
+
+# No profile found — print available profiles from ~/.aws/config
+printf 'Error: no AWS profile set.\n' >&2
+# ... (list available profiles from ~/.aws/config)
+exit 1
+```
+
+Users select their active AWS profile using the `/set-aws-profile` slash command, which stores the profile name in `~/.claude/.current-aws-profile` (mode 0600):
+
+```bash
+/set-aws-profile
+# Choose a profile from the list
+# Profile set to `my-profile`. Restart Claude Code or reload MCP servers for this to take effect.
+```
+
+Alternatively, users can manually set the profile:
+
+```bash
+echo "my-profile" > ~/.claude/.current-aws-profile
+chmod 600 ~/.claude/.current-aws-profile
+```
 
 ##### Adding a New MCP Server
 
@@ -461,6 +508,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
 | `/merged` | Cleans up after a merged PR: uses session context or remote-gone detection to auto-select the target branch, removes the worktree, deletes the local branch, checks out main, and pulls the latest. Confirms all destructive actions with the user. |
+| `/set-aws-profile` | Selects an AWS profile for the CloudWatch MCP server by listing available profiles from `~/.aws/config`, validating the user's selection, and storing it in `~/.claude/.current-aws-profile` (mode 0600). The profile is read at MCP startup. Requires Claude Code restart or MCP server reload to take effect. |
 
 ## Agent Orchestration Workflow
 

--- a/claude/commands/set-aws-profile.md
+++ b/claude/commands/set-aws-profile.md
@@ -1,0 +1,19 @@
+List available AWS profiles from `~/.aws/config` and let the user choose one to activate for the CloudWatch MCP server.
+
+## Steps
+
+1. **Read `~/.aws/config`** and enumerate all profile names:
+   - Include `[default]` if present (display as `default`)
+   - Include each `[profile <name>]` entry (display as `<name>`)
+   - If `~/.aws/config` does not exist or contains no profiles, tell the user and stop.
+
+2. **Show the current active profile** (if any): read `~/.claude/.current-aws-profile` — if it exists and is non-empty, display its first line as the current profile next to "(active)". If the file does not exist, note "no profile currently set."
+
+3. **Present the profile list** and ask the user to choose one by name.
+
+4. **Validate the selection:** the chosen name must exactly match one of the profiles enumerated in step 1.
+   - If it does not match, respond: "That profile name was not found in ~/.aws/config. Please choose from the list above." Ask again. Do not write anything to disk.
+
+5. **Write the validated profile name** to `~/.claude/.current-aws-profile` (create or overwrite). Then set file permissions to mode 0600 by running: `chmod 600 ~/.claude/.current-aws-profile`
+
+6. **Confirm:** "Profile set to `<name>`. Restart Claude Code or reload MCP servers for this to take effect."

--- a/claude/commands/set-aws-profile.md
+++ b/claude/commands/set-aws-profile.md
@@ -1,3 +1,7 @@
+---
+description: Select an AWS profile for the CloudWatch MCP server
+---
+
 List available AWS profiles from `~/.aws/config` and let the user choose one to activate for the CloudWatch MCP server.
 
 ## Steps

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -23,6 +23,7 @@ try {
 
   installClaudeWhitelist(scriptDir, os.homedir());
   installDir(scriptDir, "cursor", ".cursor", os.homedir());
+  installDir(scriptDir, "wrappers", ".claude/wrappers", os.homedir());
 
   console.log("");
   installMcpServers(scriptDir);

--- a/installer/mcp.ts
+++ b/installer/mcp.ts
@@ -142,9 +142,13 @@ export function loadMcpServers(repoRoot: string): McpServerConfig[] {
 export function buildAddArgs(
   server: McpServerConfig,
   repoRoot: string,
+  homedir: string = os.homedir(),
 ): string[] {
   if (server.wrapper !== undefined) {
-    const absoluteWrapperPath = path.join(repoRoot, server.wrapper);
+    const absoluteWrapperPath =
+      server.scope === "user"
+        ? path.join(homedir, ".claude", server.wrapper)
+        : path.join(repoRoot, server.wrapper);
     try {
       fs.statSync(absoluteWrapperPath);
     } catch (err: unknown) {

--- a/installer/test/mcp.test.ts
+++ b/installer/test/mcp.test.ts
@@ -196,7 +196,11 @@ describe("buildAddArgs — wrapper-based server", () => {
 
     const args = buildAddArgs(server, repoRoot, fakeHomedir);
 
-    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-grafana.sh");
+    const expectedWrapperPath = path.join(
+      fakeHomedir,
+      ".claude",
+      "wrappers/mcp-grafana.sh",
+    );
     assert.deepStrictEqual(args, [
       "-s",
       "user",
@@ -225,7 +229,11 @@ describe("buildAddArgs — wrapper-based server", () => {
       wrapper: "wrappers/mcp-grafana.sh",
     };
 
-    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-grafana.sh");
+    const expectedWrapperPath = path.join(
+      fakeHomedir,
+      ".claude",
+      "wrappers/mcp-grafana.sh",
+    );
 
     assert.throws(
       () => buildAddArgs(server, repoRoot, fakeHomedir),
@@ -267,7 +275,11 @@ describe("buildAddArgs — wrapper-based server", () => {
 
     const args = buildAddArgs(server, repoRoot, fakeHomedir);
 
-    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-test.sh");
+    const expectedWrapperPath = path.join(
+      fakeHomedir,
+      ".claude",
+      "wrappers/mcp-test.sh",
+    );
     assert.ok(
       args.includes(expectedWrapperPath),
       `expected args to contain "${expectedWrapperPath}", got: ${JSON.stringify(args)}`,

--- a/installer/test/mcp.test.ts
+++ b/installer/test/mcp.test.ts
@@ -178,8 +178,9 @@ describe("buildAddArgs — wrapper-based server", () => {
   it("returns correct args with absolute wrapper path and no -e flags when wrapper file exists", () => {
     // Create a real wrapper file so statSync succeeds
     const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-wrapper-"));
-    const wrappersDir = path.join(repoRoot, "wrappers");
-    fs.mkdirSync(wrappersDir);
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-wrapper-"));
+    const wrappersDir = path.join(fakeHomedir, ".claude", "wrappers");
+    fs.mkdirSync(wrappersDir, { recursive: true });
     const wrapperFile = path.join(wrappersDir, "mcp-grafana.sh");
     fs.writeFileSync(
       wrapperFile,
@@ -193,9 +194,9 @@ describe("buildAddArgs — wrapper-based server", () => {
       wrapper: "wrappers/mcp-grafana.sh",
     };
 
-    const args = buildAddArgs(server, repoRoot);
+    const args = buildAddArgs(server, repoRoot, fakeHomedir);
 
-    const expectedWrapperPath = path.join(repoRoot, "wrappers/mcp-grafana.sh");
+    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-grafana.sh");
     assert.deepStrictEqual(args, [
       "-s",
       "user",
@@ -215,6 +216,7 @@ describe("buildAddArgs — wrapper-based server", () => {
 
   it("throws with descriptive error when wrapper file does not exist", () => {
     const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-missing-"));
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-missing-"));
 
     const server = {
       name: "grafana",
@@ -223,8 +225,10 @@ describe("buildAddArgs — wrapper-based server", () => {
       wrapper: "wrappers/mcp-grafana.sh",
     };
 
+    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-grafana.sh");
+
     assert.throws(
-      () => buildAddArgs(server, repoRoot),
+      () => buildAddArgs(server, repoRoot, fakeHomedir),
       (err: unknown) => {
         assert.ok(err instanceof Error);
         assert.ok(
@@ -232,11 +236,66 @@ describe("buildAddArgs — wrapper-based server", () => {
           `expected "Wrapper script not found" in: ${err.message}`,
         );
         assert.ok(
+          err.message.includes(expectedWrapperPath),
+          `expected path "${expectedWrapperPath}" in: ${err.message}`,
+        );
+        assert.ok(
           err.message.includes("grafana"),
           `expected server name "grafana" in: ${err.message}`,
         );
         return true;
       },
+    );
+  });
+
+  it("resolves user-scope wrapper against homedir/.claude/ instead of repoRoot", () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-user-scope-"));
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-user-scope-"));
+    const wrappersDir = path.join(fakeHomedir, ".claude", "wrappers");
+    fs.mkdirSync(wrappersDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(wrappersDir, "mcp-test.sh"),
+      "#!/usr/bin/env bash\nexec echo test\n",
+    );
+
+    const server = {
+      name: "test-server",
+      scope: "user" as const,
+      transport: "stdio" as const,
+      wrapper: "wrappers/mcp-test.sh",
+    };
+
+    const args = buildAddArgs(server, repoRoot, fakeHomedir);
+
+    const expectedWrapperPath = path.join(fakeHomedir, ".claude", "wrappers/mcp-test.sh");
+    assert.ok(
+      args.includes(expectedWrapperPath),
+      `expected args to contain "${expectedWrapperPath}", got: ${JSON.stringify(args)}`,
+    );
+  });
+
+  it("resolves project-scope wrapper against repoRoot", () => {
+    const fakeRepoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-proj-scope-"));
+    const wrappersDir = path.join(fakeRepoRoot, "wrappers");
+    fs.mkdirSync(wrappersDir);
+    fs.writeFileSync(
+      path.join(wrappersDir, "some.sh"),
+      "#!/usr/bin/env bash\nexec echo some\n",
+    );
+
+    const server = {
+      name: "some-server",
+      scope: "project" as const,
+      transport: "stdio" as const,
+      wrapper: "wrappers/some.sh",
+    };
+
+    const args = buildAddArgs(server, fakeRepoRoot);
+
+    const expectedWrapperPath = path.join(fakeRepoRoot, "wrappers/some.sh");
+    assert.ok(
+      args.includes(expectedWrapperPath),
+      `expected args to contain "${expectedWrapperPath}", got: ${JSON.stringify(args)}`,
     );
   });
 });
@@ -306,7 +365,7 @@ describe("buildAddArgs — command-based server", () => {
       scope: "user" as const,
       transport: "stdio" as const,
       command: "uvx",
-      args: ["awslabs.amazon-cloudwatch-mcp-server@latest"],
+      args: ["awslabs.cloudwatch-mcp-server@0.0.19"],
     };
 
     const args = buildAddArgs(server, repoRoot);
@@ -318,7 +377,7 @@ describe("buildAddArgs — command-based server", () => {
     assert.deepStrictEqual(afterSep, [
       "cloudwatch",
       "uvx",
-      "awslabs.amazon-cloudwatch-mcp-server@latest",
+      "awslabs.cloudwatch-mcp-server@0.0.19",
     ]);
   });
 

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -14,12 +14,7 @@
       "scope": "user",
       "transport": "stdio",
       "prereq": "$HOME/.aws/credentials",
-      "env": {
-        "AWS_SHARED_CREDENTIALS_FILE": "$HOME/.aws/credentials",
-        "AWS_CONFIG_FILE": "$HOME/.aws/config"
-      },
-      "command": "uvx",
-      "args": ["awslabs.cloudwatch-mcp-server@0.0.19"]
+      "wrapper": "wrappers/mcp-cloudwatch.sh"
     },
     {
       "name": "grafana",

--- a/wrappers/mcp-cloudwatch.sh
+++ b/wrappers/mcp-cloudwatch.sh
@@ -12,6 +12,7 @@ fi
 
 # Validate profile name if set
 if [[ -n "${AWS_PROFILE:-}" ]]; then
+  # Valid AWS profile names: letters, digits, hyphens, underscores only (per AWS SDKref)
   if [[ ! "$AWS_PROFILE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
     printf 'Error: invalid AWS profile name "%s" -- must match [a-zA-Z0-9_-]+\n' "$AWS_PROFILE" >&2
     exit 1

--- a/wrappers/mcp-cloudwatch.sh
+++ b/wrappers/mcp-cloudwatch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve AWS profile: dotfile takes priority over env var
+DOTFILE="$HOME/.claude/.current-aws-profile"
+if [[ -f "$DOTFILE" ]] && [[ -s "$DOTFILE" ]]; then
+  IFS= read -r AWS_PROFILE < "$DOTFILE"
+  # Trim leading/trailing whitespace (bash-native, since we already require bash for [[ ]])
+  AWS_PROFILE="${AWS_PROFILE#"${AWS_PROFILE%%[! $'\t']*}"}"
+  AWS_PROFILE="${AWS_PROFILE%"${AWS_PROFILE##*[! $'\t']}"}"
+fi
+
+# Validate profile name if set
+if [[ -n "${AWS_PROFILE:-}" ]]; then
+  if [[ ! "$AWS_PROFILE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    printf 'Error: invalid AWS profile name "%s" -- must match [a-zA-Z0-9_-]+\n' "$AWS_PROFILE" >&2
+    exit 1
+  fi
+  export AWS_PROFILE
+  echo "CloudWatch MCP: using AWS profile '$AWS_PROFILE'" >&2
+  exec uvx awslabs.cloudwatch-mcp-server@0.0.19 "$@"
+fi
+
+# Neither dotfile nor env var provided a profile -- fail helpfully
+printf 'Error: no AWS profile set.\n' >&2
+printf 'Set one by running /set-aws-profile in Claude Code, or:\n' >&2
+printf '  echo "my-profile" > ~/.claude/.current-aws-profile\n\n' >&2
+printf 'Available profiles in ~/.aws/config:\n' >&2
+if [[ -f "$HOME/.aws/config" ]]; then
+  grep -E '^\[(default|profile [^]]+)\]' "$HOME/.aws/config" \
+    | sed 's/^\[profile //;s/^\[//;s/\]$//' >&2
+else
+  printf '  (no ~/.aws/config found)\n' >&2
+fi
+exit 1


### PR DESCRIPTION
Replaces the CloudWatch MCP server's hardcoded inline command with a wrapper script (`wrappers/mcp-cloudwatch.sh`) that selects an AWS profile at startup from `~/.claude/.current-aws-profile` or the `$AWS_PROFILE` env var. Profile names are validated against the AWS SDKref character set; the wrapper fails helpfully with a list of available profiles when none is set. A new `/set-aws-profile` slash command lets users pick a profile interactively from inside Claude Code. The installer now copies wrappers to `~/.claude/wrappers/` and registers them from that user-scope path, so the setup survives repo moves. The `buildAddArgs` function gains an optional `homedir` param for testability; all existing and new tests pass.

## Test plan

- [ ] Run `npm test` in `installer/` — all tests pass
- [ ] Run `npm run lint` and `npm run format:check` in `installer/` — both clean
- [ ] Run `install.sh` fresh and confirm `~/.claude/wrappers/mcp-cloudwatch.sh` is created and executable
- [ ] Run `install.sh` fresh and confirm the CloudWatch MCP entry in Claude config references `~/.claude/wrappers/mcp-cloudwatch.sh`
- [ ] Open Claude Code, run `/set-aws-profile`, confirm profile list appears and selection persists to `~/.claude/.current-aws-profile`
- [ ] Start Claude Code with no profile set — confirm CloudWatch wrapper prints an actionable error listing available profiles
- [ ] Set a valid profile via `/set-aws-profile`, restart Claude Code, confirm CloudWatch MCP starts cleanly