### PR TITLE
fix(build): output launcher bundle as .cjs to prevent ESM misclassification

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -16,7 +16,7 @@ await Promise.all([
     entryPoints: ['src/launcher/main.ts'],
     bundle: true,
     platform: 'node',
-    format: 'esm',
+    format: 'cjs',
     target: 'node24',
     outfile: 'dist/launcher.js',
     banner: {

--- a/build.ts
+++ b/build.ts
@@ -18,7 +18,7 @@ await Promise.all([
     platform: 'node',
     format: 'cjs',
     target: 'node24',
-    outfile: 'dist/launcher.js',
+    outfile: 'dist/launcher.cjs',
     banner: {
       js: '#!/usr/bin/env node',
     },

--- a/src/installer/launcher-install.test.ts
+++ b/src/installer/launcher-install.test.ts
@@ -13,7 +13,7 @@ function makeFakeRepo(
   fs.mkdirSync(launcherDir, { recursive: true });
 
   const shContent =
-    ["#!/usr/bin/env bash", 'exec node "$HOME/.ai-tpk/launcher.js" "$@"'].join(
+    ["#!/usr/bin/env bash", 'exec node "$HOME/.ai-tpk/launcher.cjs" "$@"'].join(
       "\n",
     ) + "\n";
   fs.writeFileSync(path.join(launcherDir, "myclaude.sh"), shContent);
@@ -23,7 +23,7 @@ function makeFakeRepo(
     const distDir = path.join(root, "dist");
     fs.mkdirSync(distDir, { recursive: true });
     fs.writeFileSync(
-      path.join(distDir, "launcher.js"),
+      path.join(distDir, "launcher.cjs"),
       "// fake launcher bundle\n",
     );
   }
@@ -45,8 +45,8 @@ describe("installLauncherScript", () => {
     fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 
-  it("copies dist/launcher.js to ~/.ai-tpk/launcher.js", () => {
-    const destBundle = path.join(fakeHome, ".ai-tpk", "launcher.js");
+  it("copies dist/launcher.cjs to ~/.ai-tpk/launcher.cjs", () => {
+    const destBundle = path.join(fakeHome, ".ai-tpk", "launcher.cjs");
     assert.ok(fs.existsSync(destBundle));
     const content = fs.readFileSync(destBundle, "utf8");
     assert.ok(content.includes("fake launcher bundle"));
@@ -58,7 +58,7 @@ describe("installLauncherScript", () => {
     assert.ok(fs.statSync(aiTpkDir).isDirectory());
   });
 
-  it("throws if dist/launcher.js is missing", () => {
+  it("throws if dist/launcher.cjs is missing", () => {
     const freshRepo = fs.mkdtempSync(
       path.join(os.tmpdir(), "launcher-test-fresh-repo-"),
     );
@@ -69,7 +69,7 @@ describe("installLauncherScript", () => {
       makeFakeRepo(freshRepo, { withBundle: false });
       assert.throws(
         () => installLauncherScript(freshRepo, { homeDir: freshHome }),
-        /dist\/launcher\.js not found/,
+        /dist\/launcher\.cjs not found/,
       );
       assert.ok(!fs.existsSync(path.join(freshHome, ".ai-tpk")));
     } finally {
@@ -83,7 +83,7 @@ describe("installLauncherScript", () => {
     assert.ok(fs.existsSync(binScript));
     const content = fs.readFileSync(binScript, "utf8");
     assert.ok(content.startsWith("#!/usr/bin/env bash"));
-    assert.ok(content.includes(".ai-tpk/launcher.js"));
+    assert.ok(content.includes(".ai-tpk/launcher.cjs"));
     const mode = fs.statSync(binScript).mode & 0o777;
     assert.equal(mode, 0o755);
   });
@@ -96,7 +96,7 @@ describe("installLauncherScript", () => {
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
 
     assert.ok(!fs.existsSync(oldLauncherDir));
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.js")));
+    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
   });
 
   it("preserves unrelated ~/.ai-tpk/ files on re-install", () => {
@@ -108,6 +108,16 @@ describe("installLauncherScript", () => {
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
 
     assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "other-tool.json")));
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.js")));
+    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
+  });
+
+  it("removes stale ~/.ai-tpk/launcher.js on re-install", () => {
+    const staleJs = path.join(fakeHome, ".ai-tpk", "launcher.js");
+    fs.writeFileSync(staleJs, "// stale bundle\n");
+
+    installLauncherScript(fakeRepo, { homeDir: fakeHome });
+
+    assert.ok(!fs.existsSync(staleJs));
+    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
   });
 });

--- a/src/installer/launcher-install.ts
+++ b/src/installer/launcher-install.ts
@@ -9,9 +9,9 @@ export function installLauncherScript(
   { homeDir = os.homedir() }: { homeDir?: string } = {},
 ): void {
   // 8a. Define paths
-  const srcBundle = path.join(repoRoot, "dist", "launcher.js");
+  const srcBundle = path.join(repoRoot, "dist", "launcher.cjs");
   const aiTpkDir = path.join(homeDir, ".ai-tpk");
-  const destBundle = path.join(aiTpkDir, "launcher.js");
+  const destBundle = path.join(aiTpkDir, "launcher.cjs");
   const binDir = path.join(homeDir, "bin");
   const targetBinPath = path.join(binDir, "myclaude");
   const srcBashScript = path.join(repoRoot, "src", "launcher", "myclaude.sh");
@@ -19,7 +19,7 @@ export function installLauncherScript(
 
   // 8b. Guard: verify required source files exist before any side effects
   if (!fs.existsSync(srcBundle)) {
-    throw new Error(`dist/launcher.js not found. Run 'pnpm run build' first.`);
+    throw new Error(`dist/launcher.cjs not found. Run 'pnpm run build' first.`);
   }
   if (!fs.existsSync(srcBashScript)) {
     throw new Error(
@@ -35,6 +35,17 @@ export function installLauncherScript(
   if (fs.existsSync(oldLauncherDir)) {
     fs.rmSync(oldLauncherDir, { recursive: true, force: true });
     console.log(c.yellow(`Removed old launcher directory: ${oldLauncherDir}`));
+  }
+
+  // 8d2. Migrate: remove stale ~/.ai-tpk/launcher.js left by pre-rename installs
+  const staleLauncherJs = path.join(aiTpkDir, "launcher.js");
+  if (fs.existsSync(staleLauncherJs)) {
+    fs.rmSync(staleLauncherJs);
+    console.log(
+      c.yellow(
+        "Removed stale ~/.ai-tpk/launcher.js (replaced by launcher.cjs)",
+      ),
+    );
   }
 
   // 8e. Install ~/bin/myclaude — refuse symlinks, backup existing
@@ -58,5 +69,5 @@ export function installLauncherScript(
 
   // 8f. Print success messages
   console.log(c.green(`Launcher installed to ~/bin/myclaude`));
-  console.log(c.green(`Launcher bundle installed to ~/.ai-tpk/launcher.js`));
+  console.log(c.green(`Launcher bundle installed to ~/.ai-tpk/launcher.cjs`));
 }

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -74,7 +74,7 @@ Shared utilities (cancellation, prompts) are in `utils.ts` and `prompts.ts`. The
 
 ## Integration with install.sh
 
-Installation is handled by `src/installer/launcher-install.ts`. The process is idempotent: it copies the pre-built bundle to `~/.ai-tpk/launcher.js` and installs the `~/bin/myclaude` bootstrap script. On upgrade, any old `~/.claude/launcher/` directory is automatically removed. The installed launcher has zero runtime dependency on the ai-tpk repository.
+Installation is handled by `src/installer/launcher-install.ts`. The process is idempotent: it copies the pre-built bundle to `~/.ai-tpk/launcher.cjs` and installs the `~/bin/myclaude` bootstrap script. On upgrade, any old `~/.claude/launcher/` directory is automatically removed, and any stale `~/.ai-tpk/launcher.js` from a previous install is removed. The installed launcher has zero runtime dependency on the ai-tpk repository.
 
 ## Migration: Existing grafana-mcp Script
 

--- a/src/launcher/myclaude.sh
+++ b/src/launcher/myclaude.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LAUNCHER_BUNDLE="$HOME/.ai-tpk/launcher.js"
+LAUNCHER_BUNDLE="$HOME/.ai-tpk/launcher.cjs"
 
 if [[ ! -f "$LAUNCHER_BUNDLE" ]]; then
   printf 'Error: myclaude launcher not found at %s\n' "$LAUNCHER_BUNDLE" >&2


### PR DESCRIPTION
Fixes a crash where `myclaude` failed with `Error: Dynamic require of "process" is not supported`. esbuild was outputting the launcher bundle in ESM format, which caused `@clack/prompts` to be resolved via its `.mjs` entry — preserving top-level `import` statements in the output. Node.js then classified the bundle as ESM and `require` became unavailable, breaking the CJS shim boilerplate.

Switches the launcher build to `format: 'cjs'` and renames the output to `launcher.cjs` so Node.js classifies it unambiguously regardless of any ancestor `package.json` `"type"` field. Adds stale-file cleanup in the installer to remove any `~/.ai-tpk/launcher.js` left by previous installs.