### PR TITLE
feat(commands): add /bug and /feature intent-routing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 
 | Command | Purpose |
 |---------|---------|
+| `/bug` | Report a bug or investigate unexpected behavior — routes directly to Tracebloom (Investigative Gate), bypassing heuristic task classification. |
+| `/feature` | Request a new feature or enhancement — routes directly to the constructive planning pipeline, bypassing the Investigative Gate. |
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -216,7 +216,21 @@ Before any planning begins, create an isolated git worktree for this session so 
 
 1. Clarify the user goal in one sentence.
 
-**Mutual exclusivity note:** After clarifying the goal, classify the task as exactly one of the following branches — only one fires per task, they are not sequential filters:
+**Intent Override** (before classification):
+
+If the user's message begins with `INTENT: investigative` or `INTENT: constructive`, skip heuristic classification and route directly:
+- `INTENT: investigative` → fire the Investigative Gate immediately (skip the Mutual Exclusivity classification below)
+- `INTENT: constructive` → skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly)
+
+The `INTENT:` override is honored regardless of source — slash commands (`/bug`, `/feature`) are the typical injection mechanism, but any message starting with a valid `INTENT:` directive will be routed accordingly.
+
+When an intent override fires, log it: "Intent override: {investigative|constructive}. Heuristic classification skipped."
+
+Strip the `INTENT:` line from the message before passing the remaining text to downstream agents. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+
+When not triggered: proceed to the Mutual Exclusivity Note below.
+
+**Mutual exclusivity note:** When no explicit `INTENT:` override is present, classify the task as exactly one of the following branches — only one fires per task, they are not sequential filters:
 - **(a) Investigative** (the task is "why is X broken?" with unknown root cause) → Investigative Gate → Tracebloom
 - **(b) Ambiguous or underspecified** (the task needs clarification before planning) → Intake Gate → Askmaw
 - **(c) Ready for planning** (clear, bounded, constructive task) → proceed to Pathfinder (which will internally handle scope confirmation and options discovery in its Section 4)

--- a/claude/commands/bug.md
+++ b/claude/commands/bug.md
@@ -1,0 +1,13 @@
+---
+description: Report a bug or investigate unexpected behavior — routes directly to Tracebloom (Investigative Gate)
+---
+
+INTENT: investigative
+
+$ARGUMENTS
+
+**Routing note for DM:** This message was submitted via the `/bug` command. The `INTENT: investigative` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip heuristic classification and fire the Investigative Gate (Tracebloom) directly. Strip the `INTENT: investigative` line before passing the task description to downstream agents.
+
+All standard Phase 0 steps (worktree creation, session variables) still apply. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+
+If the task description above is empty (user provided no arguments), ask the user to describe the bug before proceeding.

--- a/claude/commands/feature.md
+++ b/claude/commands/feature.md
@@ -1,0 +1,13 @@
+---
+description: Request a new feature or enhancement — routes directly to the constructive planning pipeline
+---
+
+INTENT: constructive
+
+$ARGUMENTS
+
+**Routing note for DM:** This message was submitted via the `/feature` command. The `INTENT: constructive` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly). Strip the `INTENT: constructive` line before passing the task description to downstream agents.
+
+All standard Phase 0 steps (worktree creation, session variables) still apply. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+
+If the task description above is empty (user provided no arguments), ask the user to describe the feature before proceeding.


### PR DESCRIPTION
Adds `/bug` and `/feature` slash commands that inject an explicit `INTENT:` routing directive into the Dungeon Master's Phase 1, bypassing heuristic task classification. `/bug` routes directly to the Investigative Gate (Tracebloom); `/feature` skips the Investigative Gate and proceeds to the Intake Gate (Askmaw/Pathfinder). The DM's Phase 1 block is updated with an Intent Override that short-circuits classification when the directive is present, with the Mutual Exclusivity Note updated to apply only when no override exists.