### PR TITLE
fix(clean-backups): use rm -r to handle backup directories

### DIFF
--- a/clean-backups.sh
+++ b/clean-backups.sh
@@ -90,7 +90,7 @@ case "$input" in
 esac
 
 for f in "${to_delete[@]}"; do
-  rm "$f"
+  rm -r "$f"
   printf "${GREEN}Deleted:${NC} %s\n" "$f"
 done
 


### PR DESCRIPTION
rm fails with "is a directory" when backup entries are directories under set -euo pipefail, aborting the deletion loop before any files are removed. Switching to rm -r handles both files and directories uniformly. The -f flag is intentionally omitted so permission errors and other unexpected failures still propagate and abort the script.