### PR TITLE
feat(agents): add Pathfinder scope confirmation + simplify DM options gate

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -123,7 +123,7 @@ Workflow flags control how the DM routes work through the pipeline. They are dis
 
 | Flag | Effect |
 |------|--------|
-| `--explore-options` | Trigger options exploration before execution planning, even if the DM would otherwise proceed directly |
+| `--explore-options` | Advisory-only mode: invoke Pathfinder to surface scope and implementation options, then stop. No plan is written, no execution follows. Use when you want to evaluate approaches before committing. |
 
 ### Worktree Context Block
 
@@ -219,8 +219,7 @@ Before any planning begins, create an isolated git worktree for this session so 
 **Mutual exclusivity note:** After clarifying the goal, classify the task as exactly one of the following branches — only one fires per task, they are not sequential filters:
 - **(a) Investigative** (the task is "why is X broken?" with unknown root cause) → Investigative Gate → Tracebloom
 - **(b) Ambiguous or underspecified** (the task needs clarification before planning) → Intake Gate → Askmaw
-- **(c) Requires options exploration** (architectural decision or multiple viable approaches) → Explore-Options Gate → Pathfinder consensus mode
-- **(d) Ready for planning** (clear, bounded, constructive task) → proceed directly to Pathfinder
+- **(c) Ready for planning** (clear, bounded, constructive task) → proceed to Pathfinder (which will internally handle scope confirmation and options discovery in its Section 4)
 
 **Investigative Gate** (between step 1 and the Intake Gate):
 
@@ -309,20 +308,36 @@ When Askmaw is skipped: proceed to step 2 as before.
 
 2. Assess whether a plan already exists in the `plans/` directory.
 
-**Explore-Options Gate** (between step 2 and step 3):
+**Explore-Options Gate** (advisory-only, between the Intake Gate and step 2):
 
-Trigger options exploration when: the `--explore-options` flag is present, OR the request appears to involve an architectural decision, technology selection, or an ambiguous approach with multiple viable paths.
-
-Suppress options exploration when: the user has already named a specific approach or technology, OR an approved plan already exists in `plans/`. The explicit `--explore-options` flag overrides suppression.
+Trigger ONLY when the `--explore-options` flag is explicitly present.
 
 When triggered:
-- Invoke Pathfinder with a delegation prompt instructing it to use Consensus Mode output format (as if `--consensus` were passed -- note: Pathfinder Consensus Mode is triggered by DM internally here; users may also trigger it directly with `--consensus` in their message), produce 2–4 viable options (not an execution plan), and return the options for user selection.
-- Present the options inline in the conversation — each option's name, summary, and Pathfinder's recommendation — then ask the user to select one or request changes. Do not proceed until the user responds.
-- **If user selects an option:** Re-invoke Pathfinder for an execution plan, passing both the selected option name and the full Consensus Mode output as context so Pathfinder does not re-research from scratch.
-- **If user rejects all options and requests different approaches:** Re-invoke Pathfinder in Consensus Mode with the user's feedback as additional constraints, then re-present options.
-- **If user wants to modify one option:** Re-invoke Pathfinder for an execution plan with the user's modifications folded in as constraints.
+- Invoke Pathfinder with `STOP_AFTER_SCOPE: true`. Pathfinder researches the codebase, produces a Scope Confirmation (objective, assumptions, affected subsystems, out of scope) and implementation options, then returns this output to DM without writing a plan.
+- DM presents scope + options to the user and waits for explicit selection. Do not proceed until the user responds.
+- **If the user does not ask to proceed with planning:** The advisory session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
+- **If user selects an option and asks to continue:** Re-invoke Pathfinder with the `## Confirmed Scope` block (using the re-invocation template below) and proceed to step 3.
 
-When not triggered: proceed directly to step 3.
+**Pathfinder re-invocation template (after scope confirmation):**
+
+````
+WORKING_DIRECTORY: {WORKTREE_PATH}
+WORKTREE_BRANCH: {WORKTREE_BRANCH}
+All file operations and Bash commands must use this directory as the working root.
+
+## Confirmed Scope
+
+**Objective:** {confirmed objective}
+**Assumptions:** {confirmed assumptions, possibly amended by user}
+**Selected Option:** {option name, or "N/A — single approach" if no options were presented}
+**Rejected Options:** {list of rejected options, or "N/A"}
+**User modifications:** {any changes the user requested to scope or approach, or "None"}
+
+## Instructions
+Proceed directly to plan generation (Section 5). Do not repeat scope confirmation.
+````
+
+When not triggered: proceed to step 2; options discovery happens naturally inside Pathfinder's Section 4.
 
 3. If no plan exists, call Pathfinder and request:
    - objective
@@ -519,7 +534,7 @@ Keep it concise and operational. Prefer facts over narration.
 
 ## Important constraints
 
-- When exploring options, DM must wait for explicit user selection before proceeding to execution planning.
+- When `--explore-options` is active, DM must present scope and options to the user and wait for explicit selection before re-invoking Pathfinder for plan generation. For normal tasks (no flag), Pathfinder's internal Scope Confirmation step handles this pause — DM must surface the Scope Confirmation output to the user and wait for confirmation before passing the Confirmed Scope block back to Pathfinder.
 - Do not invent a plan when Pathfinder should provide one.
 - Do not skip Ruinor review. All plans and implementations must be reviewed by Ruinor (mandatory baseline).
 - Invoke specialists (Riskmancer, Windwarden, Knotcutter, Truthhammer) only when:
@@ -609,15 +624,18 @@ Action:
 Example 5:
 User asks: "We need a background job system for sending emails --explore-options"
 Action:
-- **Explore-Options Gate triggers** (explicit `--explore-options` flag; no plan in `plans/`)
-- Invoke Pathfinder in Consensus Mode: instruct it to produce 2–4 viable options (not an execution plan)
-- Pathfinder returns 3 options inline:
-  - Option A: In-process queue with a database-backed jobs table
-  - Option B: Redis-backed queue with BullMQ
-  - Option C: Dedicated message broker (e.g., RabbitMQ)
-- DM presents options to user with names, summaries, and Pathfinder's recommendation; waits for explicit selection
-- User selects Option B (Redis + BullMQ)
-- DM re-invokes Pathfinder for execution plan, passing "Option B: Redis + BullMQ" and the full Consensus Mode output as context
+- **Explore-Options Gate triggers** (explicit `--explore-options` flag)
+- DM invokes Pathfinder with `STOP_AFTER_SCOPE: true`
+- Pathfinder researches codebase, produces Scope Confirmation:
+  - Objective: Add an async email delivery system decoupled from the request cycle
+  - Key Assumptions: no existing job infrastructure, Postgres is already present, email volume is moderate
+  - Affected Subsystems: `src/mailer/`, `src/jobs/`, `config/`
+  - Out of Scope: SMS notifications, retry dashboards, monitoring setup
+  - Three implementation options: (A) In-process queue with a database-backed jobs table, (B) Redis-backed queue with BullMQ, (C) Dedicated message broker (e.g., RabbitMQ); recommendation: Option B
+- Pathfinder returns scope + options output to DM (no plan written)
+- DM presents scope + options to user, user selects Option B (Redis + BullMQ)
+- DM re-invokes Pathfinder with `## Confirmed Scope` block (using re-invocation template above)
+- Pathfinder sees `## Confirmed Scope` block, skips Section 4, proceeds directly to plan generation
 - Pathfinder saves plan to `plans/20260401-143022-background-jobs.md`
 - Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -308,7 +308,7 @@ When Askmaw is skipped: proceed to step 2 as before.
 
 2. Assess whether a plan already exists in the `plans/` directory.
 
-**Explore-Options Gate** (advisory-only, between the Intake Gate and step 2):
+**Explore-Options Gate** (advisory-only, between step 2 and step 3):
 
 Trigger ONLY when the `--explore-options` flag is explicitly present.
 
@@ -317,6 +317,7 @@ When triggered:
 - DM presents scope + options to the user and waits for explicit selection. Do not proceed until the user responds.
 - **If the user does not ask to proceed with planning:** The advisory session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
 - **If user selects an option and asks to continue:** Re-invoke Pathfinder with the `## Confirmed Scope` block (using the re-invocation template below) and proceed to step 3.
+- **If user rejects presented options or requests a different approach:** Re-invoke Pathfinder with `STOP_AFTER_SCOPE: true` and the user's feedback as additional constraints appended to the delegation prompt. Repeat the scope + options presentation.
 
 **Pathfinder re-invocation template (after scope confirmation):**
 
@@ -337,18 +338,21 @@ All file operations and Bash commands must use this directory as the working roo
 Proceed directly to plan generation (Section 5). Do not repeat scope confirmation.
 ````
 
-When not triggered: proceed to step 2; options discovery happens naturally inside Pathfinder's Section 4.
+When not triggered: proceed to step 3; options discovery happens naturally inside Pathfinder's Section 4.
 
-3. If no plan exists, call Pathfinder and request:
-   - objective
-   - assumptions
-   - constraints
-   - step-by-step execution plan
-   - validation criteria
-   - risks / rollback considerations
+3. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
 
-   Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block (defined above) if a session worktree is active. Pathfinder must write plans to `{WORKING_DIRECTORY}/plans/` using the filename `{SESSION_TS}-{feature-slug}.md` (e.g., `{WORKING_DIRECTORY}/plans/20260401-143022-oauth-login.md`).
-4. Pathfinder will save the plan to `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}.md`.
+   **What Pathfinder returns depends on skip conditions:**
+   - If `REVISION_MODE: true` is present, a complete Askmaw brief covers all fields, a Tracebloom Diagnostic Report is present, or a `## Confirmed Scope` block is present in the delegation prompt → Pathfinder skips Section 4 (Scope Confirmation) and returns a completed plan directly. Proceed to step 4.
+   - Otherwise → Pathfinder researches the codebase, runs Section 4 (Scope Confirmation), and returns a structured Scope Confirmation output to DM **without writing a plan**. Proceed to step 3a.
+
+3a. When Pathfinder returns Scope Confirmation output (not a plan):
+   - Surface the scope summary and any implementation options to the user exactly as Pathfinder returned them.
+   - Wait for the user to confirm scope and (if options were presented) select an implementation approach. Do not proceed until the user responds.
+
+3b. Re-invoke Pathfinder with the confirmed scope. Use the re-invocation template defined in the Explore-Options Gate above, substituting the user's confirmed objective, assumptions, selected option, and any user modifications. Pathfinder will skip Section 4 and proceed directly to plan generation.
+
+4. Pathfinder saves the completed plan to `{WORKING_DIRECTORY}/plans/{SESSION_TS}-{feature-slug}.md`.
 
 ### Phase 2: Plan Review (Quality Gate)
 
@@ -682,3 +686,22 @@ Action:
 - Skip Pathfinder (trivial fix). Delegate to Bitsmith with Diagnostic Report as context.
 - **Implementation Review:** Run Ruinor (mandatory baseline). Skip specialist reviewers.
 - **Phase 5:** Offer PR/merge/keep options.
+
+Example 9:
+User asks: "Add webhook support for payment events"
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree
+- **Phase 1:** Task is clear and well-specified — no Tracebloom, no Askmaw
+- DM invokes Pathfinder (first invocation)
+- Pathfinder researches codebase, reaches Section 4 (Scope Confirmation), returns scope output to DM:
+  - Objective: Add inbound webhook handling for payment provider events (payment.completed, payment.failed)
+  - Key Assumptions: Payment provider is Stripe; no existing webhook infrastructure
+  - Affected Subsystems: src/webhooks/ (new), src/payments/, config/
+  - Out of Scope: Outbound webhooks, non-payment event types
+  - Option A: Synchronous webhook handler (simple, no queue)
+  - Option B: Queue-backed webhook handler (reliable, retryable)
+  - Recommendation: Option B — payment events should be idempotent and retryable
+- DM surfaces scope + options to user; user confirms scope and selects Option B
+- DM re-invokes Pathfinder with `## Confirmed Scope` block (Option B selected, Option A rejected because payment events require retry guarantees)
+- Pathfinder skips Section 4, generates full plan, saves to `plans/20260401-143022-webhook-support.md`
+- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -111,7 +111,7 @@ After codebase research and interview are complete but before writing the full p
 
 **Implementation options (conditional):** Only shown when research reveals multiple viable approaches. Each option has a name, summary, pros, cons, and reversibility. Include Pathfinder's recommendation with explicit reasons for rejecting other options. If only one viable approach exists, no options block is shown.
 
-**Return instruction:** Pathfinder returns the Scope Confirmation output to DM without writing a plan. DM surfaces this to the user and re-invokes Pathfinder with the Confirmed Scope block once the user responds.
+**Return instruction:** Pathfinder returns the Scope Confirmation output to DM without writing a plan and **stops**. Do not proceed to Section 5 until re-invoked with a `## Confirmed Scope` block. DM surfaces this output to the user and re-invokes Pathfinder once the user responds.
 
 **Structured output format:**
 
@@ -181,7 +181,7 @@ Once requirements are clear and research is complete:
 2. Create 3-6 actionable steps with verifiable acceptance criteria
 3. Avoid over-specification (not 30 micro-steps)
 4. Avoid vagueness (not "step 1: implement")
-5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly)
+5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly). Note: this confirmation covers the execution steps (the *how*); the Section 4 Scope Confirmation covered the objective and approach (the *what*). Both serve distinct purposes and both are intentional.
 6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created").
 
 ### 6. Pre-Submission Checklist

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -57,7 +57,7 @@ Agent(subagent_type="Explore", prompt="Find all authentication-related files")
 
 If `REVISION_MODE: true` is present:
 - Skip this section (section 3) entirely — the revision context and reviewer feedback supplied in DM's delegation prompt serve as the requirements input
-- Proceed directly to section 4 (Generate Plan)
+- Proceed directly to section 5 (Generate Plan)
 
 **Otherwise: check for an Askmaw intake brief in the delegation prompt.**
 
@@ -66,7 +66,7 @@ If the delegation prompt contains an `## Intake Brief` section:
 - Do **not** re-ask questions already answered in the brief
 - Use the brief's content directly as requirements input for the plan
 - You may still ask follow-up questions **only** for gaps the brief left open or that codebase research revealed as decision-critical
-- If the brief covers all fields (Objective, Scope, Constraints, Preferences, Success Criteria) with substantive content (not just "N/A" or empty placeholders), skip the interview (section 3) entirely and proceed directly to plan generation (section 4). The user confirmation step (section 4, step 5) still applies.
+- If the brief covers all fields (Objective, Scope, Constraints, Preferences, Success Criteria) with substantive content (not just "N/A" or empty placeholders), skip the interview (section 3) entirely and proceed directly to plan generation (section 5). The user confirmation step (section 5, step 5) still applies.
 
 **Otherwise: check for a Tracebloom Diagnostic Report in the delegation prompt.**
 
@@ -94,7 +94,86 @@ Ask about preferences and priorities using AskUserQuestion tool.
 - Technical facts ("What database do we use?") - explore agents find this
 - Implementation details ("How is X currently implemented?") - delegate research
 
-### 4. Generate Plan
+### 4. Scope Confirmation
+
+After codebase research and interview are complete but before writing the full plan, Pathfinder pauses and presents a structured scope summary. Because Pathfinder is a sub-agent and cannot interact with the user directly, it returns its scope summary (and options if found) as structured output to DM without writing a plan. DM surfaces this to the user, collects confirmation (and option selection if applicable), then re-invokes Pathfinder with the `## Confirmed Scope` block.
+
+**Skip conditions (first match wins — skip this entire section):**
+
+1. `REVISION_MODE: true` is present — Note: when REVISION_MODE is present, Section 3's own skip already jumps directly to Section 5 (Generate Plan), bypassing Section 4. The REVISION_MODE skip condition in Section 4 is a defensive fallback for future refactoring.
+2. Delegation prompt contains a complete Askmaw `## Intake Brief` with substantive content in all fields
+3. Delegation prompt contains a `## Diagnostic Report` from Tracebloom
+4. Delegation prompt contains a `## Confirmed Scope` block (re-invocation after prior scope confirmation)
+
+**`STOP_AFTER_SCOPE: true` handling:** Execute Section 4 fully, produce scope + options output, then STOP — do not write a plan, return structured scope output to DM. DM presents scope + options to the user and waits. If the user does not ask to proceed with planning, the advisory session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
+
+**Scope summary:** Produce a one-sentence objective, 2-3 bullets of key assumptions (inferred-but-not-stated items), a list of affected subsystems/files, and items explicitly out of scope.
+
+**Implementation options (conditional):** Only shown when research reveals multiple viable approaches. Each option has a name, summary, pros, cons, and reversibility. Include Pathfinder's recommendation with explicit reasons for rejecting other options. If only one viable approach exists, no options block is shown.
+
+**Return instruction:** Pathfinder returns the Scope Confirmation output to DM without writing a plan. DM surfaces this to the user and re-invokes Pathfinder with the Confirmed Scope block once the user responds.
+
+**Structured output format:**
+
+```markdown
+## Scope Confirmation
+
+**Objective:** {one-sentence statement of what the plan will achieve}
+
+**Key Assumptions:**
+- {inferred-but-not-stated assumption 1}
+- {inferred-but-not-stated assumption 2}
+- {inferred-but-not-stated assumption 3}
+
+**Affected Subsystems:**
+- {file or subsystem 1}
+- {file or subsystem 2}
+
+**Out of Scope:**
+- {item explicitly excluded}
+- {item explicitly excluded}
+
+## Implementation Options
+
+**Option A: {name}**
+- Summary: {brief description}
+- Pros: {list}
+- Cons: {list}
+- Reversibility: {easy / moderate / hard, with brief explanation}
+
+**Option B: {name}**
+- Summary: {brief description}
+- Pros: {list}
+- Cons: {list}
+- Reversibility: {easy / moderate / hard, with brief explanation}
+
+**Recommendation:** Option {X} — {reason for recommending this option and explicit reasons for rejecting the others}
+
+Please confirm the scope above and, if multiple options were presented, select your preferred implementation approach. Once confirmed, Pathfinder will proceed to plan generation.
+```
+
+**`## Confirmed Scope` re-invocation handling:** When the delegation prompt contains a `## Confirmed Scope` block, treat it as authoritative scope input and proceed directly to Section 5 (Generate Plan). Do not repeat scope confirmation.
+
+**Pathfinder re-invocation template (after scope confirmation):**
+
+````
+WORKING_DIRECTORY: {WORKTREE_PATH}
+WORKTREE_BRANCH: {WORKTREE_BRANCH}
+All file operations and Bash commands must use this directory as the working root.
+
+## Confirmed Scope
+
+**Objective:** {confirmed objective}
+**Assumptions:** {confirmed assumptions, possibly amended by user}
+**Selected Option:** {option name, or "N/A — single approach" if no options were presented}
+**Rejected Options:** {list of rejected options, or "N/A"}
+**User modifications:** {any changes the user requested to scope or approach, or "None"}
+
+## Instructions
+Proceed directly to plan generation (Section 5). Do not repeat scope confirmation.
+````
+
+### 5. Generate Plan
 
 Once requirements are clear and research is complete:
 
@@ -105,9 +184,9 @@ Once requirements are clear and research is complete:
 5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly)
 6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created").
 
-### 5. Pre-Submission Checklist
+### 6. Pre-Submission Checklist
 
-Before saving the plan, run through all 8 questions below. If any question reveals a deficiency, correct the plan before proceeding to step 6.
+Before saving the plan, run through all 8 questions below. If any question reveals a deficiency, correct the plan before proceeding to step 7.
 
 1. **Per-agent specificity:** Are instructions for each affected file/agent distinct where they differ meaningfully?
 2. **File reference accuracy:** Have you verified section names and line numbers by reading the actual files?
@@ -118,7 +197,7 @@ Before saving the plan, run through all 8 questions below. If any question revea
 7. **Completeness:** Does the plan cover every part of the stated objective with no unexplained gaps?
 8. **Ambiguity test:** Could a careful executor reasonably make a wrong judgement call from any instruction? If yes, rewrite that instruction.
 
-### 6. Save Plan
+### 7. Save Plan
 
 Write plan to `plans/{SESSION_TS}-{feature-slug}.md` using Write tool.
 
@@ -263,6 +342,10 @@ Mitigation:
 - **E2E:** Test user registration, login, logout, password reset
 - **Observability:** Log auth attempts, failed logins, monitor for anomalies
 
+**Note on `STOP_AFTER_SCOPE` and `--consensus` interaction:**
+
+When `STOP_AFTER_SCOPE: true` is present in the delegation prompt, Pathfinder stops after Section 4 (Scope Confirmation) and returns scope + implementation options without generating a plan or entering Consensus Mode. This is how DM implements `--explore-options`. The `--consensus` flag and `STOP_AFTER_SCOPE: true` serve different purposes and do not interact. If both `STOP_AFTER_SCOPE: true` and `--consensus` are present, `STOP_AFTER_SCOPE` takes precedence — Pathfinder performs research, produces the scope + options output, and stops without generating a plan.
+
 ## Open Questions Tracking
 
 Track unresolved questions in `plans/{SESSION_TS}-{feature-slug}-open-questions.md`.
@@ -309,6 +392,7 @@ Before considering a plan complete, verify:
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
 7. ✅ **Pre-submission checklist passed** - all 8 questions reviewed and any issues corrected before saving
+8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when REVISION_MODE, Askmaw brief, Tracebloom report, or Confirmed Scope block is present)
 
 ## Tool Usage
 

--- a/docs/WORKFLOW_ENTRY_POINTS.md
+++ b/docs/WORKFLOW_ENTRY_POINTS.md
@@ -110,13 +110,13 @@ User request received
     │  │
     │  └─ NO → Continue
     │
-    ├─ Does request involve architecture/technology decision?
+    ├─ Does request require explicit scope/options review before planning?
     │  │
-    │  ├─ YES → Pathfinder consensus mode → Options → User selects
+    │  ├─ YES → DM invokes with --explore-options flag → Scope Confirmation → Options → User selects
     │  │
     │  └─ NO → Continue
     │
-    └─ Pathfinder (direct planning)
+    └─ Pathfinder (direct planning, includes automatic Scope Confirmation)
          │
          └─ Ruinor review + specialist reviews
               │


### PR DESCRIPTION
Introduces a Scope Confirmation step (Section 4) into Pathfinder's workflow that pauses after codebase research to surface scope assumptions and implementation options to the user before plan generation begins. This catches intent misalignment early — before a full plan + review cycle — and replaces the DM's pre-research Explore-Options Gate with a post-research, codebase-informed options discovery mechanism.

The DM's `--explore-options` flag is simplified to an advisory-only mode (`STOP_AFTER_SCOPE: true`) that returns scope and options without writing a plan. Normal planning flows now include automatic scope confirmation via a two-invocation Pathfinder pattern (scope → confirm → plan).