### PR TITLE
feat(hooks): add terminal tab auto-rename on session start

### DIFF
--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# session-start.sh — Sets the terminal tab/window title to an AI-generated
+# session name when a Claude Code session starts.
+# Supports: iTerm2, tmux, cmux
+# Installed to: ~/.claude/hooks/session-start.sh
+
+# Read hook payload from stdin
+STDIN_DATA=""
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+[ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
+
+# Parse cwd from JSON payload; fall back to $PWD if jq unavailable or cwd absent
+CWD=""
+if command -v jq &>/dev/null; then
+  CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
+fi
+[ -z "$CWD" ] && CWD="$PWD"
+
+# Gather context
+DIR_NAME=$(basename "$CWD")
+REPO_NAME=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {})
+BRANCH_NAME=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Check for --name override via payload inspection
+if command -v jq &>/dev/null; then
+  SESSION_NAME=$(echo "$STDIN_DATA" | jq -r '.session_name // .name // ""' 2>/dev/null)
+  if [ -n "$SESSION_NAME" ]; then
+    exit 0
+  fi
+fi
+
+# Check for --name override via process ancestry (walk up to 3 levels)
+_check_proc_args() {
+  local pid="$1"
+  local args
+  args=$(ps -o args= -p "$pid" 2>/dev/null)
+  # Only check --name (long form). The -n short flag is intentionally omitted:
+  # it collides with unrelated processes (e.g. "bash -n", "screen -n") anywhere
+  # in the ancestry walk, causing false-positive exits.
+  if printf '%s' "$args" | grep -qE '(^| )--name( |$)'; then
+    echo "found"
+  fi
+}
+
+_pid="$PPID"
+for _level in 1 2 3; do
+  if [ -n "$(_check_proc_args "$_pid")" ]; then
+    exit 0
+  fi
+  _next_ppid=$(ps -o ppid= -p "$_pid" 2>/dev/null | tr -d ' ')
+  [ -z "$_next_ppid" ] && break
+  [ "$_next_ppid" -le 1 ] && break
+  _pid="$_next_ppid"
+done
+
+# Detect terminal
+# Detection priority: tmux is checked first because when running inside tmux,
+# the tmux window name is the visible label regardless of the host terminal
+# emulator (e.g., iTerm2 with tmux integration).
+TERMINAL=""
+if [ -n "${TMUX:-}" ]; then
+  TERMINAL="tmux"
+elif [ -n "${CMUX_WORKSPACE_ID:-}" ]; then
+  TERMINAL="cmux"
+elif [ "${TERM_PROGRAM:-}" = "iTerm.app" ]; then
+  TERMINAL="iterm2"
+elif [ "${TERM_PROGRAM:-}" = "ghostty" ]; then
+  TERMINAL="cmux"
+else
+  exit 0
+fi
+
+# Generate AI title
+# --bare strips the default system prompt, so --system-prompt provides the
+# ONLY system prompt (not appended). Do not switch to --append-system-prompt
+# as it appends to nothing under --bare.
+TITLE=$(claude -p --bare --model haiku \
+  --system-prompt "Respond with ONLY 2-5 words. No punctuation, no quotes, no explanation. Generate a short natural-language title for a coding session." \
+  "Project: ${REPO_NAME:-$DIR_NAME}, Branch: ${BRANCH_NAME:-main}, Directory: ${DIR_NAME}" \
+  </dev/null 2>/dev/null)
+
+if [ $? -ne 0 ] || [ -z "$TITLE" ]; then
+  exit 0
+fi
+
+# Sanitize: strip leading/trailing whitespace, truncate to 40 chars
+TITLE=$(printf '%s' "$TITLE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+TITLE="${TITLE:0:40}"
+if [ -z "$TITLE" ]; then
+  exit 0
+fi
+
+# Set terminal title based on detected terminal
+if [ "$TERMINAL" = "tmux" ]; then
+  tmux rename-window "$TITLE" 2>/dev/null
+elif [ "$TERMINAL" = "iterm2" ]; then
+  printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+elif [ "$TERMINAL" = "cmux" ]; then
+  if command -v cmux &>/dev/null; then
+    cmux rename-tab "$TITLE" 2>/dev/null
+  else
+    printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+  fi
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -78,11 +78,12 @@
     ],
     "SessionStart": [
       {
+        "async": true,
         "hooks": [
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/session-start.sh",
-            "timeout": 5
+            "timeout": 30
           }
         ]
       }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,46 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
 - Allowed silently: `grep "a && b" file.txt` (compound operator is inside a quoted string)
 
+#### SessionStart Hook - Terminal Tab Rename
+
+Runs at the start of every Claude Code session to set the terminal tab or window title to an AI-generated name reflecting the current project context.
+
+**Behavior:**
+1. Reads the session start event from stdin and parses the `cwd` field via `jq` (falls back to `$PWD` if `jq` is unavailable or `cwd` is absent)
+2. Gathers context: directory name, git repo name, and branch name
+3. Checks for a `--name` override — inspects the payload and walks up to 3 levels of process ancestry; if `--name` (long form only; `-n` is intentionally not checked to avoid false positives with unrelated processes) is detected, exits without setting a title
+4. Detects the active terminal emulator (see supported terminals below)
+5. Calls `claude -p --bare --model haiku` with a constrained system prompt to generate a 2-5 word session title
+6. Sanitizes the result (strips whitespace, truncates to 40 characters) and sets the terminal tab/window title
+
+**Supported terminals and detection:**
+
+| Terminal | Detection | Title mechanism |
+|----------|-----------|-----------------|
+| tmux | `$TMUX` non-empty | `tmux rename-window` |
+| cmux | `$CMUX_WORKSPACE_ID` set (primary) or `$TERM_PROGRAM=ghostty` (fallback) | `cmux rename-tab` CLI; OSC 0 escape if `cmux` not in PATH |
+| iTerm2 | `$TERM_PROGRAM=iTerm.app` | OSC 0 escape sequence (`\033]0;...\007`) |
+
+**Detection rationale:** tmux is checked before `$TERM_PROGRAM` because the tmux window name is the visible label regardless of the host terminal emulator (e.g., iTerm2 running in tmux integration mode shows the tmux window name, not the iTerm2 tab title).
+
+**`--name` interaction:** If the user launches Claude with `--name` (to set a session name explicitly), the hook detects this via payload inspection and process ancestry inspection and exits without overwriting the title.
+
+**Async and timeout:** The hook runs asynchronously with a 30-second timeout so that AI title generation does not block session startup.
+
+**Dependencies:**
+- `bash` — required
+- `git` — optional; used for repo name and branch detection; absent git context is handled gracefully
+- `jq` — optional; used for payload parsing; falls back to `$PWD` if unavailable
+- `claude` CLI — required; used for AI title generation; hook exits silently if invocation fails
+- `cmux` CLI — optional; used for cmux tab renaming; falls back to OSC 0 escape if not in PATH
+
+**`--bare` usage:** The `--bare` flag is passed to `claude -p` to prevent the session-start hook from triggering another SessionStart hook, avoiding recursive invocation.
+
+**Configuration:**
+- Script: `claude/hooks/session-start.sh`
+- Type: Async SessionStart hook
+- Timeout: 30 seconds
+
 #### SubagentStop Hook - Session Capture
 
 Runs after every sub-agent completion to capture raw session event data.


### PR DESCRIPTION
Adds a SessionStart hook that automatically renames the active terminal tab or window to a short, AI-generated title (2–5 words) whenever a Claude Code session starts. Supports iTerm2 (via OSC escape sequences), tmux (via `tmux rename-window`), and cmux (via `cmux rename-tab`, with OSC fallback). Terminal type is auto-detected from environment variables — no user configuration required. Runs asynchronously so session startup is not blocked.