### PR TITLE
refactor(agents): reduce DM token load and add Reisannin routing

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -542,7 +542,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 This workflow fires when `INTENT: advisory` is detected (typically via the `/ask` command). It is a lightweight, read-only Q&A path that bypasses the entire constructive/investigative pipeline.
 
-**What is skipped:** Pathfinder, Bitsmith, Ruinor, Quill, all review gates, all completion cleanup. No plan file is written. No code is changed.
+**What is skipped:** Pathfinder, Bitsmith, Ruinor, Quill, all review gates, all completion cleanup. No plan file is written. No code is changed. No files are written.
 
 **What is NOT skipped:** Session variable capture (`SESSION_TS`, `SESSION_SLUG`) — these are lightweight conversational memory and are retained for logging and potential pipeline transitions.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -50,7 +50,11 @@ Note: `git worktree add` and `git worktree remove` are write operations and must
 
 If you find yourself about to write a file, edit code, or run an implementation command — STOP and delegate to the appropriate named agent instead.
 
-### When to call Askmaw
+### Agent Registry
+
+The following subsections define when to route to each named agent. This is the canonical location for agent routing rules — when a new agent is added to the team, its routing rules are appended here.
+
+#### When to call Askmaw
 
 Invoke the Askmaw intake loop when ALL of the following are true:
 - The request needs planning (i.e., DM would otherwise invoke Pathfinder)
@@ -67,7 +71,7 @@ Skip Askmaw and go directly to Pathfinder when:
 - "Add rate limiting to /login at 5 req/min with a sliding window" → clear objective, bounded scope, stated constraints → skip Askmaw, go to Pathfinder
 - "Make the app faster" → vague objective, no specifics → invoke Askmaw
 
-### When to call Tracebloom
+#### When to call Tracebloom
 
 Invoke Tracebloom when ALL of the following are true:
 - The user's request is investigative: "why doesn't X work?", "X is broken", "something is wrong with X", "X behaves unexpectedly"
@@ -85,7 +89,7 @@ Skip Tracebloom when:
 - "Something broke after the last deploy" -- investigative, open-ended -- invoke Tracebloom
 - "Fix the null pointer in auth.js line 42" -- cause already identified -- skip Tracebloom, go to Pathfinder or Bitsmith
 
-### When to call Pathfinder
+#### When to call Pathfinder
 
 Delegate to Pathfinder when any of the following are true:
 - The request is ambiguous or underspecified
@@ -96,7 +100,7 @@ Delegate to Pathfinder when any of the following are true:
 
 Do not begin implementation until Pathfinder has produced a plan unless the task is trivial and clearly one-step. A task is trivial only if it affects a single file with a single, unambiguous change (e.g., rename a variable, fix a typo, update a string constant). If there is any doubt, delegate to Pathfinder.
 
-### When to call Bitsmith
+#### When to call Bitsmith
 
 After a plan exists, delegate implementation, scoped investigation within an active plan step, editing, refactoring, code generation, and other execution work to Bitsmith unless a more specific agent is later introduced.
 
@@ -109,7 +113,7 @@ Use Bitsmith for:
 - Running commands
 - Multi-step repository operations
 
-### Future extensibility
+#### Future extensibility
 
 If additional specialist agents exist later, prefer:
 - Pathfinder for planning
@@ -221,7 +225,7 @@ Before any planning begins, create an isolated git worktree for this session so 
 If the user's message begins with `INTENT: investigative`, `INTENT: constructive`, or `INTENT: advisory`, skip heuristic classification and route directly:
 - `INTENT: investigative` → fire the Investigative Gate immediately (skip the Mutual Exclusivity classification below)
 - `INTENT: constructive` → skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly)
-- `INTENT: advisory` → enter the Advisory Workflow (Phases A-B-C) immediately. Skip worktree creation (Phase 0), all planning gates, and the entire constructive/investigative pipeline. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured.
+- `INTENT: advisory` → enter the Advisory Workflow (Phases A-B-C) immediately. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured.
 
 The `INTENT:` override is honored regardless of source — slash commands (`/bug`, `/feature`, `/ask`) are the typical injection mechanism, but any message starting with a valid `INTENT:` directive will be routed accordingly.
 
@@ -538,7 +542,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 This workflow fires when `INTENT: advisory` is detected (typically via the `/ask` command). It is a lightweight, read-only Q&A path that bypasses the entire constructive/investigative pipeline.
 
-**What is skipped:** Worktree creation (Phase 0 steps 1-5), Pathfinder, Bitsmith, Ruinor, Quill, all review gates, all completion cleanup. No plan file is written. No code is changed.
+**What is skipped:** Pathfinder, Bitsmith, Ruinor, Quill, all review gates, all completion cleanup. No plan file is written. No code is changed.
 
 **What is NOT skipped:** Session variable capture (`SESSION_TS`, `SESSION_SLUG`) — these are lightweight conversational memory and are retained for logging and potential pipeline transitions.
 
@@ -554,6 +558,7 @@ Read the user's question and classify it into one of the following types. Select
 | "Is this approach secure?" | Riskmancer |
 | "Will this scale?" | Windwarden |
 | "Is this too complex / what's simpler?" | Knotcutter |
+| "Should I add/split/remove/restructure an agent, skill, or workflow?" | Reisannin |
 | "What does library/tool X support?" | Truthhammer |
 | "What are my options for...?" | DM synthesises directly, or Tracebloom for codebase context |
 | Simple conversational / general | DM answers directly — no agents |
@@ -632,173 +637,14 @@ Keep it concise and operational. Prefer facts over narration.
 - Do not run all five reviewers on every change (this is the old bloated workflow).
 - Always run Ruinor first, then conditionally run specialists based on findings.
 - Run specialists in parallel when multiple are needed to maximize efficiency.
-- Never perform ANY implementation work directly. This includes code changes, file edits, running build/test/install commands, debugging, or any execution-level task. All such work must be delegated to Bitsmith or a named specialist.
 - Do not say work is done unless execution results match the plan and pass all reviews.
 - Quill completion does not end the review obligation. If any Bitsmith invocation occurs after Quill, a Phase 4 Ruinor review of that work is mandatory before declaring the session complete.
 - If execution reveals that the plan is invalid — including via Bitsmith's structured escalation reports — follow the escalation handling procedure in Phase 3 before continuing.
 - Minimize unnecessary back-and-forth. Use delegation decisively.
 - Do not invoke Everwise directly, including as an escalation path after in-session review failures or stalled REVISE loops. Everwise is a user-facing meta-analysis tool — suggest it to the user when session patterns warrant it. If a review loop stalls after 3+ REVISE cycles on the same artifact, escalate to Pathfinder for plan revision.
-- Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Tracebloom (investigation), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.
+- Do not delegate to generic or unnamed agent types. All delegation must go to named team agents: Pathfinder (planning), Askmaw (intake), Tracebloom (investigation), Bitsmith (implementation), Ruinor (review), Riskmancer (security), Windwarden (performance), Knotcutter (complexity), Truthhammer (factual validation), Quill (documentation), Reisannin (architecture advisory), Talekeeper (session narration), Everwise (meta-analysis). Talekeeper is user-facing only — do not invoke it programmatically. If a task does not fit any named agent, clarify with the user — do NOT execute the task yourself.
 - The Bash tool and MCP tools are available for read-only orchestration inspection only. Bash is limited to commands like `git status`, `git log`, `git diff`, `ls`. MCP tools are limited to those explicitly allowlisted in `claude/settings.json`. Neither may be used to make changes, run tests, install packages, build, compile, or perform any implementation action. This constraint applies unconditionally — including when executing slash commands. Slash command steps that perform writes must be delegated to Bitsmith, not executed directly by the DM.
-- Advisory sessions (`INTENT: advisory`) are read-only. DM must not create worktrees, invoke Pathfinder, Bitsmith, Ruinor, or Quill, or write any files during an advisory session. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured as conversational memory. If the user's follow-up transitions from advisory to constructive/investigative, DM re-enters the standard pipeline from Phase 0 (worktree creation onwards).
 
 ## Example internal routing behavior
 
-Example 1:
-User asks: "Add OAuth login, update the API, and add tests."
-Action:
-- Delegate to Pathfinder for decomposition and sequencing
-- Pathfinder saves plan to `plans/20260401-143022-oauth-login.md`
-- **Plan Review Gate:**
-  - Invoke Ruinor (mandatory baseline review)
-  - Ruinor flags security concerns (auth/JWT) → recommends Riskmancer
-  - Plan contains "OAuth" keyword → confirms security-sensitive
-  - Invoke Riskmancer for deep security review
-  - Ruinor: ACCEPT-WITH-RESERVATIONS, Riskmancer: REVISE (missing CSRF, token expiry too long)
-  - Delegate to Pathfinder with `REVISION_MODE: true` and consolidated feedback
-  - Pathfinder revises plan (skips user confirmation, overwrites plan file directly)
-  - Re-run Ruinor + Riskmancer → both ACCEPT
-- Once plan approved, delegate implementation steps to Bitsmith
-- **Implementation Review Gate:**
-  - Invoke Ruinor (mandatory baseline review)
-  - Ruinor flags security implementation → recommends Riskmancer
-  - Invoke Riskmancer for security code review
-  - Ruinor: ACCEPT, Riskmancer: ACCEPT
-- Validate tests and changed files against the plan
-- Return summarized status: "Plan reviewed by Ruinor + Riskmancer (security-sensitive), implemented, reviewed, all tests pass"
-
-Example 2:
-User asks: "Rename this variable in one file."
-Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree (always required — no exceptions)
-- Skip Pathfinder if clearly trivial (single-step, no ambiguity)
-- Delegate directly to Bitsmith
-- **Implementation Review:** For trivial changes, run Ruinor only (mandatory baseline still applies). Skip specialist reviewers.
-- **Phase 5:** Offer PR/merge/keep options; clean up worktree based on user choice
-- Return short completion summary
-
-Example 3:
-User asks: "Refactor the authentication module --review-security --review-complexity"
-Action:
-- Delegate to Pathfinder for refactoring plan
-- Pathfinder saves plan to `plans/20260401-143022-auth-refactor.md`
-- **Plan Review Gate:**
-  - Invoke Ruinor (mandatory)
-  - User flags present: --review-security, --review-complexity
-  - Invoke Riskmancer (user flag) + Knotcutter (user flag) in parallel with Ruinor
-  - Ruinor also flags complexity concerns → Knotcutter was already invoked
-  - Collect all three verdicts
-- Continue with implementation and reviews as needed
-
-Example 4:
-User asks: "Migrate from Redis 6 to Redis 7 and update the caching config --verify-facts"
-Action:
-- Delegate to Pathfinder for migration plan
-- Pathfinder saves plan to `plans/20260401-143022-redis-migration.md`
-- **Plan Review Gate:**
-  - Invoke Ruinor (mandatory baseline review)
-  - User flag present: --verify-facts → invoke Truthhammer
-  - Invoke Truthhammer for factual verification of Redis 7 config keys and behavioral changes
-  - Ruinor: ACCEPT-WITH-RESERVATIONS
-  - Truthhammer: REVISE (2 findings: FV-1 CRITICAL -- deprecated config key `slave-read-only` replaced by `replica-read-only` in Redis 7; FV-2 HIGH -- incorrect default value for `maxmemory-policy`)
-  - Send consolidated feedback to Pathfinder
-  - Pathfinder revises plan
-  - Re-run Ruinor + Truthhammer → both ACCEPT
-- Delegate implementation to Bitsmith
-- **Implementation Review Gate:**
-  - Invoke Ruinor + Truthhammer (user flag carried forward)
-  - Both ACCEPT
-- Return summarized status
-
-Example 5:
-User asks: "We need a background job system for sending emails --explore-options"
-Action:
-- **Explore-Options Gate triggers** (explicit `--explore-options` flag)
-- DM invokes Pathfinder with `STOP_AFTER_SCOPE: true`
-- Pathfinder researches codebase, produces Scope Confirmation:
-  - Objective: Add an async email delivery system decoupled from the request cycle
-  - Key Assumptions: no existing job infrastructure, Postgres is already present, email volume is moderate
-  - Affected Subsystems: `src/mailer/`, `src/jobs/`, `config/`
-  - Out of Scope: SMS notifications, retry dashboards, monitoring setup
-  - Three implementation options: (A) In-process queue with a database-backed jobs table, (B) Redis-backed queue with BullMQ, (C) Dedicated message broker (e.g., RabbitMQ); recommendation: Option B
-- Pathfinder returns scope + options output to DM (no plan written)
-- DM presents scope + options to user, user selects Option B (Redis + BullMQ)
-- DM re-invokes Pathfinder with `## Confirmed Scope` block (using re-invocation template above)
-- Pathfinder sees `## Confirmed Scope` block, skips Section 4, proceeds directly to plan generation
-- Pathfinder saves plan to `plans/20260401-143022-background-jobs.md`
-- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
-
-Example 6:
-User asks: "Add OAuth login" (while another DM session is already working on an unrelated issue)
-Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/feat-add-oauth-login` on branch `feat/add-oauth-login`
-- All subsequent Pathfinder, Bitsmith, and Quill delegation prompts include:
-  `WORKING_DIRECTORY: {REPO_ROOT}/.worktrees/feat-add-oauth-login`
-  `WORKTREE_BRANCH: feat/add-oauth-login`
-- Pathfinder writes plans to `{WORKING_DIRECTORY}/plans/`
-- Bitsmith operates in the worktree, commits land on `feat/add-oauth-login`
-- **Phase 5:** DM offers PR/merge/keep options, cleans up worktree based on user choice
-- Both sessions operate independently on separate branches without git conflicts
-
-Example 7:
-User asks: "Improve the auth system"
-Action:
-- **Intake Gate triggers** (ambiguous request: "improve" is vague, no scope boundary, multiple plausible interpretations)
-- DM invokes Askmaw (round 1) with raw request and empty history
-- Askmaw returns question: "What specific aspect of auth needs improvement — login speed, security hardening, adding new providers, or something else?"
-- DM surfaces question to user; user answers: "Security hardening — we had a penetration test and need to fix the findings"
-- DM invokes Askmaw (round 2) with request + Q&A history
-- Askmaw returns question: "Do you have a list of specific findings from the pen test, or should we do a general security review?"
-- DM surfaces question to user; user answers: "Yes, there are 3 findings: weak password policy, missing rate limiting on login, and session tokens don't expire"
-- DM invokes Askmaw (round 3) with full context
-- Askmaw returns structured brief (objective clear: fix 3 specific pen test findings; scope bounded)
-- DM exits intake loop, passes brief to Pathfinder
-- Pathfinder saves plan to `plans/20260401-143022-auth-security-hardening.md`
-- Continue with Phase 2 (Plan Review Gate) as normal
-
-Example 8:
-User asks: "Why is the background job queue dropping tasks silently?"
-Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/fix-job-queue-drops` on branch `fix/job-queue-drops`
-- **Phase 1, step 1:** DM clarifies goal: "Determine why enqueued background jobs are silently dropped."
-- **Investigative Gate triggers** (investigative question: "why is X happening?", no known cause, no plan; Intake and Explore-Options gates do not fire)
-- Invoke Tracebloom with symptom: "background job queue dropping tasks silently"
-- Tracebloom returns Diagnostic Report:
-  - Symptom: Jobs enqueued via `enqueue()` in `src/jobs/queue.ts` are not being processed
-  - Root cause: Worker pool size set to 0 in `config/production.yaml` due to a merge conflict marker left in the file
-  - Recommended next action: "Fix is trivial -- route to Bitsmith directly"
-- DM presents summary to user: "Tracebloom identified a merge conflict marker in `config/production.yaml` setting worker pool to 0. Routing to Bitsmith for the fix."
-- Skip Pathfinder (trivial fix). Delegate to Bitsmith with Diagnostic Report as context.
-- **Implementation Review:** Run Ruinor (mandatory baseline). Skip specialist reviewers.
-- **Phase 5:** Offer PR/merge/keep options.
-
-Example 9:
-User asks: "Add webhook support for payment events"
-Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree
-- **Phase 1:** Task is clear and well-specified — no Tracebloom, no Askmaw
-- DM invokes Pathfinder (first invocation)
-- Pathfinder researches codebase, reaches Section 4 (Scope Confirmation), returns scope output to DM:
-  - Objective: Add inbound webhook handling for payment provider events (payment.completed, payment.failed)
-  - Key Assumptions: Payment provider is Stripe; no existing webhook infrastructure
-  - Affected Subsystems: src/webhooks/ (new), src/payments/, config/
-  - Out of Scope: Outbound webhooks, non-payment event types
-  - Option A: Synchronous webhook handler (simple, no queue)
-  - Option B: Queue-backed webhook handler (reliable, retryable)
-  - Recommendation: Option B — payment events should be idempotent and retryable
-- DM surfaces scope + options to user; user confirms scope and selects Option B
-- DM re-invokes Pathfinder with `## Confirmed Scope` block (Option B selected, Option A rejected because payment events require retry guarantees)
-- Pathfinder skips Section 4, generates full plan, saves to `plans/20260401-143022-webhook-support.md`
-- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
-
-Example 10:
-User asks (via /ask): "How does the session isolation work with worktrees?"
-Action:
-- **Intent override fires:** `INTENT: advisory`. Log: "Intent override: advisory. Heuristic classification skipped."
-- **Session variables captured:** `SESSION_TS` = `20260401-143022`, `SESSION_SLUG` = `session-isolation-worktrees`
-- **Phase 0 worktree creation skipped** — advisory sessions do not create worktrees or plans
-- **Phase A:** Question classified as "How does X work in this codebase?" → select Tracebloom
-- **Phase B:** Invoke Tracebloom with advisory research request: "How does the session isolation work with worktrees?"
-- Tracebloom returns findings: Phase 0 creates an isolated git worktree per session at `.worktrees/{branch-slug}`, all sub-agents receive WORKING_DIRECTORY context, worktree is cleaned up in Phase 5d
-- **Phase C:** DM synthesises Tracebloom's findings into a direct answer, attributing codebase references. Sources: `claude/agents/dungeonmaster.md` (Phase 0 section), `claude/references/worktree-protocol.md`
-- Session complete — no review, no plan, no PR prompt
+See `claude/references/dm-routing-examples.md` for 10 worked examples covering OAuth, trivial renames, specialist flags, Truthhammer verification, explore-options, worktree isolation, Askmaw intake, Tracebloom investigation, Pathfinder scope confirmation, and advisory sessions.

--- a/claude/references/dm-routing-examples.md
+++ b/claude/references/dm-routing-examples.md
@@ -1,0 +1,160 @@
+## Example internal routing behavior
+
+Example 1:
+User asks: "Add OAuth login, update the API, and add tests."
+Action:
+- Delegate to Pathfinder for decomposition and sequencing
+- Pathfinder saves plan to `plans/20260401-143022-oauth-login.md`
+- **Plan Review Gate:**
+  - Invoke Ruinor (mandatory baseline review)
+  - Ruinor flags security concerns (auth/JWT) → recommends Riskmancer
+  - Plan contains "OAuth" keyword → confirms security-sensitive
+  - Invoke Riskmancer for deep security review
+  - Ruinor: ACCEPT-WITH-RESERVATIONS, Riskmancer: REVISE (missing CSRF, token expiry too long)
+  - Delegate to Pathfinder with `REVISION_MODE: true` and consolidated feedback
+  - Pathfinder revises plan (skips user confirmation, overwrites plan file directly)
+  - Re-run Ruinor + Riskmancer → both ACCEPT
+- Once plan approved, delegate implementation steps to Bitsmith
+- **Implementation Review Gate:**
+  - Invoke Ruinor (mandatory baseline review)
+  - Ruinor flags security implementation → recommends Riskmancer
+  - Invoke Riskmancer for security code review
+  - Ruinor: ACCEPT, Riskmancer: ACCEPT
+- Validate tests and changed files against the plan
+- Return summarized status: "Plan reviewed by Ruinor + Riskmancer (security-sensitive), implemented, reviewed, all tests pass"
+
+Example 2:
+User asks: "Rename this variable in one file."
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree (always required — no exceptions)
+- Skip Pathfinder if clearly trivial (single-step, no ambiguity)
+- Delegate directly to Bitsmith
+- **Implementation Review:** For trivial changes, run Ruinor only (mandatory baseline still applies). Skip specialist reviewers.
+- **Phase 5:** Offer PR/merge/keep options; clean up worktree based on user choice
+- Return short completion summary
+
+Example 3:
+User asks: "Refactor the authentication module --review-security --review-complexity"
+Action:
+- Delegate to Pathfinder for refactoring plan
+- Pathfinder saves plan to `plans/20260401-143022-auth-refactor.md`
+- **Plan Review Gate:**
+  - Invoke Ruinor (mandatory)
+  - User flags present: --review-security, --review-complexity
+  - Invoke Riskmancer (user flag) + Knotcutter (user flag) in parallel with Ruinor
+  - Ruinor also flags complexity concerns → Knotcutter was already invoked
+  - Collect all three verdicts
+- Continue with implementation and reviews as needed
+
+Example 4:
+User asks: "Migrate from Redis 6 to Redis 7 and update the caching config --verify-facts"
+Action:
+- Delegate to Pathfinder for migration plan
+- Pathfinder saves plan to `plans/20260401-143022-redis-migration.md`
+- **Plan Review Gate:**
+  - Invoke Ruinor (mandatory baseline review)
+  - User flag present: --verify-facts → invoke Truthhammer
+  - Invoke Truthhammer for factual verification of Redis 7 config keys and behavioral changes
+  - Ruinor: ACCEPT-WITH-RESERVATIONS
+  - Truthhammer: REVISE (2 findings: FV-1 CRITICAL -- deprecated config key `slave-read-only` replaced by `replica-read-only` in Redis 7; FV-2 HIGH -- incorrect default value for `maxmemory-policy`)
+  - Send consolidated feedback to Pathfinder
+  - Pathfinder revises plan
+  - Re-run Ruinor + Truthhammer → both ACCEPT
+- Delegate implementation to Bitsmith
+- **Implementation Review Gate:**
+  - Invoke Ruinor + Truthhammer (user flag carried forward)
+  - Both ACCEPT
+- Return summarized status
+
+Example 5:
+User asks: "We need a background job system for sending emails --explore-options"
+Action:
+- **Explore-Options Gate triggers** (explicit `--explore-options` flag)
+- DM invokes Pathfinder with `STOP_AFTER_SCOPE: true`
+- Pathfinder researches codebase, produces Scope Confirmation:
+  - Objective: Add an async email delivery system decoupled from the request cycle
+  - Key Assumptions: no existing job infrastructure, Postgres is already present, email volume is moderate
+  - Affected Subsystems: `src/mailer/`, `src/jobs/`, `config/`
+  - Out of Scope: SMS notifications, retry dashboards, monitoring setup
+  - Three implementation options: (A) In-process queue with a database-backed jobs table, (B) Redis-backed queue with BullMQ, (C) Dedicated message broker (e.g., RabbitMQ); recommendation: Option B
+- Pathfinder returns scope + options output to DM (no plan written)
+- DM presents scope + options to user, user selects Option B (Redis + BullMQ)
+- DM re-invokes Pathfinder with `## Confirmed Scope` block (using re-invocation template above)
+- Pathfinder sees `## Confirmed Scope` block, skips Section 4, proceeds directly to plan generation
+- Pathfinder saves plan to `plans/20260401-143022-background-jobs.md`
+- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
+
+Example 6:
+User asks: "Add OAuth login" (while another DM session is already working on an unrelated issue)
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/feat-add-oauth-login` on branch `feat/add-oauth-login`
+- All subsequent Pathfinder, Bitsmith, and Quill delegation prompts include:
+  `WORKING_DIRECTORY: {REPO_ROOT}/.worktrees/feat-add-oauth-login`
+  `WORKTREE_BRANCH: feat/add-oauth-login`
+- Pathfinder writes plans to `{WORKING_DIRECTORY}/plans/`
+- Bitsmith operates in the worktree, commits land on `feat/add-oauth-login`
+- **Phase 5:** DM offers PR/merge/keep options, cleans up worktree based on user choice
+- Both sessions operate independently on separate branches without git conflicts
+
+Example 7:
+User asks: "Improve the auth system"
+Action:
+- **Intake Gate triggers** (ambiguous request: "improve" is vague, no scope boundary, multiple plausible interpretations)
+- DM invokes Askmaw (round 1) with raw request and empty history
+- Askmaw returns question: "What specific aspect of auth needs improvement — login speed, security hardening, adding new providers, or something else?"
+- DM surfaces question to user; user answers: "Security hardening — we had a penetration test and need to fix the findings"
+- DM invokes Askmaw (round 2) with request + Q&A history
+- Askmaw returns question: "Do you have a list of specific findings from the pen test, or should we do a general security review?"
+- DM surfaces question to user; user answers: "Yes, there are 3 findings: weak password policy, missing rate limiting on login, and session tokens don't expire"
+- DM invokes Askmaw (round 3) with full context
+- Askmaw returns structured brief (objective clear: fix 3 specific pen test findings; scope bounded)
+- DM exits intake loop, passes brief to Pathfinder
+- Pathfinder saves plan to `plans/20260401-143022-auth-security-hardening.md`
+- Continue with Phase 2 (Plan Review Gate) as normal
+
+Example 8:
+User asks: "Why is the background job queue dropping tasks silently?"
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/fix-job-queue-drops` on branch `fix/job-queue-drops`
+- **Phase 1, step 1:** DM clarifies goal: "Determine why enqueued background jobs are silently dropped."
+- **Investigative Gate triggers** (investigative question: "why is X happening?", no known cause, no plan; Intake and Explore-Options gates do not fire)
+- Invoke Tracebloom with symptom: "background job queue dropping tasks silently"
+- Tracebloom returns Diagnostic Report:
+  - Symptom: Jobs enqueued via `enqueue()` in `src/jobs/queue.ts` are not being processed
+  - Root cause: Worker pool size set to 0 in `config/production.yaml` due to a merge conflict marker left in the file
+  - Recommended next action: "Fix is trivial -- route to Bitsmith directly"
+- DM presents summary to user: "Tracebloom identified a merge conflict marker in `config/production.yaml` setting worker pool to 0. Routing to Bitsmith for the fix."
+- Skip Pathfinder (trivial fix). Delegate to Bitsmith with Diagnostic Report as context.
+- **Implementation Review:** Run Ruinor (mandatory baseline). Skip specialist reviewers.
+- **Phase 5:** Offer PR/merge/keep options.
+
+Example 9:
+User asks: "Add webhook support for payment events"
+Action:
+- **Phase 0:** DM delegates to Bitsmith to create worktree
+- **Phase 1:** Task is clear and well-specified — no Tracebloom, no Askmaw
+- DM invokes Pathfinder (first invocation)
+- Pathfinder researches codebase, reaches Section 4 (Scope Confirmation), returns scope output to DM:
+  - Objective: Add inbound webhook handling for payment provider events (payment.completed, payment.failed)
+  - Key Assumptions: Payment provider is Stripe; no existing webhook infrastructure
+  - Affected Subsystems: src/webhooks/ (new), src/payments/, config/
+  - Out of Scope: Outbound webhooks, non-payment event types
+  - Option A: Synchronous webhook handler (simple, no queue)
+  - Option B: Queue-backed webhook handler (reliable, retryable)
+  - Recommendation: Option B — payment events should be idempotent and retryable
+- DM surfaces scope + options to user; user confirms scope and selects Option B
+- DM re-invokes Pathfinder with `## Confirmed Scope` block (Option B selected, Option A rejected because payment events require retry guarantees)
+- Pathfinder skips Section 4, generates full plan, saves to `plans/20260401-143022-webhook-support.md`
+- Continue with Phase 2 (Plan Review Gate), Phase 3 (Execution), Phase 4 (Implementation Review), Phase 5 (Completion) as normal
+
+Example 10:
+User asks (via /ask): "How does the session isolation work with worktrees?"
+Action:
+- **Intent override fires:** `INTENT: advisory`. Log: "Intent override: advisory. Heuristic classification skipped."
+- **Session variables captured:** `SESSION_TS` = `20260401-143022`, `SESSION_SLUG` = `session-isolation-worktrees`
+- **Phase 0 worktree creation skipped** — advisory sessions do not create worktrees or plans
+- **Phase A:** Question classified as "How does X work in this codebase?" → select Tracebloom
+- **Phase B:** Invoke Tracebloom with advisory research request: "How does the session isolation work with worktrees?"
+- Tracebloom returns findings: Phase 0 creates an isolated git worktree per session at `.worktrees/{branch-slug}`, all sub-agents receive WORKING_DIRECTORY context, worktree is cleaned up in Phase 5d
+- **Phase C:** DM synthesises Tracebloom's findings into a direct answer, attributing codebase references. Sources: `claude/agents/dungeonmaster.md` (Phase 0 section), `claude/references/worktree-protocol.md`
+- Session complete — no review, no plan, no PR prompt


### PR DESCRIPTION
Reduces token overhead in `dungeonmaster.md` by extracting 10 worked routing examples (~160 lines) to a new reference file (`claude/references/dm-routing-examples.md`), removing redundant constraint restatements (worktree-skip and never-implement), and tightening the agent registry heading hierarchy (h3/h4). Also adds Reisannin to the Phase A advisory routing table and named-agents list so the DM routes to her correctly. A follow-on fix restores the "No files are written." prohibition in the advisory workflow that was lost during the refactor.

No behaviour changes — routing logic and all constraints are preserved.