### PR TITLE
feat(hooks): redesign tab rename to defer title generation until first exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,15 @@ Orchestration sessions are automatically chronicled by a two-stage shell pipelin
 
 When you want a human-readable summary of past sessions, invoke the Talekeeper narrator agent manually. It reads the enriched chronicle files, delivers a concise chat digest, and appends structured narrative sections with Mermaid diagrams to `logs/talekeeper-narrative.md`.
 
+### Terminal Tab Rename
+Terminal tab titles are automatically managed via a two-hook system:
+- **SessionStart Hook** — Restores previously stored session titles for resumed sessions (instant, no AI call)
+- **Stop Hook** — Generates a contextual 2–5 word title from the first user prompt and assistant response after the first turn completes; stores it for future resume
+
+This provides immediate context recognition when resuming sessions and automatic title generation based on what you actually worked on, without manual naming. Titles are stored in `~/.claude/session-titles/` and persist across terminal restarts. Sessions started with `--name` flag preserve their explicit title without AI override.
+
+See [docs/CONFIGURATION.md](/docs/CONFIGURATION.md) — sections "SessionStart Hook - Terminal Tab Title Restore" and "Stop Hook - Terminal Tab Title Generation" — for detailed behavior, supported terminals (tmux, cmux, iTerm2, ghostty), and dependencies.
+
 ### Specialized Agents
 Specialized AI assistants are available for orchestration (Dungeon Master), intake clarification (Askmaw), investigative diagnosis (Tracebloom), documentation (Quill), security reviews (Riskmancer), planning (Pathfinder), complexity reduction (Knotcutter), factual validation (Truthhammer), session narration (Talekeeper), performance analysis (Windwarden), code implementation (Bitsmith), and team meta-analysis (Everwise). The orchestration workflow uses an intelligent review system that reduces overhead by 60-70% while maintaining quality.
 

--- a/claude/hooks/lib-tab-rename.sh
+++ b/claude/hooks/lib-tab-rename.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# lib-tab-rename.sh -- Shared functions for terminal tab rename hooks.
+# Sourced by session-start.sh and tab-rename-stop.sh.
+# Installed to: ~/.claude/hooks/lib-tab-rename.sh
+# This file is NOT executable — it is sourced, not run directly.
+
+# _tab_rename_check_name_override
+# Returns 0 (true) if --name was detected in process ancestry, 1 (false) otherwise.
+# Callers: if _tab_rename_check_name_override; then <handle --name case>; fi
+_tab_rename_check_name_override() {
+  local _pid="$PPID"
+  local _level _next_ppid _args
+  for _level in 1 2 3; do
+    _args=$(ps -o args= -p "$_pid" 2>/dev/null)
+    # Only check --name (long form). The -n short flag is intentionally omitted:
+    # it collides with unrelated processes (e.g. "bash -n", "screen -n") anywhere
+    # in the ancestry walk, causing false-positive exits.
+    if printf '%s' "$_args" | grep -qE '(^| )--name( |$)'; then
+      return 0
+    fi
+    _next_ppid=$(ps -o ppid= -p "$_pid" 2>/dev/null | tr -d ' ')
+    [ -z "$_next_ppid" ] && break
+    [ "$_next_ppid" -le 1 ] && break
+    _pid="$_next_ppid"
+  done
+  return 1
+}
+
+# _tab_rename_detect_terminal
+# Sets the TERMINAL variable to one of: tmux, cmux, iterm2, or "" (unsupported).
+# Detection priority: tmux is checked first because when running inside tmux,
+# the tmux window name is the visible label regardless of the host terminal
+# emulator (e.g., iTerm2 with tmux integration).
+_tab_rename_detect_terminal() {
+  TERMINAL=""
+  if [ -n "${TMUX:-}" ]; then
+    TERMINAL="tmux"
+  elif [ -n "${CMUX_WORKSPACE_ID:-}" ]; then
+    TERMINAL="cmux"
+  elif [ "${TERM_PROGRAM:-}" = "iTerm.app" ]; then
+    TERMINAL="iterm2"
+  elif [ "${TERM_PROGRAM:-}" = "ghostty" ]; then
+    TERMINAL="cmux"
+  fi
+}
+
+# _tab_rename_set_title TITLE
+# Applies TITLE to the current terminal tab using the mechanism for $TERMINAL.
+# Call _tab_rename_detect_terminal first to set $TERMINAL.
+_tab_rename_set_title() {
+  local TITLE="$1"
+  if [ "$TERMINAL" = "tmux" ]; then
+    tmux rename-window "$TITLE" 2>/dev/null
+  elif [ "$TERMINAL" = "iterm2" ]; then
+    printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+  elif [ "$TERMINAL" = "cmux" ]; then
+    if command -v cmux &>/dev/null; then
+      cmux rename-tab "$TITLE" 2>/dev/null
+    else
+      printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+    fi
+  fi
+}

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -1,106 +1,53 @@
 #!/usr/bin/env bash
-# session-start.sh — Sets the terminal tab/window title to an AI-generated
-# session name when a Claude Code session starts.
-# Supports: iTerm2, tmux, cmux
+# session-start.sh -- Restores a previously stored session title for resumed sessions.
+# Title generation is handled by the Stop hook (tab-rename-stop.sh).
+# Fires on: SessionStart (async)
 # Installed to: ~/.claude/hooks/session-start.sh
 
-# Read hook payload from stdin
-STDIN_DATA=""
+# Read payload from stdin (2-second timeout)
 read -r -t 2 STDIN_DATA 2>/dev/null || true
 [ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
 
-# Parse cwd from JSON payload; fall back to $PWD if jq unavailable or cwd absent
-CWD=""
-if command -v jq &>/dev/null; then
-  CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
+# Require jq
+if ! command -v jq &>/dev/null; then
+  exit 0
 fi
-[ -z "$CWD" ] && CWD="$PWD"
 
-# Gather context
-DIR_NAME=$(basename "$CWD")
-REPO_NAME=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {})
-BRANCH_NAME=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
-
-# Check for --name override via payload inspection
-if command -v jq &>/dev/null; then
-  SESSION_NAME=$(echo "$STDIN_DATA" | jq -r '.session_name // .name // ""' 2>/dev/null)
-  if [ -n "$SESSION_NAME" ]; then
-    exit 0
-  fi
+# Parse session_id and cwd from payload
+SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  exit 0
 fi
+CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
+CWD="${CWD:-$PWD}"
+
+# Source shared tab-rename library
+# shellcheck source=lib-tab-rename.sh
+source "$(dirname "$0")/lib-tab-rename.sh"
 
 # Check for --name override via process ancestry (walk up to 3 levels)
-_check_proc_args() {
-  local pid="$1"
-  local args
-  args=$(ps -o args= -p "$pid" 2>/dev/null)
-  # Only check --name (long form). The -n short flag is intentionally omitted:
-  # it collides with unrelated processes (e.g. "bash -n", "screen -n") anywhere
-  # in the ancestry walk, causing false-positive exits.
-  if printf '%s' "$args" | grep -qE '(^| )--name( |$)'; then
-    echo "found"
-  fi
-}
-
-_pid="$PPID"
-for _level in 1 2 3; do
-  if [ -n "$(_check_proc_args "$_pid")" ]; then
-    exit 0
-  fi
-  _next_ppid=$(ps -o ppid= -p "$_pid" 2>/dev/null | tr -d ' ')
-  [ -z "$_next_ppid" ] && break
-  [ "$_next_ppid" -le 1 ] && break
-  _pid="$_next_ppid"
-done
-
-# Detect terminal
-# Detection priority: tmux is checked first because when running inside tmux,
-# the tmux window name is the visible label regardless of the host terminal
-# emulator (e.g., iTerm2 with tmux integration).
-TERMINAL=""
-if [ -n "${TMUX:-}" ]; then
-  TERMINAL="tmux"
-elif [ -n "${CMUX_WORKSPACE_ID:-}" ]; then
-  TERMINAL="cmux"
-elif [ "${TERM_PROGRAM:-}" = "iTerm.app" ]; then
-  TERMINAL="iterm2"
-elif [ "${TERM_PROGRAM:-}" = "ghostty" ]; then
-  TERMINAL="cmux"
-else
+if _tab_rename_check_name_override; then
   exit 0
 fi
 
-# Generate AI title
-# --bare strips the default system prompt, so --system-prompt provides the
-# ONLY system prompt (not appended). Do not switch to --append-system-prompt
-# as it appends to nothing under --bare.
-TITLE=$(claude -p --bare --model haiku \
-  --system-prompt "Respond with ONLY 2-5 words. No punctuation, no quotes, no explanation. Generate a short natural-language title for a coding session." \
-  "Project: ${REPO_NAME:-$DIR_NAME}, Branch: ${BRANCH_NAME:-main}, Directory: ${DIR_NAME}" \
-  </dev/null 2>/dev/null)
+# Title restore: check if a stored title exists for this session
+TITLE_DIR="$HOME/.claude/session-titles"
+TITLE_FILE="$TITLE_DIR/$SESSION_ID"
 
-if [ $? -ne 0 ] || [ -z "$TITLE" ]; then
+if [ ! -f "$TITLE_FILE" ]; then
   exit 0
 fi
 
-# Sanitize: strip leading/trailing whitespace, truncate to 40 chars
-TITLE=$(printf '%s' "$TITLE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-TITLE="${TITLE:0:40}"
+TITLE=$(cat "$TITLE_FILE" 2>/dev/null)
 if [ -z "$TITLE" ]; then
   exit 0
 fi
 
-# Set terminal title based on detected terminal
-if [ "$TERMINAL" = "tmux" ]; then
-  tmux rename-window "$TITLE" 2>/dev/null
-elif [ "$TERMINAL" = "iterm2" ]; then
-  printf '\033]0;%s\007' "$TITLE" 2>/dev/null
-elif [ "$TERMINAL" = "cmux" ]; then
-  if command -v cmux &>/dev/null; then
-    cmux rename-tab "$TITLE" 2>/dev/null
-  else
-    printf '\033]0;%s\007' "$TITLE" 2>/dev/null
-  fi
+# Detect terminal and apply title
+_tab_rename_detect_terminal
+if [ -z "$TERMINAL" ]; then
+  exit 0
 fi
+_tab_rename_set_title "$TITLE"
 
 exit 0

--- a/claude/hooks/tab-rename-stop.sh
+++ b/claude/hooks/tab-rename-stop.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# tab-rename-stop.sh -- Generates a terminal tab title from the first user-Claude exchange.
+# Fires after every turn (Stop hook) but only generates a title once per session.
+# Installed to: ~/.claude/hooks/tab-rename-stop.sh
+
+# Read payload from stdin (2-second timeout)
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+[ -z "$STDIN_DATA" ] && STDIN_DATA='{}'
+
+# Require jq
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+# Parse payload fields
+SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+TRANSCRIPT_PATH=$(echo "$STDIN_DATA" | jq -r '.transcript_path // ""' 2>/dev/null)
+CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
+CWD="${CWD:-$PWD}"
+
+# Single-fire guard: if a title file already exists for this session, exit immediately
+TITLE_DIR="$HOME/.claude/session-titles"
+TITLE_FILE="$TITLE_DIR/$SESSION_ID"
+if [ -f "$TITLE_FILE" ]; then
+  exit 0
+fi
+
+# Validate transcript path
+if [ -z "$TRANSCRIPT_PATH" ] || [ "$TRANSCRIPT_PATH" = "null" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# Source shared tab-rename library
+# shellcheck source=lib-tab-rename.sh
+source "$(dirname "$0")/lib-tab-rename.sh"
+
+# Check for --name override via process ancestry (walk up to 3 levels)
+if _tab_rename_check_name_override; then
+  # If a session started with --name is later resumed without --name, the empty sentinel
+  # ensures session-start.sh also exits silently — the tab title remains whatever the
+  # terminal shows. This is intentional: explicit --name sessions are treated as
+  # fixed-identity sessions.
+  mkdir -p "$TITLE_DIR"
+  touch "$TITLE_FILE"
+  exit 0
+fi
+
+# Detect first exchange: count non-meta user messages in the transcript
+# NOTE: transcript uses "type": "user" (not "human")
+# NOTE: guard is >= 1 (not == 1) to avoid race condition where a fast second message
+#       would permanently skip title generation; the title-file guard above is the
+#       single-fire mechanism
+USER_MSG_COUNT=$(jq -c 'select(.type == "user") | select((.isMeta // false) == false)' "$TRANSCRIPT_PATH" 2>/dev/null | wc -l | tr -d ' ')
+if [ "${USER_MSG_COUNT:-0}" -lt 1 ] 2>/dev/null; then
+  exit 0
+fi
+
+# Extract first user prompt from transcript
+# message.content may be a string or an array of content blocks
+FIRST_PROMPT=$(jq -r 'select(.type == "user") | select((.isMeta // false) == false) | .message.content | if type == "array" then map(select(.type == "text") | .text) | join(" ") else . end' "$TRANSCRIPT_PATH" 2>/dev/null | head -1)
+if [ -z "$FIRST_PROMPT" ]; then
+  exit 0
+fi
+FIRST_PROMPT="${FIRST_PROMPT:0:500}"
+
+# Extract last assistant message from Stop payload
+LAST_RESPONSE=$(echo "$STDIN_DATA" | jq -r '.last_assistant_message // ""' 2>/dev/null)
+LAST_RESPONSE="${LAST_RESPONSE:0:500}"
+
+# Gather lightweight project context
+DIR_NAME=$(basename "$CWD")
+REPO_NAME=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {} 2>/dev/null)
+
+# Generate AI title via claude -p (pipe mode does not fire session hooks; --bare strips the default system prompt)
+TITLE=$(claude -p --bare --model haiku \
+  --system-prompt "Respond with ONLY 2-5 words. No punctuation, no quotes, no explanation. Generate a short natural-language title summarizing this coding session based on the user's request and the assistant's work." \
+  "Project: ${REPO_NAME:-$DIR_NAME}, User asked: ${FIRST_PROMPT}, Assistant did: ${LAST_RESPONSE}" \
+  </dev/null 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$TITLE" ]; then
+  exit 0
+fi
+
+# Sanitize: remove newlines, strip whitespace and truncate to 40 characters
+TITLE=$(printf '%s' "$TITLE" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+TITLE="${TITLE:0:40}"
+if [ -z "$TITLE" ]; then
+  exit 0
+fi
+
+# Store title (atomic enough for this use case)
+mkdir -p "$TITLE_DIR"
+printf '%s' "$TITLE" > "$TITLE_FILE"
+
+# Detect terminal and apply title
+_tab_rename_detect_terminal
+if [ -z "$TERMINAL" ]; then
+  exit 0
+fi
+_tab_rename_set_title "$TITLE"
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -107,6 +107,11 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/talekeeper-enrich.sh",
             "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tab-rename-stop.sh",
+            "timeout": 30
           }
         ]
       }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,17 +48,15 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
 - Allowed silently: `grep "a && b" file.txt` (compound operator is inside a quoted string)
 
-#### SessionStart Hook - Terminal Tab Rename
+#### SessionStart Hook - Terminal Tab Title Restore
 
-Runs at the start of every Claude Code session to set the terminal tab or window title to an AI-generated name reflecting the current project context.
+Runs at the start of every Claude Code session to restore a previously stored terminal tab title for resumed sessions. Title generation is handled by the Stop hook (`tab-rename-stop.sh`).
 
 **Behavior:**
-1. Reads the session start event from stdin and parses the `cwd` field via `jq` (falls back to `$PWD` if `jq` is unavailable or `cwd` is absent)
-2. Gathers context: directory name, git repo name, and branch name
-3. Checks for a `--name` override — inspects the payload and walks up to 3 levels of process ancestry; if `--name` (long form only; `-n` is intentionally not checked to avoid false positives with unrelated processes) is detected, exits without setting a title
-4. Detects the active terminal emulator (see supported terminals below)
-5. Calls `claude -p --bare --model haiku` with a constrained system prompt to generate a 2-5 word session title
-6. Sanitizes the result (strips whitespace, truncates to 40 characters) and sets the terminal tab/window title
+1. Reads the session start event from stdin and parses `session_id` via `jq`; exits silently if `session_id` is absent
+2. Checks for a `--name` override — walks up to 3 levels of process ancestry; if `--name` (long form only; `-n` is intentionally not checked to avoid false positives with unrelated processes) is detected, exits without setting a title
+3. Looks up `~/.claude/session-titles/{session_id}`; if no file exists (new session), exits silently — title generation will be handled by the Stop hook after the first exchange
+4. If a stored title is found, detects the active terminal emulator and restores the title to the terminal tab
 
 **Supported terminals and detection:**
 
@@ -70,18 +68,14 @@ Runs at the start of every Claude Code session to set the terminal tab or window
 
 **Detection rationale:** tmux is checked before `$TERM_PROGRAM` because the tmux window name is the visible label regardless of the host terminal emulator (e.g., iTerm2 running in tmux integration mode shows the tmux window name, not the iTerm2 tab title).
 
-**`--name` interaction:** If the user launches Claude with `--name` (to set a session name explicitly), the hook detects this via payload inspection and process ancestry inspection and exits without overwriting the title.
+**`--name` interaction:** If the user launches Claude with `--name` (to set a session name explicitly), the hook detects this via process ancestry inspection and exits without overwriting the title.
 
-**Async and timeout:** The hook runs asynchronously with a 30-second timeout so that AI title generation does not block session startup.
+**Async and timeout:** The hook runs asynchronously with a 30-second timeout so that title restore does not block session startup.
 
 **Dependencies:**
 - `bash` — required
-- `git` — optional; used for repo name and branch detection; absent git context is handled gracefully
-- `jq` — optional; used for payload parsing; falls back to `$PWD` if unavailable
-- `claude` CLI — required; used for AI title generation; hook exits silently if invocation fails
+- `jq` — required; used for payload parsing; hook exits silently if unavailable
 - `cmux` CLI — optional; used for cmux tab renaming; falls back to OSC 0 escape if not in PATH
-
-**`--bare` usage:** The `--bare` flag is passed to `claude -p` to prevent the session-start hook from triggering another SessionStart hook, avoiding recursive invocation.
 
 **Configuration:**
 - Script: `claude/hooks/session-start.sh`
@@ -106,7 +100,9 @@ Runs after every sub-agent completion to capture raw session event data.
 
 #### Stop Hook - Session Enrichment
 
-One hook runs when you end a Claude session.
+Two Stop hooks run asynchronously when you end a Claude session. This section covers session enrichment. See "Stop Hook - Terminal Tab Title Generation" below for the tab rename hook.
+
+Note: A second Stop hook (`tab-rename-stop.sh`) also fires asynchronously for terminal tab renaming — see below.
 
 **Session enrichment (async):**
 
@@ -140,6 +136,40 @@ The `agent_transcript_path` field enables downstream tools (like Everwise Scout)
 - Type: Async command hook
 - Timeout: 60 seconds
 - Requires `jq`; exits silently if unavailable or raw log is empty
+
+#### Stop Hook - Terminal Tab Title Generation
+
+Runs after every Claude turn (Stop hook) to generate and store an AI-derived terminal tab title. Title generation fires once per session — subsequent Stop hook invocations are no-ops once a title file exists for the session.
+
+**Behavior:**
+1. Reads the Stop event from stdin; parses `session_id`, `transcript_path`, `cwd`, and `last_assistant_message`
+2. Single-fire guard: if `~/.claude/session-titles/{session_id}` already exists, exits immediately
+3. Checks for a `--name` override via process ancestry (walk up to 3 levels); if `--name` is detected, creates an empty sentinel file at `~/.claude/session-titles/{session_id}` and exits — this prevents future Stop hook invocations from generating a title, and also causes `session-start.sh` to exit silently on resume (preserving whatever title the terminal shows)
+4. Counts non-meta user messages in the transcript JSONL; exits without generating a title if fewer than 1 user message is found (e.g., the session ended before the first exchange completed)
+5. Extracts the first user prompt from the transcript JSONL file and the last assistant response from the Stop event payload
+6. Gathers lightweight project context: directory name and git repo name (if available)
+7. Calls `claude -p --bare --model haiku` with a constrained system prompt to generate a 2–5 word session title; `--bare` strips the default system prompt; pipe mode (`-p`) does not fire session hooks, avoiding recursive invocation
+8. Sanitizes the title (removes embedded newlines, strips surrounding whitespace, truncates to 40 characters)
+9. Stores the title at `~/.claude/session-titles/{session_id}`
+10. Detects the active terminal emulator and sets the tab title
+
+**Supported terminals and detection:** Same table as the SessionStart hook above.
+
+**`--name` interaction:** If a session was started with `--name`, the hook writes an empty sentinel file. This means the session title is locked to whatever the terminal already shows — no AI title is generated now or on future resumes.
+
+**Async and timeout:** The hook runs asynchronously with a 30-second timeout so that title generation does not block the user between turns.
+
+**Dependencies:**
+- `bash` — required
+- `jq` — required; used for transcript parsing and payload extraction; hook exits silently if unavailable
+- `claude` CLI — required; used for AI title generation; hook exits silently if invocation fails
+- `git` — optional; used for repo name context; absent git context is handled gracefully
+- `cmux` CLI — optional; used for cmux tab renaming; falls back to OSC 0 escape if not in PATH
+
+**Configuration:**
+- Script: `claude/hooks/tab-rename-stop.sh`
+- Type: Async Stop hook
+- Timeout: 30 seconds
 
 ## Instructions: User-Global vs. Project-Level
 


### PR DESCRIPTION
Tab titles were previously set at session start using only session metadata — before any real work had happened — making them generic and context-free.

The redesign splits the logic across two hooks: the Stop hook generates a contextual title after the session's first exchange completes and persists it to disk; the SessionStart hook restores that stored title immediately when a session is resumed. Sessions launched with `--name` receive a sentinel that suppresses automatic renaming entirely.

A shared library (`lib-tab-rename.sh`) centralises terminal detection and title-writing, and a single-fire guard ensures the Stop hook only renames on the first stop of a new session, not on every subsequent tool invocation.