### PR TITLE
feat(commands): add /ask command with advisory intent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 |---------|---------|
 | `/bug` | Report a bug or investigate unexpected behavior — routes directly to Tracebloom (Investigative Gate), bypassing heuristic task classification. |
 | `/feature` | Request a new feature or enhancement — routes directly to the constructive planning pipeline, bypassing the Investigative Gate. |
+| `/ask` | Ask a question about the codebase, architecture, or approach — lightweight Q&A with no planning or implementation. Routes to the Advisory Workflow (Phases A-B-C) for read-only research and synthesis. |
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -324,14 +324,14 @@ When Askmaw is skipped: proceed to step 2 as before.
 
 2. Assess whether a plan already exists in the `plans/` directory.
 
-**Explore-Options Gate** (advisory-only, between step 2 and step 3):
+**Explore-Options Gate** (scope-exploration-only, between step 2 and step 3):
 
 Trigger ONLY when the `--explore-options` flag is explicitly present.
 
 When triggered:
 - Invoke Pathfinder with `STOP_AFTER_SCOPE: true`. Pathfinder researches the codebase, produces a Scope Confirmation (objective, assumptions, affected subsystems, out of scope) and implementation options, then returns this output to DM without writing a plan.
 - DM presents scope + options to the user and waits for explicit selection. Do not proceed until the user responds.
-- **If the user does not ask to proceed with planning:** The advisory session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
+- **If the user does not ask to proceed with planning:** The scope-exploration session is complete — no plan is written, no execution follows. DM delivers a brief completion summary and the session concludes.
 - **If user selects an option and asks to continue:** Re-invoke Pathfinder with the `## Confirmed Scope` block (using the re-invocation template below) and proceed to step 3.
 - **If user rejects presented options or requests a different approach:** Re-invoke Pathfinder with `STOP_AFTER_SCOPE: true` and the user's feedback as additional constraints appended to the delegation prompt. Repeat the scope + options presentation.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -123,7 +123,7 @@ Workflow flags control how the DM routes work through the pipeline. They are dis
 
 | Flag | Effect |
 |------|--------|
-| `--explore-options` | Advisory-only mode: invoke Pathfinder to surface scope and implementation options, then stop. No plan is written, no execution follows. Use when you want to evaluate approaches before committing. |
+| `--explore-options` | Scope-exploration mode: invoke Pathfinder to surface scope and implementation options, then stop. No plan is written, no execution follows. Use when you want to evaluate approaches before committing. This is a constructive-pipeline flag — it has no effect when `INTENT: advisory` is active. |
 
 ### Worktree Context Block
 
@@ -191,7 +191,7 @@ These are carried in conversation memory alongside `WORKTREE_PATH` and `WORKTREE
 
 Before any planning begins, create an isolated git worktree for this session so it does not conflict with other parallel DM sessions.
 
-**No skip condition:** A worktree is always created for every session, regardless of task size or complexity. There are no exceptions.
+**Skip condition:** When `INTENT: advisory` is explicitly set (typically via the `/ask` command), skip worktree creation (steps 1-5 below) and `plans/` directory setup. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured at the top of Phase 0 — they are lightweight conversational memory, not file writes. For all other intents (investigative, constructive, or heuristically classified), worktree creation is mandatory with no exceptions. Note: if the DM heuristically classifies a message as advisory (branch (d) in the Mutual Exclusivity Note), a worktree will already have been created because Phase 0 runs before Phase 1 classification. This is acceptable — the explicit `/ask` command is the primary mechanism for advisory sessions, and the worktree will simply go unused.
 
 **When creating a worktree:**
 
@@ -218,15 +218,16 @@ Before any planning begins, create an isolated git worktree for this session so 
 
 **Intent Override** (before classification):
 
-If the user's message begins with `INTENT: investigative` or `INTENT: constructive`, skip heuristic classification and route directly:
+If the user's message begins with `INTENT: investigative`, `INTENT: constructive`, or `INTENT: advisory`, skip heuristic classification and route directly:
 - `INTENT: investigative` → fire the Investigative Gate immediately (skip the Mutual Exclusivity classification below)
 - `INTENT: constructive` → skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly)
+- `INTENT: advisory` → enter the Advisory Workflow (Phases A-B-C) immediately. Skip worktree creation (Phase 0), all planning gates, and the entire constructive/investigative pipeline. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured.
 
-The `INTENT:` override is honored regardless of source — slash commands (`/bug`, `/feature`) are the typical injection mechanism, but any message starting with a valid `INTENT:` directive will be routed accordingly.
+The `INTENT:` override is honored regardless of source — slash commands (`/bug`, `/feature`, `/ask`) are the typical injection mechanism, but any message starting with a valid `INTENT:` directive will be routed accordingly.
 
-When an intent override fires, log it: "Intent override: {investigative|constructive}. Heuristic classification skipped."
+When an intent override fires, log it: "Intent override: {investigative|constructive|advisory}. Heuristic classification skipped."
 
-Strip the `INTENT:` line from the message before passing the remaining text to downstream agents. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+Strip the `INTENT:` line from the message before passing the remaining text to downstream agents. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented. Exception: when `INTENT: advisory` is active, workflow flags are not applicable — advisory sessions bypass the constructive pipeline where workflow flags operate.
 
 When not triggered: proceed to the Mutual Exclusivity Note below.
 
@@ -234,6 +235,7 @@ When not triggered: proceed to the Mutual Exclusivity Note below.
 - **(a) Investigative** (the task is "why is X broken?" with unknown root cause) → Investigative Gate → Tracebloom
 - **(b) Ambiguous or underspecified** (the task needs clarification before planning) → Intake Gate → Askmaw
 - **(c) Ready for planning** (clear, bounded, constructive task) → proceed to Pathfinder (which will internally handle scope confirmation and options discovery in its Section 4)
+- **(d) Advisory** (the task is a question — "how does X work?", "is this a good approach?", "what are my options?") → Advisory Workflow (Phases A-B-C)
 
 **Investigative Gate** (between step 1 and the Intake Gate):
 
@@ -532,6 +534,64 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
     Log the cleanup result in the completion summary.
 
+### Advisory Workflow (Phases A-B-C)
+
+This workflow fires when `INTENT: advisory` is detected (typically via the `/ask` command). It is a lightweight, read-only Q&A path that bypasses the entire constructive/investigative pipeline.
+
+**What is skipped:** Worktree creation (Phase 0 steps 1-5), Pathfinder, Bitsmith, Ruinor, Quill, all review gates, all completion cleanup. No plan file is written. No code is changed.
+
+**What is NOT skipped:** Session variable capture (`SESSION_TS`, `SESSION_SLUG`) — these are lightweight conversational memory and are retained for logging and potential pipeline transitions.
+
+**Relationship to `--explore-options`:** The `--explore-options` workflow flag is a constructive-pipeline flag that invokes Pathfinder for scope and options discovery. It has no effect when `INTENT: advisory` is active. These are distinct concepts: `INTENT: advisory` is a Q&A mode; `--explore-options` is a scope-exploration mode within the constructive pipeline.
+
+**Phase A — Question Classification:**
+
+Read the user's question and classify it into one of the following types. Select 0-3 agents to invoke based on the classification:
+
+| Question type | Agent(s) to invoke |
+|---|---|
+| "How does X work in this codebase?" | Tracebloom (read-only investigation) |
+| "Is this approach secure?" | Riskmancer |
+| "Will this scale?" | Windwarden |
+| "Is this too complex / what's simpler?" | Knotcutter |
+| "What does library/tool X support?" | Truthhammer |
+| "What are my options for...?" | DM synthesises directly, or Tracebloom for codebase context |
+| Simple conversational / general | DM answers directly — no agents |
+
+If the question spans multiple concerns (e.g., "Is this approach secure and will it scale?"), select all relevant agents (e.g., Riskmancer + Windwarden). Maximum 3 agents per advisory session.
+
+**Mixed-intent handling:** If the user's question contains an embedded constructive or investigative request alongside the advisory question (e.g., "How does X work? Can you fix the bug in it?"), answer the advisory portion first using Phases A-B-C, then inform the user that the constructive or investigative portion requires transitioning to the standard pipeline. Do not silently ignore the non-advisory portion.
+
+**Phase B — Parallel Research:**
+
+Invoke selected agents in parallel. Each agent receives the user's question and returns findings only — no plans, no diffs, no code changes, no implementation suggestions.
+
+Agent delegation template for advisory research:
+
+```
+## Advisory Research Request
+
+**User question:** "{user's question, verbatim}"
+
+**Your role:** Provide analysis and findings relevant to your specialty. This is a read-only advisory — do not produce plans, diffs, code changes, or implementation steps. Return your findings as a clear, structured summary.
+```
+
+When Tracebloom is invoked for advisory research, it operates in read-only investigation mode — no Diagnostic Report format is required. It simply returns relevant codebase findings.
+
+If no agents are selected (DM answers directly), skip Phase B entirely.
+
+**Phase C — Synthesis:**
+
+Assemble agent findings (if any) with DM's own understanding into a clear, direct answer. Present the answer to the user.
+
+- If agents were invoked: attribute key findings to the agent that produced them (e.g., "Riskmancer notes that..." or "Based on Tracebloom's investigation...")
+- If DM answered directly: no attribution needed
+- Compile a Sources list of files, agent findings, or external references cited during the advisory session for inclusion in the output contract
+- No review gate — there is no code to review
+- The advisory session ends after presenting the answer. No completion summary, no worktree cleanup, no PR prompt.
+
+**Follow-up handling:** If the user asks follow-up questions in the same session, repeat Phases A-B-C for each follow-up. The session remains in advisory mode until the user explicitly requests a constructive or investigative action (e.g., "OK, let's fix that" or "Create a plan for this"), at which point DM transitions to the standard pipeline starting from Phase 0.
+
 ## Output contract
 
 When responding back to the main thread, structure your result as:
@@ -550,6 +610,13 @@ When responding back to the main thread, structure your result as:
 - Documentation: updated by Quill / skipped (no planning session)
 - Worktree: `{path}` on branch `{branch}` — {cleanup action taken} / skipped (no worktree)
 - Risks / follow-ups
+
+For advisory sessions (`INTENT: advisory`), use this simplified structure instead:
+
+- Question
+- Agents consulted (list, or "None — answered directly")
+- Answer summary (1-3 sentences)
+- Sources (files, agent findings, or external references cited)
 
 Keep it concise and operational. Prefer facts over narration.
 
@@ -573,6 +640,7 @@ Keep it concise and operational. Prefer facts over narration.
 - Do not invoke Everwise directly, including as an escalation path after in-session review failures or stalled REVISE loops. Everwise is a user-facing meta-analysis tool — suggest it to the user when session patterns warrant it. If a review loop stalls after 3+ REVISE cycles on the same artifact, escalate to Pathfinder for plan revision.
 - Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Tracebloom (investigation), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.
 - The Bash tool and MCP tools are available for read-only orchestration inspection only. Bash is limited to commands like `git status`, `git log`, `git diff`, `ls`. MCP tools are limited to those explicitly allowlisted in `claude/settings.json`. Neither may be used to make changes, run tests, install packages, build, compile, or perform any implementation action. This constraint applies unconditionally — including when executing slash commands. Slash command steps that perform writes must be delegated to Bitsmith, not executed directly by the DM.
+- Advisory sessions (`INTENT: advisory`) are read-only. DM must not create worktrees, invoke Pathfinder, Bitsmith, Ruinor, or Quill, or write any files during an advisory session. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured as conversational memory. If the user's follow-up transitions from advisory to constructive/investigative, DM re-enters the standard pipeline from Phase 0 (worktree creation onwards).
 
 ## Example internal routing behavior
 
@@ -722,3 +790,15 @@ Action:
 - DM re-invokes Pathfinder with `## Confirmed Scope` block (Option B selected, Option A rejected because payment events require retry guarantees)
 - Pathfinder skips Section 4, generates full plan, saves to `plans/20260401-143022-webhook-support.md`
 - Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
+
+Example 10:
+User asks (via /ask): "How does the session isolation work with worktrees?"
+Action:
+- **Intent override fires:** `INTENT: advisory`. Log: "Intent override: advisory. Heuristic classification skipped."
+- **Session variables captured:** `SESSION_TS` = `20260401-143022`, `SESSION_SLUG` = `session-isolation-worktrees`
+- **Phase 0 worktree creation skipped** — advisory sessions do not create worktrees or plans
+- **Phase A:** Question classified as "How does X work in this codebase?" → select Tracebloom
+- **Phase B:** Invoke Tracebloom with advisory research request: "How does the session isolation work with worktrees?"
+- Tracebloom returns findings: Phase 0 creates an isolated git worktree per session at `.worktrees/{branch-slug}`, all sub-agents receive WORKING_DIRECTORY context, worktree is cleaned up in Phase 5d
+- **Phase C:** DM synthesises Tracebloom's findings into a direct answer, attributing codebase references. Sources: `claude/agents/dungeonmaster.md` (Phase 0 section), `claude/references/worktree-protocol.md`
+- Session complete — no review, no plan, no PR prompt

--- a/claude/commands/ask.md
+++ b/claude/commands/ask.md
@@ -1,0 +1,13 @@
+---
+description: Ask a question about the codebase, architecture, or approach — lightweight Q&A with no planning or implementation
+---
+
+INTENT: advisory
+
+$ARGUMENTS
+
+**Routing note for DM:** This message was submitted via the `/ask` command. The `INTENT: advisory` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip heuristic classification and enter the Advisory Workflow (Phases A-B-C) directly. Strip the `INTENT: advisory` line before processing the question.
+
+No worktree creation or plan file applies — advisory sessions do not create worktrees or plans. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured as lightweight memory. Workflow flags (e.g., `--explore-options`) are not applicable in advisory mode — `--explore-options` is a constructive-pipeline flag.
+
+If the question above is empty (user provided no arguments), ask the user what they would like to know before proceeding.


### PR DESCRIPTION
Introduces a `/ask` slash command for lightweight Q&A and brainstorm sessions that bypass the full planning and implementation pipeline. The DM routes `INTENT: advisory` through a new Phase A-B-C workflow — question classification, optional parallel read-only specialist research (Tracebloom, Riskmancer, Windwarden, Knotcutter, Truthhammer), and direct synthesis — with no worktree, no planning, and no review gates.

Also renames the `--explore-options` flag description from "Advisory-only mode" to "Scope-exploration mode" to eliminate the semantic collision with the new advisory intent.