### PR TITLE
fix(wrappers): handle empty EXTRA_ARGS array under set -u in mcp-grafana.sh

### DIFF
--- a/wrappers/mcp-grafana.sh
+++ b/wrappers/mcp-grafana.sh
@@ -9,4 +9,4 @@ if [[ "${GRAFANA_DISABLE_WRITE:-}" == "true" ]]; then
   EXTRA_ARGS+=("--disable-write")
 fi
 
-exec uvx mcp-grafana "${EXTRA_ARGS[@]}" "$@"
+exec uvx mcp-grafana ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} "$@"


### PR DESCRIPTION
Expanding an empty bash array under `set -euo pipefail` triggers an unbound variable error on macOS bash (3.2.x), crashing the wrapper before `uvx mcp-grafana` starts. The fix replaces the unsafe `"${EXTRA_ARGS[@]}"` expansion with the standard `${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}` idiom, which is a no-op when the array is empty and expands normally when it has elements.