### PR TITLE
fix(claude): fix agent/skill/command doc inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Everwise now includes Scout, a selective transcript analysis capability. When ch
 Reusable capabilities including skill creation, commit message generation, and pull request automation. Three mandatory global skills via `CLAUDE.md`:
 
 - **`commit-message-guide`** — Enforces conventional commit format for all git commits
-- **`validate-before-pr`** — Runs lint and format checks before opening a PR; gates PR creation on passing checks
+- **`validate-before-pr`** — Runs lint and format checks (via stack detection: npm, Make, Python, Go, Rust) before opening a PR; gates PR creation on passing checks
 - **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation
 
 ### Slash Commands
@@ -689,6 +689,7 @@ When adding new hooks, agents, or skills, update the relevant documentation in `
 
 Agent definitions can reference shared behavioral vocabulary defined in `claude/references/`. This eliminates duplication across multiple agents:
 
+- **`claude/references/github-auth-probe.md`** — Canonical procedure for verifying GitHub account access before pushing or committing. Both `commit-message-guide` and `open-pull-request` skills reference this to ensure consistent GitHub authentication checks.
 - **`claude/references/review-gates.md`** — Shared two-gate review framework (Plan Review Gate and Implementation Review Gate) for all reviewer agents (Ruinor, Riskmancer, Windwarden, Knotcutter, Truthhammer). Defines universal operational constraints (read-only operation, in-memory returns) and plan-file-scoping rules. Each reviewer agent defines its own domain-specific criteria for each gate inline in its definition file.
 - **`claude/references/verdict-taxonomy.md`** — Shared verdict labels (REJECT, REVISE, ACCEPT-WITH-RESERVATIONS, ACCEPT) and severity scales. Agents load this reference when issuing verdicts to ensure consistent evaluation vocabulary.
 - **`claude/references/worktree-protocol.md`** — Shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. Agents load this reference when operating in isolated worktrees to ensure consistent path handling.

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -35,6 +35,7 @@ Check the workbench before every strike. This is a per-operation invariant — i
 Bitsmith does not guess the correct path. She surfaces the conflict.
 
 When `WORKING_DIRECTORY` is absent from the delegation prompt: for read-only tasks, behavior is unchanged — operate in the main working tree as before. For write-bearing tasks (any Write, Edit, or file-modifying Bash command), defer to the Path Mismatch Guard (scenario 3 above).
+
 ## The Forge's Jurisdiction
 
 ### What Bitsmith Touches

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -316,7 +316,7 @@ Trigger options exploration when: the `--explore-options` flag is present, OR th
 Suppress options exploration when: the user has already named a specific approach or technology, OR an approved plan already exists in `plans/`. The explicit `--explore-options` flag overrides suppression.
 
 When triggered:
-- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed), produce 2–4 viable options (not an execution plan), and return the options for user selection.
+- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed -- note: Pathfinder Consensus Mode is triggered by DM internally; it is not a user-facing flag), produce 2–4 viable options (not an execution plan), and return the options for user selection.
 - Present the options inline in the conversation — each option's name, summary, and Pathfinder's recommendation — then ask the user to select one or request changes. Do not proceed until the user responds.
 - **If user selects an option:** Re-invoke Pathfinder for an execution plan, passing both the selected option name and the full Consensus Mode output as context so Pathfinder does not re-research from scratch.
 - **If user rejects all options and requests different approaches:** Re-invoke Pathfinder in Consensus Mode with the user's feedback as additional constraints, then re-present options.
@@ -332,13 +332,13 @@ When not triggered: proceed directly to step 3.
    - validation criteria
    - risks / rollback considerations
 
-   Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block (defined above) if a session worktree is active. Pathfinder must write plans to `{WORKING_DIRECTORY}/plans/` using the filename `{SESSION_TS}-{feature-slug}.md` (e.g., `plans/20260401-143022-oauth-login.md`).
-4. Pathfinder will save the plan to `plans/{SESSION_TS}-{feature-slug}.md`.
+   Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block (defined above) if a session worktree is active. Pathfinder must write plans to `{WORKING_DIRECTORY}/plans/` using the filename `{SESSION_TS}-{feature-slug}.md` (e.g., `{WORKING_DIRECTORY}/plans/20260401-143022-oauth-login.md`).
+4. Pathfinder will save the plan to `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}.md`.
 
 ### Phase 2: Plan Review (Quality Gate)
 
 1. **Mandatory Baseline Review**: Always invoke Ruinor first
-   - Pass the specific plan file path (e.g., `plans/oauth-login.md`) to Ruinor
+   - Pass the specific plan file path (e.g., `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{SESSION_SLUG}.md`) to Ruinor
    - Ruinor provides comprehensive baseline review and flags specialist concerns
    - Collect Ruinor's verdict, findings, and specialist recommendations
 
@@ -463,7 +463,7 @@ When not triggered: proceed directly to step 3.
 
     **5b — Documentation update:**
     If Pathfinder was invoked during this session, invoke Quill with the following three context items:
-    - (a) plan file path (e.g., `plans/oauth-login.md`)
+    - (a) plan file path (e.g., `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{SESSION_SLUG}.md`)
     - (b) list of files changed during implementation, collected via `git diff --name-only` against the pre-execution commit
     - (c) one-sentence feature summary
 
@@ -544,7 +544,7 @@ Example 1:
 User asks: "Add OAuth login, update the API, and add tests."
 Action:
 - Delegate to Pathfinder for decomposition and sequencing
-- Pathfinder saves plan to `plans/oauth-login.md`
+- Pathfinder saves plan to `plans/20260401-143022-oauth-login.md`
 - **Plan Review Gate:**
   - Invoke Ruinor (mandatory baseline review)
   - Ruinor flags security concerns (auth/JWT) → recommends Riskmancer
@@ -577,7 +577,7 @@ Example 3:
 User asks: "Refactor the authentication module --review-security --review-complexity"
 Action:
 - Delegate to Pathfinder for refactoring plan
-- Pathfinder saves plan to `plans/auth-refactor.md`
+- Pathfinder saves plan to `plans/20260401-143022-auth-refactor.md`
 - **Plan Review Gate:**
   - Invoke Ruinor (mandatory)
   - User flags present: --review-security, --review-complexity
@@ -590,7 +590,7 @@ Example 4:
 User asks: "Migrate from Redis 6 to Redis 7 and update the caching config --verify-facts"
 Action:
 - Delegate to Pathfinder for migration plan
-- Pathfinder saves plan to `plans/redis-migration.md`
+- Pathfinder saves plan to `plans/20260401-143022-redis-migration.md`
 - **Plan Review Gate:**
   - Invoke Ruinor (mandatory baseline review)
   - User flag present: --verify-facts → invoke Truthhammer
@@ -618,7 +618,7 @@ Action:
 - DM presents options to user with names, summaries, and Pathfinder's recommendation; waits for explicit selection
 - User selects Option B (Redis + BullMQ)
 - DM re-invokes Pathfinder for execution plan, passing "Option B: Redis + BullMQ" and the full Consensus Mode output as context
-- Pathfinder saves plan to `plans/background-jobs.md`
+- Pathfinder saves plan to `plans/20260401-143022-background-jobs.md`
 - Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
 
 Example 6:
@@ -646,7 +646,7 @@ Action:
 - DM invokes Askmaw (round 3) with full context
 - Askmaw returns structured brief (objective clear: fix 3 specific pen test findings; scope bounded)
 - DM exits intake loop, passes brief to Pathfinder
-- Pathfinder saves plan to `plans/auth-security-hardening.md`
+- Pathfinder saves plan to `plans/20260401-143022-auth-security-hardening.md`
 - Continue with Phase 2 (Plan Review Gate) as normal
 
 Example 8:

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -316,7 +316,7 @@ Trigger options exploration when: the `--explore-options` flag is present, OR th
 Suppress options exploration when: the user has already named a specific approach or technology, OR an approved plan already exists in `plans/`. The explicit `--explore-options` flag overrides suppression.
 
 When triggered:
-- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed -- note: Pathfinder Consensus Mode is triggered by DM internally; it is not a user-facing flag), produce 2–4 viable options (not an execution plan), and return the options for user selection.
+- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed -- note: Pathfinder Consensus Mode is triggered by DM internally here; users may also trigger it directly with `--consensus` in their message), produce 2–4 viable options (not an execution plan), and return the options for user selection.
 - Present the options inline in the conversation — each option's name, summary, and Pathfinder's recommendation — then ask the user to select one or request changes. Do not proceed until the user responds.
 - **If user selects an option:** Re-invoke Pathfinder for an execution plan, passing both the selected option name and the full Consensus Mode output as context so Pathfinder does not re-research from scratch.
 - **If user rejects all options and requests different approaches:** Re-invoke Pathfinder in Consensus Mode with the user's feedback as additional constraints, then re-present options.

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -37,10 +37,11 @@ For each session chronicle analysis, follow this sequence:
 This step runs once at the start of every Everwise invocation, before loading chronicles.
 
 1. Use `Glob` to find any existing Talekeeper chronicle file matching `logs/talekeeper-*.jsonl`. Read one of them with `Read`.
-2. Scan the entries for any that contain an `agent_transcript_path` field (or an equivalent field whose value contains a `~/.claude/projects/` or `/.claude/projects/` path).
+2. Scan the entries for any that contain an `agent_transcript_path` field (or an equivalent field whose value contains a `~/.claude/projects/`, `/.claude/projects/`, `~/.cursor/projects/`, or `/.cursor/projects/` path).
 3. From that path, extract `transcript_base_path` by stripping the trailing `/{session_id}/subagents/agent-{id}.jsonl` portion. The encoded project directory is the segment immediately after `projects/` and before the first `/{session_id}/` segment.
    - Example: from `/Users/alice/.claude/projects/-Users-alice-work-my-project/abc123/subagents/agent-xyz.jsonl`, extract `/Users/alice/.claude/projects/-Users-alice-work-my-project`
 4. Verify the extracted path exists by running a `Glob` with pattern `{transcript_base_path}/*/subagents/`. If it returns results, `transcript_base_path` is confirmed.
+   - **Cursor fallback:** If no chronicle entry contains a `~/.claude/projects/` path but entries contain a `~/.cursor/projects/` path, use the Cursor path instead. The extraction and verification logic is identical -- only the base directory differs. If both paths exist, check both.
 5. If no chronicle entry contains an `agent_transcript_path` field, or if the extracted path does not exist, set `transcript_base_path = null` and note: "Transcript base path discovery failed; continuing with chronicle-only analysis."
 6. Store the discovered path as `transcript_base_path` for use in Steps 2b and 2c.
 

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -41,7 +41,7 @@ This step runs once at the start of every Everwise invocation, before loading ch
 3. From that path, extract `transcript_base_path` by stripping the trailing `/{session_id}/subagents/agent-{id}.jsonl` portion. The encoded project directory is the segment immediately after `projects/` and before the first `/{session_id}/` segment.
    - Example: from `/Users/alice/.claude/projects/-Users-alice-work-my-project/abc123/subagents/agent-xyz.jsonl`, extract `/Users/alice/.claude/projects/-Users-alice-work-my-project`
 4. Verify the extracted path exists by running a `Glob` with pattern `{transcript_base_path}/*/subagents/`. If it returns results, `transcript_base_path` is confirmed.
-   - **Cursor fallback:** If no chronicle entry contains a `~/.claude/projects/` path but entries contain a `~/.cursor/projects/` path, use the Cursor path instead. The extraction and verification logic is identical -- only the base directory differs. If both paths exist, check both.
+   - **Cursor fallback:** If no chronicle entry contains a `~/.claude/projects/` path but entries contain a `~/.cursor/projects/` path, use the Cursor path instead. The extraction and verification logic is identical -- only the base directory differs. If both `~/.claude/projects/` and `~/.cursor/projects/` paths exist, prefer `~/.claude/projects/` as the primary `transcript_base_path`, but also check `~/.cursor/projects/` for any transcripts not found at the primary path.
 5. If no chronicle entry contains an `agent_transcript_path` field, or if the extracted path does not exist, set `transcript_base_path = null` and note: "Transcript base path discovery failed; continuing with chronicle-only analysis."
 6. Store the discovered path as `transcript_base_path` for use in Steps 2b and 2c.
 

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -156,7 +156,6 @@ Flag patterns that don't meet their fitness criteria as speculative complexity.
    - Dependencies pulled in for marginal gains
 
 3. **Propose Aggressive Reduction**
-   - Propose aggressive reduction
    - Eliminate abstractions that don't earn their keep
    - Replace frameworks with direct solutions
    - Inline rarely-changed "reusable" code
@@ -208,7 +207,7 @@ See `claude/references/verdict-taxonomy.md`. Apply through the lens of complexit
 
 ## Success Criteria
 
-- Achieved 50%+ reduction in components, abstractions, or features
+- Meaningful, measurable reduction in components, abstractions, or features (target 50%+ where baseline complexity justifies it; smaller reductions are valid when the starting point is already lean)
 - Eliminated unnecessary dependencies
 - Replaced general frameworks with specific solutions
 - Maintained or improved core functionality

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -12,7 +12,7 @@ tools: "Read, Write, Grep, Glob, Bash, Agent"
 
 ## Core Mission
 
-Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/*.md`. You never implement code. You plan.
+Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/{SESSION_TS}-{feature-slug}.md`. You never implement code. You plan.
 
 ## Worktree Awareness
 
@@ -20,8 +20,8 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 
 ### Pathfinder-Specific Worktree Rules
 
-- Write all plan files to `{WORKING_DIRECTORY}/plans/{name}.md` instead of `plans/{name}.md`
-- Write `open-questions.md` to `{WORKING_DIRECTORY}/plans/open-questions.md`
+- Write all plan files to `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}.md` instead of `plans/{SESSION_TS}-{feature-slug}.md`
+- Write the open-questions file to `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}-open-questions.md` (e.g., if the plan is `plans/20260401-143022-oauth-login.md`, the open-questions file is `plans/20260401-143022-oauth-login-open-questions.md`)
 - All codebase research (Grep, Glob, Read, Bash) should target `{WORKING_DIRECTORY}` as the search root
 
 ## Key Responsibilities
@@ -30,8 +30,8 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 - Gather requirements through user preferences and priorities
 - Research codebase facts via explore agents
 - Produce work plans with 3-6 actionable steps
-- Save plans to `plans/{name}.md`
-- Track open questions in `plans/open-questions.md`
+- Save plans to `plans/{SESSION_TS}-{feature-slug}.md`
+- Track open questions in `plans/{SESSION_TS}-{feature-slug}-open-questions.md`
 
 ## Operational Workflow
 
@@ -66,6 +66,7 @@ If the delegation prompt contains an `## Intake Brief` section:
 - Do **not** re-ask questions already answered in the brief
 - Use the brief's content directly as requirements input for the plan
 - You may still ask follow-up questions **only** for gaps the brief left open or that codebase research revealed as decision-critical
+- If the brief covers all fields (Objective, Scope, Constraints, Preferences, Success Criteria) with substantive content (not just "N/A" or empty placeholders), skip the interview (section 3) entirely and proceed directly to plan generation (section 4). The user confirmation step (section 4, step 5) still applies.
 
 **Otherwise: check for a Tracebloom Diagnostic Report in the delegation prompt.**
 
@@ -119,7 +120,7 @@ Before saving the plan, run through all 8 questions below. If any question revea
 
 ### 6. Save Plan
 
-Write plan to `plans/{feature-name}.md` using Write tool.
+Write plan to `plans/{SESSION_TS}-{feature-slug}.md` using Write tool.
 
 ## Plan Structure
 
@@ -264,7 +265,7 @@ Mitigation:
 
 ## Open Questions Tracking
 
-Track unresolved questions in `plans/open-questions.md`.
+Track unresolved questions in `plans/{SESSION_TS}-{feature-slug}-open-questions.md`.
 
 ### File Format
 
@@ -322,8 +323,8 @@ Before considering a plan complete, verify:
 **Tool Workflow:**
 1. Use Agent(subagent_type="Explore") for codebase research
 2. Use AskUserQuestion for preference/priority questions
-3. Use Write to save completed plan to `plans/{name}.md`
-4. Use Write to update `plans/open-questions.md` when needed
+3. Use Write to save completed plan to `plans/{SESSION_TS}-{feature-slug}.md`
+4. Use Write to update `plans/{SESSION_TS}-{feature-slug}-open-questions.md` when needed
 
 ## Examples
 

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -191,7 +191,7 @@ Objectives:
 
 ## Consensus Mode (RALPLAN-DR)
 
-When user includes `--consensus` in their message (e.g., "Create a plan for X --consensus"), provide enhanced decision-making structure.
+When `--consensus` is present — either passed by DM delegation or included directly in the user's message (e.g., "Create a plan for X --consensus") — provide enhanced decision-making structure.
 
 ### Standard Consensus Output
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -21,8 +21,6 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 - All documentation reads and writes are relative to `{WORKING_DIRECTORY}`
 - File generation targets `{WORKING_DIRECTORY}/README.md`, `{WORKING_DIRECTORY}/docs/`, etc.
 
-Talekeeper is unaffected by worktree isolation. It writes to gitignored session logs (not to the working tree) and is user-invoked only.
-
 ## Operational Workflow
 
 **1. Gap Analysis**

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -14,7 +14,7 @@ permissionMode: acceptEdits
 When invoked, Talekeeper reads the enriched session chronicle files produced by the Stop hook pipeline, identifies sessions that have not yet been narrated, and does two things:
 
 1. Delivers a concise chat summary of all new sessions directly to the user.
-2. Appends a structured narrative section to `logs/talekeeper-narrative.md`, including per-session Mermaid diagrams showing agent interaction flows.
+2. Adds a structured narrative section to `logs/talekeeper-narrative.md`, including per-session Mermaid diagrams showing agent interaction flows.
 
 After writing narrative output, she records which sessions have been narrated so she does not repeat herself on the next invocation.
 
@@ -87,7 +87,7 @@ Example chat output for two sessions:
 
 ## Written Output: logs/talekeeper-narrative.md
 
-Talekeeper appends a new section to `logs/talekeeper-narrative.md` each time it runs. Never overwrite existing content. If the file does not exist, create it and begin writing with no preamble — start directly with the run header.
+Talekeeper adds a new section to `logs/talekeeper-narrative.md` each time it runs (implemented as read-existing + concatenate-new + write-full-result, since the Write tool overwrites). Always preserve existing content when writing. If the file does not exist, create it and begin writing with no preamble — start directly with the run header.
 
 ### Run Header
 

--- a/claude/commands/open-pr.md
+++ b/claude/commands/open-pr.md
@@ -2,5 +2,7 @@
 description: Open a pull request following the open-pull-request skill workflow
 ---
 
+First, invoke the `validate-before-pr` skill. Run its lint and format checks. Only if both checks pass, proceed to the next step. If either check fails, stop and report the failure -- do not open the PR.
+
 Follow the `open-pull-request` skill exactly — conventional branch naming, conventional PR title,
 draft mode, assigned to @me, pre-flight checklist. Do not use any shortcut or simplified workflow.

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -42,4 +42,4 @@ Compound commands:
 
 ## Applies To
 
-All agents with Bash tool access: Ruinor, Riskmancer, Windwarden, Knotcutter, Truthhammer, Quill, Pathfinder, Bitsmith, Dungeonmaster.
+All agents with Bash tool access: Bitsmith, Dungeonmaster, Knotcutter, Pathfinder, Quill, Riskmancer, Ruinor, Tracebloom, Truthhammer, Windwarden.

--- a/claude/references/github-auth-probe.md
+++ b/claude/references/github-auth-probe.md
@@ -1,0 +1,19 @@
+# GitHub Account Probe — Shared Reference
+
+This file defines the canonical procedure for verifying GitHub account access before pushing or committing. All skills that require GitHub authentication verification must reference this file.
+
+## Probe Procedure
+
+1. **Extract owner/repo:** Parse the remote URL from `git remote get-url origin` to extract `{owner}/{repo}`.
+2. **Probe access:** Run `gh api repos/{owner}/{repo}` as a harmless read-only probe.
+3. **If probe succeeds:** The current authenticated account has access to this repository. Proceed with the operation.
+4. **If probe fails:** Run `gh auth switch` to cycle to the next authenticated GitHub account.
+5. **Repeat:** Probe again with the new account. Continue cycling until access is confirmed or all authenticated accounts are exhausted.
+6. **If all accounts fail:** Abort the operation and report that no authenticated GitHub account has access to this repository.
+
+## Additional Checks (PR workflow only)
+
+When this probe is used before pushing or opening a PR (as opposed to committing):
+
+- **Do not push or open the PR** until the probe succeeds.
+- **Commit author verification:** Once the correct account is confirmed, verify `git config user.email` belongs to that account (cross-check with `gh api user --jq '.email'` if unsure). Fix with `git config user.email "correct@email.com"` if wrong.

--- a/claude/references/review-gates.md
+++ b/claude/references/review-gates.md
@@ -4,7 +4,7 @@ This file defines the shared two-gate framework for all reviewer agents. Each re
 
 ## Plan Review Gate
 
-Before implementation begins, reviewers examine the specific plan file provided by Dungeon Master (typically `plans/{name}.md`).
+Before implementation begins, reviewers examine the specific plan file provided by Dungeon Master (typically `plans/{SESSION_TS}-{feature-slug}.md`).
 
 **Note:** Only review the plan file specified in the request, not all plans in the directory.
 
@@ -16,6 +16,7 @@ After execution completes, reviewers examine the changed files and paths that we
 
 - Reviewers operate read-only — Write and Edit tools are blocked.
 - Return reviews in-memory — provide verdict and findings directly in your response to Dungeon Master. Do NOT write review files.
+- Reviewer agents may run verification commands (tests, linting, static analysis) during reviews. This does not override DM's own no-implementation constraint -- DM delegates review work, it does not execute it.
 
 ## Note on Domain-Specific Criteria
 

--- a/claude/references/worktree-protocol.md
+++ b/claude/references/worktree-protocol.md
@@ -40,3 +40,7 @@ Git commands (commit, branch, status, diff, log) automatically operate on the wo
 ## Role-Specific Additions
 
 Each agent that receives the `WORKING_DIRECTORY:` block may define additional rules governing how the protocol applies to its specific responsibilities (e.g., where plan files are written, where documentation targets are set, how worktree creation is handled). Those additions are defined inline in each agent's definition and complement — but do not override — the shared rules above.
+
+## Agents Not Affected by Worktree Isolation
+
+Talekeeper is unaffected by worktree isolation. It writes to gitignored session logs (not to the working tree) and is user-invoked only.

--- a/claude/skills/commit-message-guide/SKILL.md
+++ b/claude/skills/commit-message-guide/SKILL.md
@@ -123,7 +123,7 @@ Created with `git commit --fixup=<commit-hash>` for automatic squashing during r
 
 Before creating a commit, verify:
 
-- [ ] **GitHub account**: Extract `{owner}/{repo}` from `git remote get-url origin`. Run `gh api repos/{owner}/{repo}` as a harmless probe. If it succeeds, the current account has access — proceed. If it fails, run `gh auth switch` to cycle to the next authenticated account and probe again. Repeat until access is confirmed or all accounts are exhausted. If all accounts fail, abort and report.
+- [ ] **GitHub account**: Verified per the account probe in `claude/references/github-auth-probe.md` (extract `{owner}/{repo}`, probe with `gh api`, switch accounts if needed)
 - [ ] Code builds successfully
 - [ ] All tests pass
 - [ ] Code is formatted (run formatter)

--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -158,8 +158,7 @@ After push, open with draft + assignee, e.g. `gh pr create --draft --assignee @m
 
 ## Pre-flight checklist
 
-- [ ] **GitHub account**: Extract `{owner}/{repo}` from `git remote get-url origin`. Run `gh api repos/{owner}/{repo}` as a harmless probe. If it succeeds, the current account has access — proceed. If it fails, run `gh auth switch` to cycle to the next authenticated account and probe again. Repeat until access is confirmed or all accounts are exhausted. If all accounts fail, abort and report. Do not push or open the PR until the probe succeeds.
-- [ ] **Commit author**: Once the correct account is confirmed, verify `git config user.email` belongs to that account (cross-check with `gh api user --jq '.email'` if unsure). Fix with `git config user.email "correct@email.com"` if wrong.
+- [ ] **GitHub account and commit author**: Verified per the account probe in `claude/references/github-auth-probe.md` (extract `{owner}/{repo}`, probe with `gh api`, switch accounts if needed, verify commit author email)
 - [ ] **Branch has no existing PR**: Verified that the current branch has no open or merged PR—if one exists, switched to main, fetched latest, and created a new branch
 - [ ] **Before push**: all tracked changes (and intended new files) are **committed**—`git status` shows nothing that still needs committing for work going into the PR
 - [ ] History is **compact**: prefer `--amend` / `--fixup` + autosquash; new commits only when scope or topic differs

--- a/claude/skills/validate-before-pr/SKILL.md
+++ b/claude/skills/validate-before-pr/SKILL.md
@@ -19,11 +19,25 @@ This skill is **mandatory** for:
 
 **Do not** open a PR through any means without running this skill first.
 
+## Stack Detection
+
+Before running the checks below, detect which toolchain the repository uses. Check in this order and use the **first match**:
+
+1. **`package.json` exists** (Node/npm): Use `npm run lint` and `npm run format:check` (Steps 1-2 below as written).
+2. **`Makefile` exists with `lint` and `fmt` targets**: Use `make lint` and `make fmt` (substitute these in Steps 1-2).
+3. **`pyproject.toml` exists**: Use `ruff check .` for lint and `ruff format --check .` for format (substitute in Steps 1-2).
+4. **`setup.py` or `setup.cfg` exists** (legacy Python): Use `flake8 .` for lint and `black --check .` for format (substitute in Steps 1-2).
+5. **`go.mod` exists** (Go): Use `golangci-lint run` for lint and `gofmt -l .` for format check (substitute in Steps 1-2; format check passes if `gofmt -l .` produces no output).
+6. **`Cargo.toml` exists** (Rust): Use `cargo clippy` for lint and `cargo fmt --check` for format check (substitute in Steps 1-2).
+7. **No match**: Warn the user that no recognized lint/format toolchain was found. Skip validation and proceed to `open-pull-request` with a note that pre-PR checks were not run.
+
+The npm commands in Steps 1-2 below are the default. When stack detection selects a different toolchain, substitute the corresponding commands but follow the same pass/fail logic.
+
 ## Steps
 
 Each check must be run as a **separate, standalone Bash call**. Do not chain commands with `&&` or `;` — this is required by the bash-style rule.
 
-### Step 1 — Run lint
+### Step 1 — Run lint (npm default: `npm run lint`)
 
 Run the following as a standalone Bash call:
 
@@ -34,7 +48,7 @@ npm run lint
 - If lint **passes** (exit code 0): proceed to Step 2.
 - If lint **fails** (non-zero exit): stop immediately. Do not proceed to format check or PR creation. Report the full lint output to the user and request that the errors be fixed before retrying.
 
-### Step 2 — Run format check
+### Step 2 — Run format check (npm default: `npm run format:check`)
 
 Run the following as a standalone Bash call:
 

--- a/claude/skills/validate-before-pr/SKILL.md
+++ b/claude/skills/validate-before-pr/SKILL.md
@@ -24,7 +24,7 @@ This skill is **mandatory** for:
 Before running the checks below, detect which toolchain the repository uses. Check in this order and use the **first match**:
 
 1. **`package.json` exists** (Node/npm): Use `npm run lint` and `npm run format:check` (Steps 1-2 below as written).
-2. **`Makefile` exists with `lint` and `fmt` targets**: Use `make lint` and `make fmt` (substitute these in Steps 1-2).
+2. **`Makefile` exists with `lint` target**: Use `make lint` for lint. For format check: look for a `make fmt-check`, `make format-check`, or `make check-format` target (exits non-zero on violations without modifying files). If the Makefile only has a `fmt` target that modifies files, skip the format check for this project and warn the user: "Makefile `fmt` target detected but it modifies files — skipping format check. Add a `fmt-check` target to enable it." (substitute lint command in Step 1).
 3. **`pyproject.toml` exists**: Use `ruff check .` for lint and `ruff format --check .` for format (substitute in Steps 1-2).
 4. **`setup.py` or `setup.cfg` exists** (legacy Python): Use `flake8 .` for lint and `black --check .` for format (substitute in Steps 1-2).
 5. **`go.mod` exists** (Go): Use `golangci-lint run` for lint and `gofmt -l .` for format check (substitute in Steps 1-2; format check passes if `gofmt -l .` produces no output).


### PR DESCRIPTION
Fixes a set of documentation inconsistencies identified in a comprehensive review of the `claude/` agent and skill configuration. Unifies the plan filename contract to the session-scoped timestamped format across all agents, aligns Pathfinder's open-questions naming with DM's Phase 5a scheme, and extracts the duplicated GitHub account probe into a shared reference. Adds `validate-before-pr` as an explicit gate in the `/open-pr` command, makes the validation skill stack-agnostic (npm, Make, Python, Go, Rust), and adds a Pathfinder guardrail to skip re-interviewing when an Askmaw brief is already complete. Also resolves several smaller quality issues: Knotcutter's rigid 50% criterion, Talekeeper's misleading "append" semantics, Everwise's missing Cursor path fallback, and a stray Talekeeper note in Quill's definition.