### PR TITLE
feat(talekeeper): add per-agent token tracking to enrich pipeline

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -523,7 +523,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     - note any unfinished items or follow-ups
     - Reservations logged: yes/no -- [file path or "N/A if no ACCEPT-WITH-RESERVATIONS verdicts"]
     - if Quill was invoked in 5b, include a line noting that documentation was updated; otherwise note that documentation update was skipped (no planning session)
-    - Worktree status (path, branch, or 'skipped' if no worktree)
+    - Worktree status (path, branch, cleanup action taken, or 'skipped' if no worktree)
+    - Token usage: read the session's enriched chronicle file — glob `logs/talekeeper-*.jsonl` in the worktree root (or repo root if no worktree is active) and select the file most recently modified during this session. Sum `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` across all entries using `jq`. Report as: "Tokens: {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read" (divide raw counts by 1000, round to 1 decimal). If the chronicle file is not found, unreadable, or contains no token data, report "Token usage: unavailable".
     - if notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
 
     **5d — Worktree log:**
@@ -604,7 +605,8 @@ When responding back to the main thread, structure your result as:
   - Specialist reviews invoked (if any): Riskmancer / Windwarden / Knotcutter / Truthhammer verdicts
 - Final validation
 - Documentation: updated by Quill / skipped (no planning session)
-- Worktree: `{path}` on branch `{branch}` — preserved / skipped (no worktree)
+- Worktree: `{path}` on branch `{branch}` — {cleanup action taken} / skipped (no worktree)
+- Token usage: {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read (or "unavailable")
 - Risks / follow-ups
 
 For advisory sessions (`INTENT: advisory`), use this simplified structure instead:

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -18,7 +18,7 @@ Everwise does NOT perform tasks. She does NOT rewrite production configs. She do
 
 ## Scope of Analysis
 
-Everwise focuses on seven improvement dimensions:
+Everwise focuses on eight improvement dimensions:
 
 - **Agent personas** — Is the agent's personality, voice, or self-description causing misunderstandings about its role?
 - **Skill and tool allocation** — Does an agent lack a tool it demonstrably needs, or have tools it misuses?
@@ -27,6 +27,7 @@ Everwise focuses on seven improvement dimensions:
 - **Escalation rules** — Are escalations triggering too late, too early, or not at all?
 - **Team topology** — Is the overall agent graph missing a necessary role, or duplicating coverage?
 - **Memory policy** — Do agents lack persistence they demonstrably need, or persist information they should not?
+- **Token efficiency** -- Are agents consuming disproportionate tokens relative to their output? Are there sessions with anomalously high token spend? Could routing or prompt changes reduce cost?
 
 ## Review Protocol
 
@@ -62,6 +63,8 @@ Look for:
 - Tasks routed to an agent that had to immediately re-route or escalate
 - Repeated calls to the same agent for the same type of work within a session
 - Missing agent activations where one should logically have been invoked
+- Agents with disproportionately high token counts (`input_tokens` + `output_tokens`) relative to other agents of the same type across sessions
+- Sessions where total token consumption (summed across all agents) exceeds 2x the median for sessions of comparable scope (similar agent count)
 
 ### Step 2b: Flag Entries for Transcript Drill-Down
 
@@ -139,6 +142,7 @@ Assign each identified problem to one of these types:
 | `escalation_problem` | Escalation triggers fire too early, too late, or are ignored |
 | `topology_problem` | Team structure itself is inadequate — missing role, duplicate role, or wrong hierarchy |
 | `memory_policy_problem` | Agents lack persistence they need, or persist information they should not |
+| `token_efficiency_problem` | Agent or session token consumption is disproportionate, anomalous, or reducible through configuration changes |
 
 ### Step 4: Infer Root Cause
 
@@ -206,7 +210,7 @@ Every lesson written to `lessons/` must conform to this schema:
   "lesson_id": "string — unique identifier, format: EVW-YYYY-MM-DD-NNN",
   "created_at": "ISO 8601 timestamp",
   "tier": "candidate | recurring | validated",
-  "problem_type": "persona_problem | skill_allocation_problem | routing_problem | handoff_problem | escalation_problem | topology_problem | memory_policy_problem",
+  "problem_type": "persona_problem | skill_allocation_problem | routing_problem | handoff_problem | escalation_problem | topology_problem | memory_policy_problem | token_efficiency_problem",
   "sessions_observed": ["list of session_id strings where problem was observed"],
   "evidence": "string — factual description of what was observed in the chronicles",
   "inference": "string — Everwise's interpretation of the root cause",

--- a/claude/hooks/talekeeper-enrich.sh
+++ b/claude/hooks/talekeeper-enrich.sh
@@ -51,6 +51,31 @@ echo "$VALID_ENTRIES" | while IFS= read -r entry; do
   last_msg=$(echo "$entry" | jq -r '.last_assistant_message // ""')
   agent_transcript_path=$(echo "$entry" | jq -r '.agent_transcript_path // ""')
 
+  # Extract token usage from agent transcript if available
+  input_tokens=0
+  output_tokens=0
+  cache_creation_input_tokens=0
+  cache_read_input_tokens=0
+
+  if [ -n "$agent_transcript_path" ]
+  then
+    if [ -f "$agent_transcript_path" ]
+    then
+      file_size=$(wc -c < "$agent_transcript_path" 2>/dev/null || echo "0")
+      if [ "$file_size" -le 52428800 ]
+      then
+        token_json=$(jq -s '[.[] | select(.type == "assistant") | .message.usage // {}] | { input_tokens: (map(.input_tokens // 0) | add // 0), output_tokens: (map(.output_tokens // 0) | add // 0), cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0), cache_read_input_tokens: (map(.cache_read_input_tokens // 0) | add // 0) }' "$agent_transcript_path" 2>/dev/null)
+        if [ -n "$token_json" ]
+        then
+          input_tokens=$(echo "$token_json" | jq -r '.input_tokens // 0' 2>/dev/null || echo "0")
+          output_tokens=$(echo "$token_json" | jq -r '.output_tokens // 0' 2>/dev/null || echo "0")
+          cache_creation_input_tokens=$(echo "$token_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null || echo "0")
+          cache_read_input_tokens=$(echo "$token_json" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null || echo "0")
+        fi
+      fi
+    fi
+  fi
+
   # Build summary from structural metadata only (not interpreting free-text)
   summary="${agent_type} completed (${hook_event_name})"
 
@@ -80,7 +105,11 @@ echo "$VALID_ENTRIES" | while IFS= read -r entry; do
     --arg summary "$summary" \
     --argjson verdict "$verdict" \
     --argjson agent_transcript_path "$atp_arg" \
-    '{timestamp: $ts, event_type: $event_type, agent_type: $agent_type, agent_id: $agent_id, session_id: $session_id, summary: $summary, verdict: $verdict, agent_transcript_path: $agent_transcript_path}'
+    --argjson input_tokens "$input_tokens" \
+    --argjson output_tokens "$output_tokens" \
+    --argjson cache_creation_input_tokens "$cache_creation_input_tokens" \
+    --argjson cache_read_input_tokens "$cache_read_input_tokens" \
+    '{timestamp: $ts, event_type: $event_type, agent_type: $agent_type, agent_id: $agent_id, session_id: $session_id, summary: $summary, verdict: $verdict, agent_transcript_path: $agent_transcript_path, input_tokens: $input_tokens, output_tokens: $output_tokens, cache_creation_input_tokens: $cache_creation_input_tokens, cache_read_input_tokens: $cache_read_input_tokens}'
 
 done >> "$OUTPUT_FILE" 2>/dev/null
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -111,8 +111,9 @@ Processes the raw sub-agent event log captured during the session into a structu
 1. Reads `logs/talekeeper-raw.jsonl`
 2. Filters out `hook-agent-*` noise and `talekeeper` self-captures
 3. Extracts structured fields (agent type, session ID, reviewer verdicts) from each entry
-4. Writes an enriched JSONL chronicle to `logs/talekeeper-{session_id}.jsonl`
-5. Clears the raw log on success
+4. Reads the agent's transcript file (recorded in `agent_transcript_path`) and sums token usage across all `type: "assistant"` entries
+5. Writes an enriched JSONL chronicle to `logs/talekeeper-{session_id}.jsonl`
+6. Clears the raw log on success
 
 **Enriched Chronicle Schema:**
 
@@ -128,8 +129,12 @@ Each JSONL line in `logs/talekeeper-{session_id}.jsonl` contains:
 | `summary` | string | Structural summary of the agent's completion (not free-text input) |
 | `verdict` | string or null | For reviewer agents only: `ACCEPT`, `REVISE`, `REJECT`, or `ACCEPT-WITH-RESERVATIONS`; `null` otherwise |
 | `agent_transcript_path` | string or null | For SubagentStop events: path to the agent's JSONL transcript in `~/.claude/projects/`; `null` for non-SubagentStop events |
+| `input_tokens` | integer | Total input tokens consumed by the agent (summed across all assistant turns); `0` when transcript is unavailable |
+| `output_tokens` | integer | Total output tokens produced by the agent; `0` when transcript is unavailable |
+| `cache_creation_input_tokens` | integer | Total tokens written to the prompt cache by the agent; `0` when transcript is unavailable |
+| `cache_read_input_tokens` | integer | Total tokens read from the prompt cache by the agent; `0` when transcript is unavailable |
 
-The `agent_transcript_path` field enables downstream tools (like Everwise Scout) to discover and read raw subagent transcripts for deeper analysis.
+The `agent_transcript_path` field enables downstream tools (like Everwise Scout) to discover and read raw subagent transcripts for deeper analysis. The token fields enable Everwise to identify agents or sessions with disproportionate token consumption without requiring direct transcript access.
 
 **Configuration:**
 - Script: `claude/hooks/talekeeper-enrich.sh`


### PR DESCRIPTION
The Talekeeper pipeline previously captured no token usage data. This adds per-agent token extraction from subagent transcript files in the enrichment step, surfaces aggregate session totals in the DM's Phase 5c completion summary, and equips Everwise to detect token efficiency problems as a new analysis dimension. The CONFIGURATION.md schema reference is updated to reflect the four new chronicle fields.