### PR TITLE
feat(references): add quill documentation style guide

### DIFF
--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -12,9 +12,9 @@ permissionMode: acceptEdits
 ## Core Mission
 Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
-## Mandatory Style Constraint
+## Documentation Style
 
-Before writing any documentation, read and follow `claude/skills/quill-documentation-style.md`. This skill is the primary style authority. All documentation decisions defer to it.
+See `claude/references/quill-documentation-style.md` for the standing style guide. All documentation decisions defer to it.
 
 The core rule: document intent, constraints, and decisions. Do not narrate readable code. When details are already clear in source, point to the code instead of restating it.
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -12,6 +12,12 @@ permissionMode: acceptEdits
 ## Core Mission
 Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
+## Mandatory Style Constraint
+
+Before writing any documentation, read and follow `claude/skills/quill-documentation-style.md`. This skill is the primary style authority. All documentation decisions defer to it.
+
+The core rule: document intent, constraints, and decisions. Do not narrate readable code. When details are already clear in source, point to the code instead of restating it.
+
 ## Worktree Awareness
 
 See `claude/references/worktree-protocol.md` for the shared activation rule.

--- a/claude/references/quill-documentation-style.md
+++ b/claude/references/quill-documentation-style.md
@@ -1,4 +1,4 @@
-# Skill: Document for intent, not narration
+# Quill Documentation Style Guide
 
 When generating documentation, assume the code is the primary source of truth and is readable by engineers. Do not rewrite code into prose unless the behavior is non-obvious, risky, or critical to understand.
 
@@ -50,6 +50,7 @@ Before adding documentation detail, check:
 4. Would a pointer to the code be more useful than prose?
 
 If the answer to (1) is yes and (2) is no — do not expand in prose.
+If the answer to (2) is yes — include the explanation; it adds value the code alone does not provide.
 If the answer to (3) is yes — prefer a brief summary plus a code reference.
 If the answer to (4) is yes — point to the code.
 
@@ -66,6 +67,10 @@ If the answer to (4) is yes — point to the code.
 - "The function checks if `x` is null, then iterates through the array, then maps the values…"
 - "This class has three properties: …"
 - "This method calls helper A, then helper B, then returns the result."
+
+## On code examples
+
+Code examples that demonstrate usage are documentation, not narration. Prefer a working example over a prose description of how to call an API, instantiate a class, or configure a module. Examples show; prose tells.
 
 ## By doc type
 

--- a/claude/skills/quill-documentation-style.md
+++ b/claude/skills/quill-documentation-style.md
@@ -1,0 +1,133 @@
+# Skill: Document for intent, not narration
+
+When generating documentation, assume the code is the primary source of truth and is readable by engineers. Do not rewrite code into prose unless the behavior is non-obvious, risky, or critical to understand.
+
+## Core principle
+
+Documentation should explain what the reader cannot quickly infer from code.
+
+Prefer documenting:
+
+- Purpose and intent
+- Architectural role
+- Key decisions and tradeoffs
+- Assumptions and invariants
+- Interfaces and contracts
+- Important flows at a high level
+- Extension points
+- Operational concerns, failure modes, and caveats
+- Where in the codebase the logic lives
+
+Avoid documenting:
+
+- Step-by-step implementation that is already clear in code
+- Obvious control flow
+- Lists of methods, fields, or classes without added insight
+- Prose that mirrors function bodies
+- Details that are easier to verify by opening the source
+
+## Anti-pattern: prose shadowing code
+
+Do not create prose that merely shadows the implementation. If a doc section would read like a paraphrase of the code beneath it, delete the section and point to the code instead.
+
+## Default behavior
+
+When code is self-explanatory:
+
+- Name the relevant module, class, function, or file
+- Briefly state its responsibility in one sentence
+- Point the reader there instead of restating implementation details
+
+Use docs as a map to the codebase, not a transcript of it.
+
+## Decision rule
+
+Before adding documentation detail, check:
+
+1. Can a competent engineer learn this faster by reading the referenced code?
+2. Does this explanation add intent, constraints, or context that the code does not show?
+3. Is this detail likely to become stale if the implementation changes?
+4. Would a pointer to the code be more useful than prose?
+
+If the answer to (1) is yes and (2) is no — do not expand in prose.
+If the answer to (3) is yes — prefer a brief summary plus a code reference.
+If the answer to (4) is yes — point to the code.
+
+## What good documentation looks like
+
+**Good:**
+
+- "Request validation happens in `FooValidator`; this layer defines the contract and the failure semantics."
+- "Retry behavior is centralized in `bar/retry.ts`; the important constraint is that only idempotent operations use it."
+- "The sync pipeline is split into ingest, normalize, and publish stages. Stage boundaries matter because only normalized records are persisted."
+
+**Bad:**
+
+- "The function checks if `x` is null, then iterates through the array, then maps the values…"
+- "This class has three properties: …"
+- "This method calls helper A, then helper B, then returns the result."
+
+## By doc type
+
+### README / service docs
+
+Focus on:
+- What the component does and when to use it
+- Key entry points
+- Major dependencies
+- Config, runtime, and operational caveats
+
+Avoid deep implementation walkthroughs.
+
+### Design docs / technical specs
+
+Focus on:
+- Decisions, tradeoffs, and alternatives considered
+- Data flow, boundaries, and invariants
+- Risks
+
+Avoid re-explaining code structure that already exists.
+
+### ADRs
+
+Focus on:
+- Decision, context, and consequences
+- Rejected alternatives
+
+Avoid implementation narration except where it materially affects the decision.
+
+### Inline code comments / docstrings
+
+Use for:
+- Non-obvious behavior
+- Contract details (units, edge cases, side effects)
+- Surprising constraints
+
+Avoid comments that merely paraphrase the next line of code.
+
+## Style rules
+
+- Be concise.
+- Prefer references to exact code locations over repeated prose.
+- Summarize responsibilities, not mechanics.
+- Explain why more than how.
+- Treat the reader as capable of reading code.
+- Do not inflate docs with exhaustive descriptions unless explicitly requested.
+
+## Compression rule
+
+For every section, ask: "Am I helping the reader understand, decide, debug, extend, or operate?"
+
+If not, cut it.
+
+## Output preference
+
+When in doubt, structure entries as:
+
+- **What it is**
+- **Why it exists**
+- **Important constraints**
+- **Where the logic lives**
+- **What is non-obvious**
+
+Do not include implementation walkthroughs unless necessary for correctness or operations.


### PR DESCRIPTION
Quill would generate verbose documentation that paraphrases readable code — summarizing what functions do, restating parameters, and narrating structure that is already clear from the source. Over time, this kind of documentation drifts from the code it describes and adds maintenance burden without adding clarity.

This adds `claude/references/quill-documentation-style.md`, a standing style guide that enforces intent-not-narration documentation: write why, not what; point to code rather than re-explain it; omit docs that add no information. The guide is wired directly into Quill's agent definition so it governs every documentation pass Quill performs.