### PR TITLE
docs(.claude): document clone-run-forget repo design intent

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,3 +27,17 @@ Before performing any of these actions, stop and ask: **"Repo scope (`.claude/`)
 2. **Show the concrete paths.** When asking, include the actual directory paths so the user can confirm without needing to remember the mapping.
 3. **For artifact types that only exist in user scope today** (agents, commands, hooks, references): still confirm intent, because the user may want to create a repo-scope equivalent or may be confused about where the artifact will land.
 4. **Do not skip this step** even if the user's request seems to imply a scope. Explicit confirmation prevents mistakes.
+
+## Repository Design Intent (Mandatory Context)
+
+This repository is a **clone → run → forget** tool.
+
+The workflow is:
+1. User clones the repo
+2. User runs `install.sh`
+3. `install.sh` copies the contents of `claude/` (agents, skills, commands, hooks, references, settings, CLAUDE.md) to `~/.claude/`, and `wrappers/` to `~/.claude/wrappers/`. It also registers MCP servers. Additional harnesses may be supported in future.
+4. The installed artifacts are fully self-contained — they carry no references back to the repo. The repo may be retained for future updates (re-run `install.sh` after `git pull`), but this is optional.
+
+**Critical implication for all changes:** The installed artifacts carry **no back-references to this repository**. Once copied, they are standalone files at their destination. Any change you make must therefore be complete and self-contained within the artifact itself — do not add relative paths, symlinks, or runtime references that assume the repo still exists on disk.
+
+This self-containment constraint applies to everything `install.sh` installs — the contents of `claude/` and `wrappers/`. It does **not** apply to repo-scope artifacts in `.claude/`, which are only active when the repo is checked out. When reviewing or authoring any artifact in `claude/` or `wrappers/`, always ask: *"Will this work correctly after being copied to its destination with no repo present?"*


### PR DESCRIPTION
Adds a mandatory context section to `.claude/CLAUDE.md` so AI agents understand this repo's design: `install.sh` copies `claude/` to `~/.claude/` and `wrappers/` to `~/.claude/wrappers/`; the installed artifacts are fully self-contained with no back-references to the repo. Agents are instructed to apply the self-containment rule to installed artifacts only, not to repo-scope `.claude/` artifacts.