### PR TITLE
feat(hooks): add compound-command enforcement and permission-learning hooks

### DIFF
--- a/claude/hooks/permission-learn.sh
+++ b/claude/hooks/permission-learn.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# permission-learn.sh — PermissionRequest hook
+# Denies compound Bash commands; logs single-command requests for manual review.
+# Fails open if jq is unavailable.
+
+# Read hook payload from stdin
+STDIN_DATA=""
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+[ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
+
+# Fail open if jq is unavailable
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+# Extract tool name and command — only act on Bash calls with a non-empty command
+TOOL_NAME=$(echo "$STDIN_DATA" | jq -r '.tool_name // ""' 2>/dev/null)
+COMMAND=$(echo "$STDIN_DATA" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Extract agent metadata — default to "none" if absent
+AGENT_ID=$(echo "$STDIN_DATA" | jq -r '.agent_id // "none"' 2>/dev/null)
+AGENT_TYPE=$(echo "$STDIN_DATA" | jq -r '.agent_type // "none"' 2>/dev/null)
+
+# Strip quoted strings to avoid false positives on literal && or ; inside strings.
+# Double-quote stripping first (removes any single quotes nested inside double-quoted strings),
+# then single-quote stripping second.
+STRIPPED=$(printf '%s' "$COMMAND" | sed 's/"[^"]*"//g')
+STRIPPED=$(printf '%s' "$STRIPPED" | sed "s/'[^']*'//g")
+
+# Check for compound operators in the stripped command
+COMPOUND=0
+if printf '%s' "$STRIPPED" | grep -q '&&'; then
+  COMPOUND=1
+fi
+if printf '%s' "$STRIPPED" | grep -q ';'; then
+  COMPOUND=1
+fi
+NEWLINE_COUNT=$(printf '%s' "$STRIPPED" | wc -l | tr -d ' ')
+if [ "$NEWLINE_COUNT" -gt 0 ]; then
+  COMPOUND=1
+fi
+
+if [ "$COMPOUND" -eq 1 ]; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PermissionRequest",
+      decision: {
+        behavior: "deny",
+        message: "Compound commands (&&, ;, newlines) are not allowed. Split into separate Bash calls — one command per call."
+      }
+    }
+  }'
+  exit 0
+fi
+
+# Single command — log the request for manual review, then exit 0 with no JSON
+# output so the normal permission dialog handles it.
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+LOG_FILE="$HOME/.claude/permission-requests.log"
+printf '%s | agent_type=%s | agent_id=%s | command=%s\n' \
+  "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >> "$LOG_FILE"
+
+exit 0

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -6,6 +6,8 @@ This file defines the required Bash command style for all agents. It is the auth
 
 Never chain commands using `&&` or `;` as sequential execution operators. Always issue each command as a separate, standalone Bash call.
 
+**Enforcement:** This rule is enforced automatically by the `PermissionRequest` hook (`permission-learn.sh`) in `claude/settings.json`. Any compound Bash command will be denied at the permission stage with a clear error message directing you to split the command into separate calls.
+
 Pipes (`|`) are permitted **only for data transformation** (feeding the output of one command into a filter). Do not use pipes as a substitute for sequential control flow.
 
 **Wrong — sequential chaining:**

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -65,6 +65,28 @@
     "mcp__kubernetes__ping"
   ],
   "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/permission-learn.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/session-start.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "hooks": [

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,6 +17,37 @@ Pre-configured marketplaces for plugin discovery:
 
 Hooks allow you to run automated checks or tasks at specific points in your Claude workflow.
 
+#### PermissionRequest Hook - Compound Command Enforcement and Request Logging
+
+Runs when a Bash command falls outside the `allowedTools` list and requires permission.
+
+**Behavior:**
+1. Reads the permission request event from stdin
+2. Extracts the Bash command and strips quoted strings to avoid false positives
+3. Detects compound operators: `&&`, `;` (semicolon), or embedded newlines
+4. Denies permission if compound operators are found, returning a message directing the agent to split the command into separate Bash calls
+5. For single commands, appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
+6. Fails open (no output, exit 0) if `jq` is unavailable
+
+**Purpose:** Enforces the no-compound-commands rule defined in `claude/references/bash-style.md` at the permission stage. Keeps the human permission checkpoint intact for any single command not already covered by `allowedTools`, while providing a log for manual review of what commands are being requested.
+
+**Configuration:**
+- Script: `claude/hooks/permission-learn.sh`
+- Type: PermissionRequest hook
+- Timeout: 5 seconds
+- Requires `jq`; fails gracefully if unavailable
+
+**Log format** (`~/.claude/permission-requests.log`):
+```
+2026-04-09T14:27:44Z | agent_type=Bitsmith | agent_id=abc123 | command=npm install express
+```
+
+**Example:**
+- Denied: `git status && git diff` (contains `&&` — agent is told to split into separate calls)
+- Denied: `cd repo ; npm install` (contains `;`)
+- Logged + normal dialog: `docker ps` (single command not in allowedTools)
+- Allowed silently: `grep "a && b" file.txt` (compound operator is inside a quoted string)
+
 #### SubagentStop Hook - Session Capture
 
 Runs after every sub-agent completion to capture raw session event data.


### PR DESCRIPTION
Adds two user-scope Claude Code hooks to mechanically enforce the no-compound-commands bash style rule and reduce permission fatigue.

`bash-no-chain.sh` (PreToolUse) blocks any Bash call containing `&&`, `;` chaining, or bare newlines before execution, returning an in-context message that directs agents to split into separate calls. `permission-learn.sh` (PermissionRequest) denies compound commands at the permission layer and auto-promotes clean single commands to `localSettings`, so they stop prompting in future sessions.

Enforcement note added to `bash-style.md`; full configuration docs added to `docs/CONFIGURATION.md`.

Known trade-offs (tracked in plans/open-questions): for/while loop semicolons are flagged as false positives (rare in agent usage); `settings.local.json` grows with exact-match rules over time (periodic pruning recommended).