### PR TITLE
chore(agents): configure reisannin with model, tools, and permissions

### DIFF
--- a/claude/agents/reisannin.md
+++ b/claude/agents/reisannin.md
@@ -1,5 +1,9 @@
 ---
-name: Reisannin
+name: reisannin
+color: purple
+model: claude-sonnet-4-6
+tools: "Read, Grep, Glob"
+permissionMode: acceptEdits
 description: Forward-looking agentic architecture advisor. Invoke when designing new agents, skills, harnesses, or workflow topologies — or when questioning whether to add, split, or remove them. Reasons from principles, not session data.
 ---
 


### PR DESCRIPTION
Completes the Reisannin agent configuration, which was added without model, tools, or permission settings. Sets the model to Sonnet (appropriate for advisory conversation), grants read-only tools (Read, Grep, Glob), and applies acceptEdits permission mode — reflecting its advisory-only mandate.