### PR TITLE
chore(agents): apply r2 3/3-consensus fixes (F-3, R2-1, R2-7)

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -357,7 +357,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 3. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
 
    **What Pathfinder returns depends on skip conditions:**
-   - If `REVISION_MODE: true` is present, a complete Askmaw brief covers all fields, a Tracebloom Diagnostic Report is present, or a `## Confirmed Scope` block is present in the delegation prompt → Pathfinder skips Section 4 (Scope Confirmation) and returns a completed plan directly. Proceed to step 4.
+   - If `REVISION_MODE: true` is present, a complete Askmaw brief covers all fields, a Tracebloom Diagnostic Report is present, or a `## Confirmed Scope` block is present in the delegation prompt → Pathfinder skips Section 4 (Scope Confirmation) and writes the completed plan to disk and signals completion. Proceed to step 4.
    - Otherwise → Pathfinder researches the codebase, runs Section 4 (Scope Confirmation), and returns a structured Scope Confirmation output to DM **without writing a plan**. Proceed to step 3a.
 
 3a. When Pathfinder returns Scope Confirmation output (not a plan):

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -393,7 +393,7 @@ Before considering a plan complete, verify:
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
 7. ✅ **Pre-submission checklist passed** - all 8 questions reviewed and any issues corrected before saving
-8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when Askmaw brief, Tracebloom report, or Confirmed Scope block is present — REVISION_MODE skips via Section 3 directly to Section 5)
+8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when Askmaw brief, Tracebloom report, or Confirmed Scope block is present — REVISION_MODE skips Sections 3 and 4 entirely — proceed directly to Section 5)
 
 ## Tool Usage
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -3,7 +3,7 @@ name: quill
 color: pink
 description: "Documentation specialist. Produces or updates project docs (READMEs, API specs, architecture guides, user manuals) from a session plan and a list of changed files."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 permissionMode: acceptEdits
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,7 @@
 | **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | N/A |
 | **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
 | **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | N/A |
-| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4.5 | N/A |
+| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | N/A |
 | **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-6 | Specialist (opt-in) |
 | **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-6 | N/A |
 | **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-sonnet-4.5 | Specialist (opt-in) |


### PR DESCRIPTION
Applies three agent config fixes that reached 3/3 cross-review consensus (Ruinor, Knotcutter, Everwise) from a second Reisannin architecture review round.

Changes: DM plan-persistence wording corrected (Pathfinder writes to disk, does not return plan in-response); Quill model upgraded from haiku-4-5 to sonnet-4-6; Pathfinder success criteria REVISION_MODE skip description rewritten to accurately state that both Sections 3 and 4 are bypassed. Also corrects a stale model reference in docs/AGENTS.md.