### PR TITLE
feat(launcher): add myclaude interactive session wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,84 @@ Currently configured servers:
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
 
+### myclaude — Session Launcher
+
+The `myclaude` command is an interactive wizard that configures MCP environment variables and launches Claude with the Dungeon Master agent. Instead of manually exporting environment variables before each session, you run `myclaude` from your shell to select your desired MCPs and their configuration (Grafana cluster + role, AWS profile), then launch a pre-configured Claude session.
+
+**Prerequisites:** Run `./install.sh` first to install the launcher to `~/bin/myclaude`.
+
+**Usage:** From any directory, run:
+
+```bash
+myclaude
+```
+
+The wizard will present a multi-step flow:
+
+1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana and/or CloudWatch)
+2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch)
+3. **Launch** — Claude opens with `--agent dungeonmaster` and the correct environment variables set
+
+**Persistence:** Your last-used selections are saved to `~/.config/myclaude/config.json` and pre-fill the wizard on your next run. You can accept them with Enter or change them.
+
+#### Grafana Configuration
+
+Create `~/.config/grafana-clusters.yaml` with your cluster definitions. The file must use this YAML schema:
+
+```yaml
+clusters:
+  - id: prod-us-east
+    name: Production US-East
+    url: https://grafana.prod.us-east.example.com
+    viewer_token: glsa_xxxxxxxxxxxxxxxx_viewer
+    editor_token: glsa_xxxxxxxxxxxxxxxx_editor
+
+  - id: staging
+    name: Staging
+    url: https://grafana.staging.example.com
+    viewer_token: glsa_yyyyyyyyyyyyyyyy_viewer
+    editor_token: glsa_yyyyyyyyyyyyyyyy_editor
+```
+
+Each cluster requires:
+- `id` — Unique identifier for the cluster
+- `name` — Display name shown in the wizard
+- `url` — Grafana URL (must start with `http://` or `https://`)
+- `viewer_token` — Grafana service account token with read-only permissions
+- `editor_token` — Grafana service account token with read-write permissions
+
+The wizard lets you select a cluster and choose a role (Viewer or Editor). If you select Viewer, the launcher automatically sets `GRAFANA_DISABLE_WRITE=true`, which the Grafana MCP server wrapper translates into the `--disable-write` CLI flag.
+
+**Legacy token migration:** If your clusters use a single `token` field instead of separate `viewer_token`/`editor_token` fields, the launcher will fall back to using `token` as `viewer_token` with a warning. Update your YAML to add the new token fields to remove the warning.
+
+#### CloudWatch Configuration
+
+The launcher reads AWS profiles from `~/.aws/config` (standard AWS CLI configuration). In the wizard, select your active profile for the current session. The launcher stores this choice in `~/.claude/.current-aws-profile` so the CloudWatch MCP server wrapper can resolve it at startup.
+
+**Note:** This is equivalent to running `/set-aws-profile` in Claude — the launcher and the slash command write to the same dotfile, so they stay in sync.
+
+#### Environment Variables Set by myclaude
+
+When you select Grafana with Viewer role, the launcher sets:
+```
+GRAFANA_URL={cluster_url}
+GRAFANA_SERVICE_ACCOUNT_TOKEN={viewer_token}
+GRAFANA_DISABLE_WRITE=true
+```
+
+When you select Grafana with Editor role:
+```
+GRAFANA_URL={cluster_url}
+GRAFANA_SERVICE_ACCOUNT_TOKEN={editor_token}
+```
+
+When you select CloudWatch:
+```
+AWS_PROFILE={profile}
+```
+
+These variables are passed to `claude --agent dungeonmaster`, and they flow through to all MCP server subprocesses.
+
 #### MCP Server Configuration Format
 
 Server definitions are stored in `/mcp-servers.json` (repository root) using a declarative JSON schema. This allows configuration changes without modifying the installer code.

--- a/installer/launcher-install.ts
+++ b/installer/launcher-install.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+import { backupIfExists } from "./fs-utils.js";
+import { c } from "./colors.js";
+
+// Directories within launcher/ that should be copied to the installed location.
+// Update this list when adding new subdirectories under launcher/.
+// test/ is intentionally excluded (dev-only).
+const LAUNCHER_SUBDIRS_TO_COPY = ["mcp"];
+
+// Files in launcher/ root that must NOT be copied as TypeScript source.
+// These are handled separately or excluded entirely.
+const LAUNCHER_ROOT_EXCLUDE = new Set([
+  "package.json", // copied separately
+  "myclaude.sh", // copied to ~/bin, not to launcher dir
+  "README.md", // dev-only documentation
+]);
+
+export function installLauncherScript(
+  repoRoot: string,
+  {
+    skipNpmInstall = false,
+    homeDir = os.homedir(),
+  }: { skipNpmInstall?: boolean; homeDir?: string } = {},
+): void {
+  const srcLauncherDir = path.join(repoRoot, "launcher");
+  const destLauncherDir = path.join(homeDir, ".claude", "launcher");
+  const binDir = path.join(homeDir, "bin");
+  const targetBinPath = path.join(binDir, "myclaude");
+  const srcBashScript = path.join(srcLauncherDir, "myclaude.sh");
+  const srcPackageJson = path.join(srcLauncherDir, "package.json");
+
+  // 1. Create destination directory
+  // On re-install: remove all non-node_modules content to prevent stale .ts files
+  if (fs.existsSync(destLauncherDir)) {
+    for (const entry of fs.readdirSync(destLauncherDir, {
+      withFileTypes: true,
+    })) {
+      if (entry.name === "node_modules") continue;
+      fs.rmSync(path.join(destLauncherDir, entry.name), {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
+  fs.mkdirSync(destLauncherDir, { recursive: true });
+
+  // 2. Copy root-level .ts files (excluding test/, package.json, myclaude.sh, README.md)
+  const rootEntries = fs.readdirSync(srcLauncherDir, { withFileTypes: true });
+  for (const entry of rootEntries) {
+    if (
+      entry.isFile() &&
+      entry.name.endsWith(".ts") &&
+      !LAUNCHER_ROOT_EXCLUDE.has(entry.name)
+    ) {
+      fs.copyFileSync(
+        path.join(srcLauncherDir, entry.name),
+        path.join(destLauncherDir, entry.name),
+      );
+    }
+  }
+
+  // 3. Copy allowed subdirectories (mcp/ etc.) — one level deep, .ts files only
+  for (const subdir of LAUNCHER_SUBDIRS_TO_COPY) {
+    const srcSubdir = path.join(srcLauncherDir, subdir);
+    const destSubdir = path.join(destLauncherDir, subdir);
+    if (!fs.existsSync(srcSubdir)) continue;
+    fs.mkdirSync(destSubdir, { recursive: true });
+    const subEntries = fs.readdirSync(srcSubdir, { withFileTypes: true });
+    for (const entry of subEntries) {
+      if (entry.isFile() && entry.name.endsWith(".ts")) {
+        fs.copyFileSync(
+          path.join(srcSubdir, entry.name),
+          path.join(destSubdir, entry.name),
+        );
+      }
+    }
+  }
+
+  // 4. Copy package.json
+  fs.copyFileSync(srcPackageJson, path.join(destLauncherDir, "package.json"));
+
+  // 5. Run npm install in the destination directory
+  if (!skipNpmInstall) {
+    console.log("Installing launcher dependencies...");
+    try {
+      execSync("npm install", {
+        cwd: destLauncherDir,
+        stdio: "inherit",
+      });
+    } catch (err) {
+      console.error(
+        c.red(
+          `Failed to install launcher dependencies in ${destLauncherDir}.\n` +
+            `Run: cd ${destLauncherDir} && npm install`,
+        ),
+      );
+      throw err;
+    }
+  }
+
+  // 6. Install ~/bin/myclaude — refuse symlinks, backup existing
+  fs.mkdirSync(binDir, { recursive: true });
+  try {
+    const stat = fs.lstatSync(targetBinPath);
+    if (stat.isSymbolicLink()) {
+      console.warn(
+        c.yellow(
+          `Warning: ${targetBinPath} is a symlink. Remove it manually before re-running install.sh.`,
+        ),
+      );
+      return;
+    }
+  } catch {
+    // File does not exist — fine
+  }
+  backupIfExists(targetBinPath);
+  fs.copyFileSync(srcBashScript, targetBinPath);
+  fs.chmodSync(targetBinPath, 0o755);
+
+  console.log(c.green(`Launcher installed to ~/bin/myclaude`));
+  console.log(c.green(`Launcher source installed to ~/.claude/launcher/`));
+}

--- a/installer/main.ts
+++ b/installer/main.ts
@@ -2,6 +2,7 @@ import { parseArgs } from "./cli.js";
 import { installDir } from "./fs-utils.js";
 import { installClaudeWhitelist } from "./claude.js";
 import { installMcpServers } from "./mcp.js";
+import { installLauncherScript } from "./launcher-install.js";
 import { c } from "./colors.js";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
@@ -27,6 +28,9 @@ try {
 
   console.log("");
   installMcpServers(scriptDir);
+
+  console.log("");
+  installLauncherScript(scriptDir);
 
   console.log("");
   console.log(c.green("✓ Installation complete!"));

--- a/installer/test/launcher-install.test.ts
+++ b/installer/test/launcher-install.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { installLauncherScript } from "../launcher-install.js";
+
+function makeFakeLauncherRepo(root: string): void {
+  const launcherDir = path.join(root, "launcher");
+  const mcpDir = path.join(launcherDir, "mcp");
+  fs.mkdirSync(launcherDir, { recursive: true });
+  fs.mkdirSync(mcpDir, { recursive: true });
+  fs.mkdirSync(path.join(launcherDir, "test"), { recursive: true });
+
+  fs.writeFileSync(path.join(launcherDir, "main.ts"), "// main");
+  fs.writeFileSync(path.join(launcherDir, "config.ts"), "// config");
+  fs.writeFileSync(path.join(launcherDir, "types.ts"), "// types");
+  fs.writeFileSync(path.join(mcpDir, "grafana.ts"), "// grafana");
+  fs.writeFileSync(path.join(mcpDir, "cloudwatch.ts"), "// cloudwatch");
+  fs.writeFileSync(path.join(launcherDir, "test", "config.test.ts"), "// test");
+  fs.writeFileSync(path.join(launcherDir, "README.md"), "# readme");
+  fs.writeFileSync(
+    path.join(launcherDir, "package.json"),
+    JSON.stringify({
+      name: "myclaude-launcher",
+      dependencies: { tsx: "^4.21.0" },
+    }),
+  );
+  const shContent =
+    [
+      "#!/usr/bin/env bash",
+      'LAUNCHER_DIR="$HOME/.claude/launcher"',
+      'exec "$LAUNCHER_DIR/node_modules/.bin/tsx" main.ts "$@"',
+    ].join("\n") + "\n";
+  fs.writeFileSync(path.join(launcherDir, "myclaude.sh"), shContent);
+  fs.chmodSync(path.join(launcherDir, "myclaude.sh"), 0o755);
+}
+
+describe("installLauncherScript", () => {
+  let fakeRepo: string;
+  let fakeHome: string;
+
+  before(() => {
+    fakeRepo = fs.mkdtempSync(path.join(os.tmpdir(), "launcher-test-repo-"));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "launcher-test-home-"));
+    makeFakeLauncherRepo(fakeRepo);
+  });
+
+  after(() => {
+    fs.rmSync(fakeRepo, { recursive: true, force: true });
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("copies root-level .ts files to ~/.claude/launcher/", () => {
+    installLauncherScript(fakeRepo, {
+      skipNpmInstall: true,
+      homeDir: fakeHome,
+    });
+    const dest = path.join(fakeHome, ".claude", "launcher");
+    assert.ok(fs.existsSync(path.join(dest, "main.ts")));
+    assert.ok(fs.existsSync(path.join(dest, "config.ts")));
+    assert.ok(fs.existsSync(path.join(dest, "types.ts")));
+  });
+
+  it("copies mcp/ subdirectory .ts files", () => {
+    const dest = path.join(fakeHome, ".claude", "launcher", "mcp");
+    assert.ok(fs.existsSync(path.join(dest, "grafana.ts")));
+    assert.ok(fs.existsSync(path.join(dest, "cloudwatch.ts")));
+  });
+
+  it("does NOT copy test/ directory", () => {
+    const dest = path.join(fakeHome, ".claude", "launcher");
+    assert.ok(!fs.existsSync(path.join(dest, "test")));
+  });
+
+  it("does NOT copy README.md or myclaude.sh into launcher dir", () => {
+    const dest = path.join(fakeHome, ".claude", "launcher");
+    assert.ok(!fs.existsSync(path.join(dest, "README.md")));
+    assert.ok(!fs.existsSync(path.join(dest, "myclaude.sh")));
+  });
+
+  it("copies package.json to launcher dir", () => {
+    const dest = path.join(fakeHome, ".claude", "launcher", "package.json");
+    assert.ok(fs.existsSync(dest));
+    const pkg = JSON.parse(fs.readFileSync(dest, "utf8")) as { name?: string };
+    assert.equal(pkg.name, "myclaude-launcher");
+  });
+
+  it("installs ~/bin/myclaude with correct content and permissions", () => {
+    const binScript = path.join(fakeHome, "bin", "myclaude");
+    assert.ok(fs.existsSync(binScript));
+    const content = fs.readFileSync(binScript, "utf8");
+    assert.ok(
+      content.includes("$HOME/.claude/launcher"),
+      "should reference launcher dir",
+    );
+    assert.ok(
+      content.startsWith("#!/usr/bin/env bash"),
+      "should have bash shebang",
+    );
+    const mode = fs.statSync(binScript).mode & 0o777;
+    assert.equal(mode, 0o755, "should be executable");
+  });
+
+  it("cleans stale files on re-install", () => {
+    // Plant a stale file in the destination
+    const dest = path.join(fakeHome, ".claude", "launcher");
+    fs.writeFileSync(path.join(dest, "stale.ts"), "// stale");
+
+    // Re-run install
+    installLauncherScript(fakeRepo, {
+      skipNpmInstall: true,
+      homeDir: fakeHome,
+    });
+
+    // Stale file should be gone
+    assert.ok(!fs.existsSync(path.join(dest, "stale.ts")));
+    // Real files should still be there
+    assert.ok(fs.existsSync(path.join(dest, "main.ts")));
+  });
+});

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,0 +1,82 @@
+# Launcher Module — myclaude Interactive Wizard
+
+The launcher is a TypeScript module that implements the `myclaude` interactive wizard. It allows users to configure MCP environment variables and launch Claude with the Dungeon Master agent in a single command.
+
+## Quick Start
+
+From the repository root:
+
+```bash
+npm run launch
+```
+
+Or directly:
+
+```bash
+npx tsx launcher/main.ts
+```
+
+After installation via `./install.sh`, the launcher is available as:
+
+```bash
+myclaude
+```
+
+## Testing
+
+Tests live in `launcher/test/`. Run all tests (installer + launcher) with:
+
+```bash
+npm test
+```
+
+## Grafana Configuration Format
+
+The launcher reads `~/.config/grafana-clusters.yaml`. Required structure:
+
+```yaml
+clusters:
+  - id: prod-us-east
+    name: Production US-East
+    url: https://grafana.prod.example.com
+    viewer_token: glsa_xxxxxxxxxxxxxxxx_viewer
+    editor_token: glsa_xxxxxxxxxxxxxxxx_editor
+```
+
+**Required fields:** `id`, `name`, `url`, `viewer_token`, `editor_token`.
+
+**Legacy fallback:** If a cluster has only a `token` field, the launcher warns and uses it as `viewer_token` (see `mcp/grafana.ts` for details). Ensure the file is readable only by the user: `chmod 600 ~/.config/grafana-clusters.yaml`.
+
+## Environment Variables and Role Translation
+
+The launcher constructs environment variables based on user selections:
+
+- **Grafana Viewer:** Sets `GRAFANA_DISABLE_WRITE=true`, which `wrappers/mcp-grafana.sh` translates to `--disable-write` for the Grafana MCP server.
+- **Grafana Editor:** Does not set `GRAFANA_DISABLE_WRITE` (read-write mode).
+- **CloudWatch:** Writes the selected AWS profile to `~/.claude/.current-aws-profile` (shared with the CloudWatch MCP wrapper).
+
+## Persistence Format
+
+User selections are saved to `~/.config/myclaude/config.json` with mode 0600. If the file is missing or malformed, the config loader returns a default empty config, and the wizard prompts for selections on first run.
+
+## Architecture
+
+The wizard orchestration lives in `main.ts`. Type definitions are in `types.ts`. MCP-specific logic is split across:
+
+- `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
+- `mcp/cloudwatch.ts` — AWS profile parsing and profile selection
+
+Shared utilities (cancellation, prompts) are in `utils.ts` and `prompts.ts`. The `env.ts` module builds environment variables; `config.ts` handles persistence; `launch.ts` executes the final Claude command.
+
+## Integration with install.sh
+
+Installation is handled by `installer/launcher-install.ts`. The process is idempotent: it cleans prior artifacts, copies source to `~/.claude/launcher/`, runs `npm install` locally, and installs the `~/bin/myclaude` bootstrap script. The installed launcher has zero runtime dependency on the ai-tpk repository.
+
+## Migration: Existing grafana-mcp Script
+
+Users with the legacy `~/bin/grafana-mcp` script can continue using it or switch to `myclaude`. The two are independent; there is no automatic migration.
+
+## See Also
+
+- **`wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
+- **`installer/launcher-install.ts`** — Installation logic for the launcher

--- a/launcher/config.ts
+++ b/launcher/config.ts
@@ -1,0 +1,30 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { LauncherConfig } from "./types.js";
+
+const CONFIG_DIR = path.join(os.homedir(), ".config", "myclaude");
+const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
+
+const DEFAULT_CONFIG: LauncherConfig = {
+  selectedMcps: [],
+};
+
+export function loadConfig(): LauncherConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_FILE, "utf8");
+    const parsed = JSON.parse(raw) as LauncherConfig;
+    return parsed;
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function saveConfig(config: LauncherConfig): void {
+  // 0o700 on directory, 0o600 on file — config reveals operational context (cluster names, profiles)
+  fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
+    mode: 0o600,
+    encoding: "utf8",
+  });
+}

--- a/launcher/env.ts
+++ b/launcher/env.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { ResolvedConfig } from "./types.js";
+
+const AWS_PROFILE_DOTFILE = path.join(
+  os.homedir(),
+  ".claude",
+  ".current-aws-profile",
+);
+
+export function buildEnvVars(config: ResolvedConfig): Record<string, string> {
+  const envVars: Record<string, string> = {};
+
+  if (config.grafana) {
+    const { cluster, role } = config.grafana;
+    envVars["GRAFANA_URL"] = cluster.url;
+
+    if (role === "viewer") {
+      envVars["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.viewer_token;
+      envVars["GRAFANA_DISABLE_WRITE"] = "true";
+    } else {
+      // editor role — no GRAFANA_DISABLE_WRITE
+      envVars["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.editor_token;
+    }
+  }
+
+  if (config.cloudwatch) {
+    const profile = config.cloudwatch.profile;
+    envVars["AWS_PROFILE"] = profile;
+
+    // mcp-cloudwatch.sh reads ~/.claude/.current-aws-profile and overrides AWS_PROFILE.
+    // Write the dotfile so both paths agree — same behaviour as /set-aws-profile command.
+    const dotfileDir = path.dirname(AWS_PROFILE_DOTFILE);
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(AWS_PROFILE_DOTFILE, profile + "\n", {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  }
+
+  return envVars;
+}

--- a/launcher/launch.ts
+++ b/launcher/launch.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "node:child_process";
+
+export function launchClaude(envVars: Record<string, string>): never {
+  // Merge envVars into the current process environment
+  const env = { ...process.env, ...envVars };
+
+  // spawnSync with stdio: "inherit" blocks until claude exits,
+  // then we forward the exit code. This correctly propagates signals and exit status.
+  const result = spawnSync("claude", ["--agent", "dungeonmaster"], {
+    stdio: "inherit",
+    env,
+  });
+
+  process.exit(result.status ?? 1);
+}

--- a/launcher/main.ts
+++ b/launcher/main.ts
@@ -1,0 +1,95 @@
+import { intro, outro, log } from "@clack/prompts";
+import { loadConfig, saveConfig } from "./config.js";
+import { loadGrafanaClusters, configureGrafana } from "./mcp/grafana.js";
+import { loadAwsProfiles, configureCloudWatch } from "./mcp/cloudwatch.js";
+import { selectMcps } from "./prompts.js";
+import { buildEnvVars } from "./env.js";
+import { launchClaude } from "./launch.js";
+import type { ResolvedConfig, LauncherConfig } from "./types.js";
+
+async function main(): Promise<void> {
+  intro("myclaude — Session Launcher");
+
+  const savedConfig = loadConfig();
+
+  // MCP selection
+  const selectedMcps = await selectMcps(savedConfig.selectedMcps);
+
+  const resolved: ResolvedConfig = {};
+  // Carry forward unselected MCP settings so defaults are preserved for next run
+  const updatedConfig: LauncherConfig = {
+    ...savedConfig,
+    selectedMcps,
+  };
+
+  // Grafana configuration
+  if (selectedMcps.includes("grafana")) {
+    let clusters;
+    try {
+      clusters = loadGrafanaClusters();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const grafanaConfig = await configureGrafana(
+      clusters,
+      savedConfig.grafana?.clusterId,
+      savedConfig.grafana?.role,
+    );
+
+    resolved.grafana = grafanaConfig;
+    updatedConfig.grafana = {
+      clusterId: grafanaConfig.cluster.id,
+      role: grafanaConfig.role,
+    };
+  }
+
+  // CloudWatch configuration
+  if (selectedMcps.includes("cloudwatch")) {
+    let profiles;
+    try {
+      profiles = loadAwsProfiles();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const cwConfig = await configureCloudWatch(
+      profiles,
+      savedConfig.cloudwatch?.profile,
+    );
+
+    resolved.cloudwatch = cwConfig;
+    updatedConfig.cloudwatch = {
+      profile: cwConfig.profile,
+    };
+  }
+
+  // Persist updated selections
+  saveConfig(updatedConfig);
+
+  // Build env vars summary for outro
+  const envVars = buildEnvVars(resolved);
+  const lines: string[] = [];
+  if (resolved.grafana) {
+    lines.push(
+      `Grafana: ${resolved.grafana.cluster.name} (${resolved.grafana.role})`,
+    );
+  }
+  if (resolved.cloudwatch) {
+    lines.push(`CloudWatch: ${resolved.cloudwatch.profile}`);
+  }
+  if (lines.length === 0) {
+    lines.push("No MCPs configured — launching Claude with current env.");
+  }
+
+  outro(`Launching: ${lines.join(" · ")}`);
+
+  launchClaude(envVars);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/launcher/mcp/cloudwatch.ts
+++ b/launcher/mcp/cloudwatch.ts
@@ -1,0 +1,60 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { select } from "@clack/prompts";
+import type { CloudWatchConfig } from "../types.js";
+import { handleCancel } from "../utils.js";
+
+const DEFAULT_CONFIG_PATH = path.join(os.homedir(), ".aws", "config");
+
+export function loadAwsProfiles(configPath?: string): string[] {
+  const resolvedPath = configPath ?? DEFAULT_CONFIG_PATH;
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `AWS config not found at ${resolvedPath}. Create it or deselect CloudWatch.`,
+    );
+  }
+
+  const lines = fs.readFileSync(resolvedPath, "utf8").split("\n");
+  const profiles: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Match [default] or [profile <name>]
+    const defaultMatch = /^\[default\]$/i.exec(trimmed);
+    if (defaultMatch) {
+      profiles.push("default");
+      continue;
+    }
+    const profileMatch = /^\[profile\s+([^\]]+)\]$/i.exec(trimmed);
+    if (profileMatch) {
+      const profileName = profileMatch[1].trim();
+      if (profileName) {
+        profiles.push(profileName);
+      }
+    }
+  }
+
+  if (profiles.length === 0) {
+    throw new Error(
+      `No AWS profiles found in ${resolvedPath}. Check the file format.`,
+    );
+  }
+
+  return profiles;
+}
+
+export async function configureCloudWatch(
+  profiles: string[],
+  previousProfile?: string,
+): Promise<CloudWatchConfig> {
+  const profileValue = await select({
+    message: "Select AWS profile for CloudWatch:",
+    options: profiles.map((p) => ({ value: p, label: p })),
+    initialValue: previousProfile ?? profiles[0],
+  });
+  handleCancel(profileValue);
+
+  return { profile: profileValue as string };
+}

--- a/launcher/mcp/grafana.ts
+++ b/launcher/mcp/grafana.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { parse as parseYaml } from "yaml";
+import { log, select, cancel } from "@clack/prompts";
+import type { GrafanaCluster, GrafanaConfig, GrafanaRole } from "../types.js";
+import { handleCancel } from "../utils.js";
+
+const DEFAULT_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".config",
+  "grafana-clusters.yaml",
+);
+
+interface RawCluster {
+  id?: unknown;
+  name?: unknown;
+  url?: unknown;
+  viewer_token?: unknown;
+  editor_token?: unknown;
+  token?: unknown;
+}
+
+export function loadGrafanaClusters(configPath?: string): GrafanaCluster[] {
+  const resolvedPath = configPath ?? DEFAULT_CONFIG_PATH;
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `Grafana clusters config not found at ${resolvedPath}. Create it or deselect Grafana.`,
+    );
+  }
+
+  // Warn if file is world- or group-readable (tokens live here)
+  const stat = fs.statSync(resolvedPath);
+  if (stat.mode & 0o077) {
+    log.warn(
+      `${resolvedPath} is readable by other users. Run: chmod 600 ${resolvedPath}`,
+    );
+  }
+
+  const raw = fs.readFileSync(resolvedPath, "utf8");
+  // maxAliasCount guards against YAML anchor/alias expansion bombs
+  const parsed = parseYaml(raw, { maxAliasCount: 100 }) as {
+    clusters?: RawCluster[];
+  };
+
+  if (!parsed?.clusters || !Array.isArray(parsed.clusters)) {
+    throw new Error(
+      `Grafana clusters config at ${resolvedPath} has no 'clusters' array.`,
+    );
+  }
+
+  if (parsed.clusters.length === 0) {
+    throw new Error(
+      `Grafana clusters config at ${resolvedPath} has an empty 'clusters' array.`,
+    );
+  }
+
+  return parsed.clusters.map((c: RawCluster, idx: number): GrafanaCluster => {
+    const id = String(c.id ?? "");
+    const name = String(c.name ?? "");
+    const url = String(c.url ?? "");
+
+    if (!id || !name) {
+      throw new Error(
+        `Cluster entry at index ${idx} is missing required fields (id, name).`,
+      );
+    }
+
+    if (!url || !/^https?:\/\//i.test(url)) {
+      throw new Error(
+        `Cluster "${name}" has a missing or invalid url (must start with http:// or https://).`,
+      );
+    }
+
+    // Legacy token fallback: warn and use token as viewer_token
+    let viewer_token = String(c.viewer_token ?? "");
+    let editor_token = String(c.editor_token ?? "");
+
+    if (!viewer_token && !editor_token && c.token) {
+      log.warn(
+        `Cluster "${name}" uses legacy 'token' field. Add 'viewer_token' and 'editor_token' to ~/.config/grafana-clusters.yaml.`,
+      );
+      viewer_token = String(c.token);
+      editor_token = "";
+    }
+
+    return { id, name, url, viewer_token, editor_token };
+  });
+}
+
+export async function configureGrafana(
+  clusters: GrafanaCluster[],
+  previousClusterId?: string,
+  previousRole?: GrafanaRole,
+): Promise<GrafanaConfig> {
+  const clusterValue = await select({
+    message: "Select Grafana cluster:",
+    options: clusters.map((c) => ({
+      value: c.id,
+      label: c.name,
+      hint: c.url,
+    })),
+    initialValue: previousClusterId ?? clusters[0]?.id,
+  });
+  handleCancel(clusterValue);
+
+  const selectedCluster = clusters.find((c) => c.id === clusterValue);
+  if (!selectedCluster) {
+    cancel("Selected cluster not found.");
+    process.exit(1);
+  }
+
+  const roleValue = await select<GrafanaRole>({
+    message: "Select access role:",
+    options: [
+      {
+        value: "viewer" as GrafanaRole,
+        label: "Viewer (read-only)",
+        hint: "uses --disable-write",
+      },
+      {
+        value: "editor" as GrafanaRole,
+        label: "Editor (read + write)",
+      },
+    ],
+    initialValue: previousRole ?? "viewer",
+  });
+  handleCancel(roleValue);
+
+  if (roleValue === "editor" && !selectedCluster.editor_token) {
+    cancel(
+      `Cluster "${selectedCluster.name}" has no editor_token configured. Update ~/.config/grafana-clusters.yaml or select Viewer role.`,
+    );
+    process.exit(1);
+  }
+
+  if (roleValue === "viewer" && !selectedCluster.viewer_token) {
+    cancel(
+      `Cluster "${selectedCluster.name}" has no viewer_token configured. Update ~/.config/grafana-clusters.yaml or select Editor role.`,
+    );
+    process.exit(1);
+  }
+
+  return {
+    cluster: selectedCluster,
+    role: roleValue as GrafanaRole,
+  };
+}

--- a/launcher/myclaude.sh
+++ b/launcher/myclaude.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LAUNCHER_DIR="$HOME/.claude/launcher"
+
+if [[ ! -f "$LAUNCHER_DIR/main.ts" ]]; then
+  printf 'Error: myclaude launcher not found at %s\n' "$LAUNCHER_DIR" >&2
+  printf 'Re-run install.sh to reinstall it.\n' >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  printf 'Error: node is not installed or not in PATH. Please install Node.js >= 18.18.0.\n' >&2
+  exit 1
+fi
+
+case ":$PATH:" in
+  *":${HOME}/bin:"*) ;;
+  *)
+    printf 'Warning: ~/bin is not in PATH. Add it to your shell profile to use the myclaude command.\n' >&2
+    ;;
+esac
+
+cd "$LAUNCHER_DIR"
+TSX_BIN="$LAUNCHER_DIR/node_modules/.bin/tsx"
+if [[ ! -x "$TSX_BIN" ]]; then
+  printf 'Error: tsx not found at %s\n' "$TSX_BIN" >&2
+  printf 'Re-run install.sh to reinstall dependencies.\n' >&2
+  exit 1
+fi
+exec "$TSX_BIN" main.ts "$@"

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "myclaude-launcher",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@clack/prompts": "^0.9.0",
+    "tsx": "^4.21.0",
+    "yaml": "^2.7.0"
+  }
+}

--- a/launcher/prompts.ts
+++ b/launcher/prompts.ts
@@ -1,0 +1,18 @@
+import { multiselect } from "@clack/prompts";
+import { handleCancel } from "./utils.js";
+
+export async function selectMcps(
+  previousSelections: string[],
+): Promise<string[]> {
+  const value = await multiselect({
+    message: "Select MCPs to configure for this session:",
+    options: [
+      { value: "grafana", label: "Grafana", hint: "cluster + role" },
+      { value: "cloudwatch", label: "CloudWatch", hint: "AWS profile" },
+    ],
+    initialValues: previousSelections,
+    required: false,
+  });
+  handleCancel(value);
+  return value as string[];
+}

--- a/launcher/test/cloudwatch.test.ts
+++ b/launcher/test/cloudwatch.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadAwsProfiles } from "../mcp/cloudwatch.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), "ai-tpk-cloudwatch-test-"),
+);
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write an AWS config file to the temp dir and return its path
+// ---------------------------------------------------------------------------
+
+function writeAwsConfig(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// loadAwsProfiles
+// ---------------------------------------------------------------------------
+
+describe("loadAwsProfiles", () => {
+  it('parses [default] as "default"', () => {
+    const filePath = writeAwsConfig(
+      "default-only.ini",
+      `
+[default]
+region = us-east-1
+`,
+    );
+    const profiles = loadAwsProfiles(filePath);
+    assert.deepStrictEqual(profiles, ["default"]);
+  });
+
+  it('parses [profile foo-bar] as "foo-bar"', () => {
+    const filePath = writeAwsConfig(
+      "named-profile.ini",
+      `
+[profile foo-bar]
+region = eu-west-1
+`,
+    );
+    const profiles = loadAwsProfiles(filePath);
+    assert.deepStrictEqual(profiles, ["foo-bar"]);
+  });
+
+  it("handles a file with multiple profiles (default + named)", () => {
+    const filePath = writeAwsConfig(
+      "multi-profile.ini",
+      `
+[default]
+region = us-east-1
+
+[profile dev]
+region = us-west-2
+
+[profile prod]
+region = eu-central-1
+`,
+    );
+    const profiles = loadAwsProfiles(filePath);
+    assert.deepStrictEqual(profiles, ["default", "dev", "prod"]);
+  });
+
+  it("ignores non-profile sections (e.g. [sso-session my-session])", () => {
+    const filePath = writeAwsConfig(
+      "with-sso.ini",
+      `
+[default]
+region = us-east-1
+
+[sso-session my-session]
+sso_start_url = https://example.awsapps.com/start
+`,
+    );
+    const profiles = loadAwsProfiles(filePath);
+    assert.deepStrictEqual(profiles, ["default"]);
+  });
+
+  it("trims whitespace from profile names", () => {
+    const filePath = writeAwsConfig(
+      "padded.ini",
+      `
+[profile  padded ]
+region = us-east-1
+`,
+    );
+    const profiles = loadAwsProfiles(filePath);
+    assert.deepStrictEqual(profiles, ["padded"]);
+  });
+
+  it("throws when the config file does not exist", () => {
+    const missingPath = path.join(tmpDir, "does-not-exist.ini");
+    assert.throws(
+      () => loadAwsProfiles(missingPath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("AWS config not found"),
+    );
+  });
+
+  it("throws when no profiles are found in the file", () => {
+    const filePath = writeAwsConfig(
+      "no-profiles.ini",
+      `
+# This file has no profile sections
+region = us-east-1
+output = json
+`,
+    );
+    assert.throws(
+      () => loadAwsProfiles(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("No AWS profiles found"),
+    );
+  });
+});

--- a/launcher/test/config.test.ts
+++ b/launcher/test/config.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadConfig, saveConfig } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// The real CONFIG_FILE path (hardcoded in config.ts — no path injection).
+// We back up any existing file before the suite and restore it after.
+// ---------------------------------------------------------------------------
+
+const configDir = path.join(os.homedir(), ".config", "myclaude");
+// Re-derive using the same logic as config.ts
+const REAL_CONFIG_FILE = path.join(
+  os.homedir(),
+  ".config",
+  "myclaude",
+  "config.json",
+);
+
+// Temp dir for scratch space used in tests that need it
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-config-test-"));
+
+// Snapshot state before any tests run
+let priorContent: string | null = null;
+let priorDirExisted = false;
+
+before(() => {
+  priorDirExisted = fs.existsSync(configDir);
+  if (fs.existsSync(REAL_CONFIG_FILE)) {
+    priorContent = fs.readFileSync(REAL_CONFIG_FILE, "utf8");
+  }
+});
+
+after(() => {
+  // Restore original state
+  if (priorContent !== null) {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(REAL_CONFIG_FILE, priorContent, "utf8");
+  } else if (!priorDirExisted && fs.existsSync(configDir)) {
+    // We created the dir during tests; remove it
+    fs.rmSync(configDir, { recursive: true });
+  } else if (priorDirExisted && fs.existsSync(REAL_CONFIG_FILE)) {
+    // Dir existed but file did not — remove just the file
+    if (priorContent === null) {
+      fs.rmSync(REAL_CONFIG_FILE, { force: true });
+    }
+  }
+
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// Helper: ensure the real config file does not exist before a test
+function removeConfigFile(): void {
+  if (fs.existsSync(REAL_CONFIG_FILE)) {
+    fs.rmSync(REAL_CONFIG_FILE);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// loadConfig
+// ---------------------------------------------------------------------------
+
+describe("loadConfig", () => {
+  it("returns { selectedMcps: [] } when file does not exist", () => {
+    removeConfigFile();
+    const result = loadConfig();
+    assert.deepStrictEqual(result, { selectedMcps: [] });
+  });
+
+  it("returns { selectedMcps: [] } when file contains malformed JSON", () => {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(REAL_CONFIG_FILE, "not valid json {{", "utf8");
+    const result = loadConfig();
+    assert.deepStrictEqual(result, { selectedMcps: [] });
+  });
+
+  it("correctly parses a valid config file", () => {
+    const config = {
+      selectedMcps: ["grafana", "cloudwatch"],
+      cloudwatch: { profile: "my-profile" },
+    };
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(REAL_CONFIG_FILE, JSON.stringify(config), "utf8");
+    const result = loadConfig();
+    assert.deepStrictEqual(result, config);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveConfig
+// ---------------------------------------------------------------------------
+
+describe("saveConfig", () => {
+  it("creates the directory and file when they do not exist", () => {
+    // Remove both file and dir so saveConfig must create them from scratch
+    if (fs.existsSync(REAL_CONFIG_FILE)) {
+      fs.rmSync(REAL_CONFIG_FILE);
+    }
+    if (fs.existsSync(configDir)) {
+      fs.rmSync(configDir, { recursive: true });
+    }
+    saveConfig({ selectedMcps: ["grafana"] });
+    assert.ok(
+      fs.existsSync(REAL_CONFIG_FILE),
+      "config file should exist after saveConfig",
+    );
+  });
+
+  it("overwrites an existing config file", () => {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      REAL_CONFIG_FILE,
+      JSON.stringify({ selectedMcps: ["old"] }),
+      "utf8",
+    );
+    saveConfig({ selectedMcps: ["new"] });
+    const written = JSON.parse(
+      fs.readFileSync(REAL_CONFIG_FILE, "utf8"),
+    ) as unknown;
+    assert.deepStrictEqual(written, { selectedMcps: ["new"] });
+  });
+
+  it("round-trip: saveConfig then loadConfig returns the same data", () => {
+    const config = {
+      selectedMcps: ["grafana", "cloudwatch"],
+      grafana: { clusterId: "prod", role: "viewer" as const },
+      cloudwatch: { profile: "default" },
+    };
+    saveConfig(config);
+    const loaded = loadConfig();
+    assert.deepStrictEqual(loaded, config);
+  });
+
+  it("writes the file with mode 0o600", () => {
+    saveConfig({ selectedMcps: [] });
+    const mode = fs.statSync(REAL_CONFIG_FILE).mode & 0o777;
+    assert.strictEqual(
+      mode,
+      0o600,
+      `expected mode 0o600, got 0o${mode.toString(8)}`,
+    );
+  });
+});

--- a/launcher/test/env.test.ts
+++ b/launcher/test/env.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { buildEnvVars } from "../env.js";
+import type { ResolvedConfig, GrafanaCluster } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Dotfile isolation strategy:
+//
+// `buildEnvVars` writes ~/.claude/.current-aws-profile whenever CloudWatch is
+// configured. We back up the real file before the suite runs and restore it
+// (or remove the file) afterwards. This keeps tests hermetic without
+// suppressing the real write, which means the dotfile path remains exercised.
+// ---------------------------------------------------------------------------
+
+const dotfileDir = path.join(os.homedir(), ".claude");
+const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
+
+let priorDotfileContent: string | null = null;
+
+before(() => {
+  if (fs.existsSync(dotfilePath)) {
+    priorDotfileContent = fs.readFileSync(dotfilePath, "utf8");
+  }
+});
+
+after(() => {
+  if (priorDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(dotfilePath, priorDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(dotfilePath)) {
+    fs.rmSync(dotfilePath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeCluster: GrafanaCluster = {
+  id: "test-cluster",
+  name: "Test Cluster",
+  url: "https://grafana.test.example.com",
+  viewer_token: "viewer-token-abc",
+  editor_token: "editor-token-xyz",
+};
+
+// ---------------------------------------------------------------------------
+// buildEnvVars
+// ---------------------------------------------------------------------------
+
+describe("buildEnvVars", () => {
+  it("Grafana viewer: sets URL, token from viewer_token, and GRAFANA_DISABLE_WRITE=true", () => {
+    const config: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "viewer" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(
+      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      fakeCluster.viewer_token,
+    );
+    assert.strictEqual(env["GRAFANA_DISABLE_WRITE"], "true");
+  });
+
+  it("Grafana editor: sets URL and token from editor_token, and GRAFANA_DISABLE_WRITE is absent", () => {
+    const config: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "editor" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(
+      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      fakeCluster.editor_token,
+    );
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "GRAFANA_DISABLE_WRITE"),
+      "GRAFANA_DISABLE_WRITE must not be present for editor role",
+    );
+  });
+
+  it("CloudWatch only: returns AWS_PROFILE", () => {
+    const config: ResolvedConfig = {
+      cloudwatch: { profile: "my-dev-profile" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["AWS_PROFILE"], "my-dev-profile");
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "GRAFANA_URL"),
+      "GRAFANA_URL must not be present when no Grafana config",
+    );
+  });
+
+  it("Grafana + CloudWatch combined: all keys merged correctly", () => {
+    const config: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "viewer" },
+      cloudwatch: { profile: "prod" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(
+      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      fakeCluster.viewer_token,
+    );
+    assert.strictEqual(env["GRAFANA_DISABLE_WRITE"], "true");
+    assert.strictEqual(env["AWS_PROFILE"], "prod");
+  });
+
+  it("empty config ({}): returns empty env var map", () => {
+    const config: ResolvedConfig = {};
+    const env = buildEnvVars(config);
+    assert.deepStrictEqual(env, {});
+  });
+});

--- a/launcher/test/grafana.test.ts
+++ b/launcher/test/grafana.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadGrafanaClusters } from "../mcp/grafana.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-grafana-test-"));
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write YAML content to a temp file and return the file path
+// ---------------------------------------------------------------------------
+
+function writeYaml(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// loadGrafanaClusters
+// ---------------------------------------------------------------------------
+
+describe("loadGrafanaClusters", () => {
+  it("parses a valid YAML file with viewer_token and editor_token fields", () => {
+    const filePath = writeYaml(
+      "valid.yaml",
+      `
+clusters:
+  - id: prod
+    name: Production
+    url: https://grafana.example.com
+    viewer_token: viewer-tok-123
+    editor_token: editor-tok-456
+`,
+    );
+    const clusters = loadGrafanaClusters(filePath);
+    assert.strictEqual(clusters.length, 1);
+    assert.deepStrictEqual(clusters[0], {
+      id: "prod",
+      name: "Production",
+      url: "https://grafana.example.com",
+      viewer_token: "viewer-tok-123",
+      editor_token: "editor-tok-456",
+    });
+  });
+
+  it("falls back when a cluster has legacy token but no viewer_token/editor_token", () => {
+    // The log.warn call from @clack/prompts may emit to stdout — this is acceptable.
+    const filePath = writeYaml(
+      "legacy.yaml",
+      `
+clusters:
+  - id: staging
+    name: Staging
+    url: https://staging.grafana.example.com
+    token: legacy-tok-789
+`,
+    );
+    const clusters = loadGrafanaClusters(filePath);
+    assert.strictEqual(clusters.length, 1);
+    assert.strictEqual(clusters[0]?.viewer_token, "legacy-tok-789");
+    assert.strictEqual(clusters[0]?.editor_token, "");
+  });
+
+  it("throws when the config file does not exist", () => {
+    const missingPath = path.join(tmpDir, "does-not-exist.yaml");
+    assert.throws(
+      () => loadGrafanaClusters(missingPath),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("Grafana clusters config not found"),
+    );
+  });
+
+  it("throws when the file has no clusters key", () => {
+    const filePath = writeYaml(
+      "no-clusters.yaml",
+      `
+something_else:
+  - id: x
+`,
+    );
+    assert.throws(
+      () => loadGrafanaClusters(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("no 'clusters' array"),
+    );
+  });
+
+  it("throws when the clusters array is empty", () => {
+    const filePath = writeYaml(
+      "empty-clusters.yaml",
+      `
+clusters: []
+`,
+    );
+    assert.throws(
+      () => loadGrafanaClusters(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("empty 'clusters' array"),
+    );
+  });
+
+  it("throws when a cluster entry is missing required id or name fields", () => {
+    const filePath = writeYaml(
+      "missing-fields.yaml",
+      `
+clusters:
+  - url: https://grafana.example.com
+    viewer_token: tok
+    editor_token: tok2
+`,
+    );
+    assert.throws(
+      () => loadGrafanaClusters(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("missing required fields"),
+    );
+  });
+
+  it("throws when a cluster entry has an invalid or missing url", () => {
+    const filePath = writeYaml(
+      "bad-url.yaml",
+      `
+clusters:
+  - id: broken
+    name: Broken
+    url: not-a-url
+    viewer_token: tok
+    editor_token: tok2
+`,
+    );
+    assert.throws(
+      () => loadGrafanaClusters(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("missing or invalid url"),
+    );
+  });
+});

--- a/launcher/types.ts
+++ b/launcher/types.ts
@@ -1,0 +1,34 @@
+export type GrafanaRole = "viewer" | "editor";
+
+export interface GrafanaCluster {
+  id: string;
+  name: string;
+  url: string;
+  viewer_token: string;
+  editor_token: string;
+}
+
+export interface GrafanaConfig {
+  cluster: GrafanaCluster;
+  role: GrafanaRole;
+}
+
+export interface CloudWatchConfig {
+  profile: string;
+}
+
+export interface ResolvedConfig {
+  grafana?: GrafanaConfig;
+  cloudwatch?: CloudWatchConfig;
+}
+
+export interface LauncherConfig {
+  selectedMcps: string[];
+  grafana?: {
+    clusterId: string;
+    role: GrafanaRole;
+  };
+  cloudwatch?: {
+    profile: string;
+  };
+}

--- a/launcher/utils.ts
+++ b/launcher/utils.ts
@@ -1,0 +1,10 @@
+import { isCancel, cancel } from "@clack/prompts";
+
+export function handleCancel(
+  value: unknown,
+): asserts value is NonNullable<unknown> {
+  if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(0);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "ai-tpk",
+      "dependencies": {
+        "@clack/prompts": "^0.9.0",
+        "yaml": "^2.7.0"
+      },
       "devDependencies": {
         "@types/node": "^25.5.2",
         "lefthook": "^2.1.4",
@@ -12,6 +16,27 @@
         "oxlint": "^1.58.0",
         "tsx": "latest",
         "typescript": "latest"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.9.1.tgz",
+      "integrity": "sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.4.1",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1430,6 +1455,12 @@
         }
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1439,6 +1470,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "2.1.0",
@@ -1490,6 +1527,21 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,20 +2,25 @@
   "name": "ai-tpk",
   "private": true,
   "type": "module",
+  "dependencies": {
+    "@clack/prompts": "^0.9.0",
+    "yaml": "^2.7.0"
+  },
   "devDependencies": {
     "@types/node": "^25.5.2",
     "lefthook": "^2.1.4",
     "oxfmt": "^0.43.0",
     "oxlint": "^1.58.0",
-    "tsx": "latest",
+    "tsx": "^4.21.0",
     "typescript": "latest"
   },
   "scripts": {
     "prepare": "lefthook install",
     "setup": "tsx installer/main.ts",
-    "test": "node --import tsx/esm --test 'installer/test/**/*.test.ts'",
-    "lint": "oxlint installer/",
-    "format": "oxfmt --write installer/",
-    "format:check": "oxfmt --check installer/"
+    "launch": "tsx launcher/main.ts",
+    "test": "node --import tsx/esm --test 'installer/test/**/*.test.ts' 'launcher/test/**/*.test.ts'",
+    "lint": "oxlint installer/ launcher/",
+    "format": "oxfmt --write installer/ launcher/",
+    "format:check": "oxfmt --check installer/ launcher/"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["installer/**/*.ts"]
+  "include": ["installer/**/*.ts", "launcher/**/*.ts"]
 }

--- a/wrappers/mcp-grafana.sh
+++ b/wrappers/mcp-grafana.sh
@@ -4,4 +4,9 @@ set -euo pipefail
 : "${GRAFANA_URL:?Error: GRAFANA_URL is not set}"
 : "${GRAFANA_SERVICE_ACCOUNT_TOKEN:?Error: GRAFANA_SERVICE_ACCOUNT_TOKEN is not set}"
 
-exec uvx mcp-grafana "$@"
+EXTRA_ARGS=()
+if [[ "${GRAFANA_DISABLE_WRITE:-}" == "true" ]]; then
+  EXTRA_ARGS+=("--disable-write")
+fi
+
+exec uvx mcp-grafana "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
Adds `myclaude`, a TypeScript wizard installed to `~/bin/myclaude` by `./install.sh`. It walks through Grafana cluster/role and CloudWatch profile selection before launching `claude --agent dungeonmaster` with the correct environment variables. Viewer role enforces server-side read-only mode via `--disable-write`. Selections persist so repeat sessions skip through to launch.

**Setup required:** update `~/.config/grafana-clusters.yaml` to use `viewer_token`/`editor_token` per cluster (legacy `token` field is accepted with a warning).