### PR TITLE
chore(agents): apply consensus agent workflow fixes

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -444,7 +444,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 5. Track implementation artifacts (changed files, new code).
 
-**Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree.
+**Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree. The counter resets to zero after each intermediate or Phase 4 Ruinor review, regardless of verdict.
 
 ### Phase 4: Implementation Review (Quality Gate)
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -388,7 +388,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
    - Provide Pathfinder with **consolidated feedback from Ruinor and all invoked specialists** using the delegation template below
    - Wait for Pathfinder to revise the plan file
    - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations **and** the original user flags from this session)
-   - Continue this review-revise loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS If this is the 3rd or subsequent revision round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another revision cycle.
+   - Continue this review-revise loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS.
+   - **Stalled-loop termination:** If this is the 3rd or subsequent revision round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another revision cycle.
 
    **Revision delegation template** (use this every time DM re-delegates to Pathfinder from Phase 2 step 4, including subsequent revision rounds after repeated REVISE/REJECT verdicts — every iteration of the review-revise loop uses this same template with updated feedback):
    ```
@@ -467,7 +468,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     - Provide Bitsmith with **consolidated feedback from Ruinor and all invoked specialists**
     - Wait for Bitsmith to fix the issues
     - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations **and** the original user flags from this session)
-    - Continue this review-fix loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS If this is the 3rd or subsequent fix round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another fix cycle.
+    - Continue this review-fix loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS.
+    - **Stalled-loop termination:** If this is the 3rd or subsequent fix round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another fix cycle.
 
     When Ruinor issues REJECT (not REVISE), require Bitsmith to produce a written remediation brief — a short summary of what was changed and why — before the re-review invocation. Pass this brief explicitly to Ruinor as context in the re-review delegation prompt. This distinguishes REJECT remediation from REVISE remediation and prevents rubber-stamp re-approvals.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -208,7 +208,7 @@ Before any planning begins, create an isolated git worktree for this session so 
 
 3. **Handle branch collisions:** If `git worktree add` fails because the branch already exists, retry with a numeric suffix (`feat/add-oauth-login-2`, then `-3`). After 3 failures, fall back to main working tree and warn the user.
 
-4. **Set session context:** The DM carries `WORKTREE_PATH`, `WORKTREE_BRANCH`, `SESSION_TS`, and `SESSION_SLUG` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used.
+4. **Set session context:** The DM carries `WORKTREE_PATH`, `WORKTREE_BRANCH`, `SESSION_TS`, and `SESSION_SLUG` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used. If a session is interrupted and context is lost, run `git worktree list` to recover `WORKTREE_PATH` and `WORKTREE_BRANCH`. Inspect `{WORKTREE_PATH}/plans/` to recover `SESSION_TS` and `SESSION_SLUG` from the plan filename.
 
 5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 
@@ -387,14 +387,15 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 4. If revision needed:
    - Provide Pathfinder with **consolidated feedback from Ruinor and all invoked specialists** using the delegation template below
    - Wait for Pathfinder to revise the plan file
-   - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations)
-   - Continue this review-revise loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS
+   - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations **and** the original user flags from this session)
+   - Continue this review-revise loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS If this is the 3rd or subsequent revision round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another revision cycle.
 
    **Revision delegation template** (use this every time DM re-delegates to Pathfinder from Phase 2 step 4, including subsequent revision rounds after repeated REVISE/REJECT verdicts — every iteration of the review-revise loop uses this same template with updated feedback):
    ```
    REVISION_MODE: true
    WORKING_DIRECTORY: {WORKTREE_PATH}
    WORKTREE_BRANCH: {WORKTREE_BRANCH}
+   USER_FLAGS: {comma-separated flags from original user request (e.g. --review-security), or "None"}
    All file operations and Bash commands must use this directory as the working root.
 
    ## Plan to Revise
@@ -465,8 +466,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 4. If fixes needed:
     - Provide Bitsmith with **consolidated feedback from Ruinor and all invoked specialists**
     - Wait for Bitsmith to fix the issues
-    - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations)
-    - Continue this review-fix loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS
+    - **Return to step 1**: Re-run Ruinor (and conditionally re-run specialists based on new recommendations **and** the original user flags from this session)
+    - Continue this review-fix loop until all reviewers issue ACCEPT or ACCEPT-WITH-RESERVATIONS If this is the 3rd or subsequent fix round for the same artifact, stop the loop and escalate to Pathfinder for a plan revision rather than requesting another fix cycle.
 
     When Ruinor issues REJECT (not REVISE), require Bitsmith to produce a written remediation brief — a short summary of what was changed and why — before the re-review invocation. Pass this brief explicitly to Ruinor as context in the re-review delegation prompt. This distinguishes REJECT remediation from REVISE remediation and prevents rubber-stamp re-approvals.
 

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -100,10 +100,9 @@ After codebase research and interview are complete but before writing the full p
 
 **Skip conditions (first match wins — skip this entire section):**
 
-1. `REVISION_MODE: true` is present — Note: when REVISION_MODE is present, Section 3's own skip already jumps directly to Section 5 (Generate Plan), bypassing Section 4. The REVISION_MODE skip condition in Section 4 is a defensive fallback for future refactoring.
-2. Delegation prompt contains a complete Askmaw `## Intake Brief` with substantive content in all fields
-3. Delegation prompt contains a `## Diagnostic Report` from Tracebloom
-4. Delegation prompt contains a `## Confirmed Scope` block (re-invocation after prior scope confirmation)
+1. Delegation prompt contains a complete Askmaw `## Intake Brief` with substantive content in all fields
+2. Delegation prompt contains a `## Diagnostic Report` from Tracebloom
+3. Delegation prompt contains a `## Confirmed Scope` block (re-invocation after prior scope confirmation)
 
 **`STOP_AFTER_SCOPE: true` handling:** Execute Section 4 fully, produce scope + options output, then STOP — do not write a plan, return structured scope output to DM. DM presents scope + options to the user and waits. If the user does not ask to proceed with planning, the advisory session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
 
@@ -153,6 +152,8 @@ Please confirm the scope above and, if multiple options were presented, select y
 ```
 
 **`## Confirmed Scope` re-invocation handling:** When the delegation prompt contains a `## Confirmed Scope` block, treat it as authoritative scope input and proceed directly to Section 5 (Generate Plan). Do not repeat scope confirmation.
+
+> **Note:** This template must match the re-invocation template in `dungeonmaster.md`. If either file is edited, update both to keep the handoff contract in sync.
 
 **Pathfinder re-invocation template (after scope confirmation):**
 

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -393,7 +393,7 @@ Before considering a plan complete, verify:
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
 7. ✅ **Pre-submission checklist passed** - all 8 questions reviewed and any issues corrected before saving
-8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when REVISION_MODE, Askmaw brief, Tracebloom report, or Confirmed Scope block is present)
+8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when Askmaw brief, Tracebloom report, or Confirmed Scope block is present — REVISION_MODE skips via Section 3 directly to Section 5)
 
 ## Tool Usage
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -1,7 +1,7 @@
 ---
 name: quill
 color: pink
-description: "MUST BE USED to craft or update project documentation. Use PROACTIVELY after major features, API changes, or when onboarding developers. Produces READMEs, API specs, architecture guides, and user manuals."
+description: "Documentation specialist. Produces or updates project docs (READMEs, API specs, architecture guides, user manuals) from a session plan and a list of changed files."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
 model: claude-haiku-4-5
 permissionMode: acceptEdits

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -2,7 +2,7 @@
 name: truthhammer
 color: orange
 description: "Factual validation specialist verifying claims about external systems against authoritative sources."
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"


### PR DESCRIPTION
Applies eight agent config fixes identified through a 4-agent cross-review (Reisannin, Ruinor, Knotcutter, Everwise). Changes affect truthhammer, quill, dungeonmaster, and pathfinder agents.

Key fixes: Truthhammer model upgraded to sonnet-4-6 for dense technical reasoning; Quill description depoliticised to prevent spurious invocations; DM stalled-loop termination clauses added to Phase 2 and Phase 4; user-flag carry-forward added to revision delegation template; Phase 0 context-recovery instructions added; Pathfinder dead REVISION_MODE Section 4 skip condition removed; dual-template sync comment added.

All changes are fully self-contained per the install.sh clone-run-forget constraint.