### PR TITLE
feat(hooks): ban process substitution in bash commands

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -20,5 +20,5 @@ The `validate-before-pr` skill MUST be invoked before any PR creation. It runs l
 
 ## Bash Command Style
 
-- Never chain commands using `&&` or `;`. Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
+- Never chain commands using `&&` or `;`, and never use process substitution (`<(...)` / `>(...)`). Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
 - Always issue each command as a separate, standalone Bash call.

--- a/claude/hooks/permission-learn.sh
+++ b/claude/hooks/permission-learn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # permission-learn.sh — PermissionRequest hook
-# Denies compound Bash commands; logs single-command requests for manual review.
+# Denies compound Bash commands and process substitution; logs single-command requests for manual review.
 # Fails open if jq is unavailable.
 
 # Read hook payload from stdin
@@ -43,6 +43,12 @@ NEWLINE_COUNT=$(printf '%s' "$STRIPPED" | wc -l | tr -d ' ')
 if [ "$NEWLINE_COUNT" -gt 0 ]; then
   COMPOUND=1
 fi
+if printf '%s' "$STRIPPED" | grep -qF '<('; then
+  COMPOUND=1
+fi
+if printf '%s' "$STRIPPED" | grep -qF '>('; then
+  COMPOUND=1
+fi
 
 if [ "$COMPOUND" -eq 1 ]; then
   jq -n '{
@@ -50,7 +56,7 @@ if [ "$COMPOUND" -eq 1 ]; then
       hookEventName: "PermissionRequest",
       decision: {
         behavior: "deny",
-        message: "Compound commands (&&, ;, newlines) are not allowed. Split into separate Bash calls — one command per call."
+        message: "Compound commands (&&, ;, newlines) and process substitution (<(...), >(...)) are not allowed. Split into separate Bash calls — one command per call. Replace process substitution with temp files."
       }
     }
   }'

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -35,12 +35,41 @@ git stash && git pull | grep "Already up to date"
 grep "ERROR" app.log | wc -l
 ```
 
+## Rule: No Process Substitution
+
+Never use process substitution (`<(cmd)` or `>(cmd)`). Each substitution spawns a subshell that Claude Code treats as a separate command, triggering an additional permission request per substitution. Use temporary files instead.
+
+**Enforcement:** This rule is enforced automatically by the `PermissionRequest` hook (`permission-learn.sh`). Any command containing `<(` or `>(` outside of quoted strings will be denied.
+
+**Wrong — process substitution:**
+```bash
+diff <(sort file1.txt) <(sort file2.txt)
+```
+
+**Right:** Three separate Bash calls using temp files:
+1. `sort file1.txt > /tmp/sorted1.txt`
+2. `sort file2.txt > /tmp/sorted2.txt`
+3. `diff /tmp/sorted1.txt /tmp/sorted2.txt`
+
+**Wrong — output process substitution:**
+```bash
+tee >(grep ERROR > errors.log) < app.log
+```
+
+**Right:** Two separate Bash calls:
+1. `cp app.log /tmp/app-copy.log`
+2. `grep ERROR /tmp/app-copy.log > errors.log`
+
 ## Rationale
 
 Compound commands:
 - Require interactive user approval as a single opaque block
 - Make it harder to diagnose which step failed
 - Violate the project-wide style rule defined in `CLAUDE.md`
+
+Process substitution additionally:
+- Spawns subshells that each trigger a separate Claude Code permission request
+- Cannot be split within a single command — requires rewriting with temp files
 
 ## Applies To
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,9 +21,21 @@ Hooks allow you to run automated checks or tasks at specific points in your Clau
 
 Runs when a Bash command falls outside the `allowedTools` list and requires permission.
 
-**Purpose:** Enforces the no-compound-commands rule (defined in `claude/references/bash-style.md`) at the permission stage and logs non-allowed single commands for manual review. Script: `claude/hooks/permission-learn.sh`.
+**Behavior:**
+1. Reads the permission request event from stdin
+2. Extracts the Bash command and strips quoted strings to avoid false positives
+3. Detects compound operators (`&&`, `;`, embedded newlines) and process substitution (`<(`, `>(`)
+4. Denies permission if any banned syntax is found, returning a message directing the agent to split the command into separate Bash calls and replace process substitution with temp files
+5. For single commands, appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
+6. Fails open (no output, exit 0) if `jq` is unavailable
 
-**Non-obvious behaviors:** Fails open if `jq` is unavailable (no output, exit 0). Quoted strings are stripped before compound-operator detection to avoid false positives (e.g., `grep "a && b" file.txt` is allowed).
+**Purpose:** Enforces the bash style rules defined in `claude/references/bash-style.md` at the permission stage. Keeps the human permission checkpoint intact for any single command not already covered by `allowedTools`, while providing a log for manual review of what commands are being requested.
+
+**Configuration:**
+- Script: `claude/hooks/permission-learn.sh`
+- Type: PermissionRequest hook
+- Timeout: 5 seconds
+- Requires `jq`; fails gracefully if unavailable
 
 **Log format** (`~/.claude/permission-requests.log`):
 ```
@@ -33,6 +45,7 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 **Example:**
 - Denied: `git status && git diff` (contains `&&` — agent is told to split into separate calls)
 - Denied: `cd repo ; npm install` (contains `;`)
+- Denied: `diff <(sort a.txt) <(sort b.txt)` (process substitution — agent is told to use temp files)
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
 - Allowed silently: `grep "a && b" file.txt` (compound operator is inside a quoted string)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ Pre-configured marketplaces for plugin discovery:
 
 Hooks allow you to run automated checks or tasks at specific points in your Claude workflow.
 
-#### PermissionRequest Hook - Compound Command Enforcement and Request Logging
+#### PermissionRequest Hook - Bash Style Enforcement and Request Logging
 
 Runs when a Bash command falls outside the `allowedTools` list and requires permission.
 
@@ -47,7 +47,7 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 - Denied: `cd repo ; npm install` (contains `;`)
 - Denied: `diff <(sort a.txt) <(sort b.txt)` (process substitution — agent is told to use temp files)
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
-- Allowed silently: `grep "a && b" file.txt` (compound operator is inside a quoted string)
+- Logged + normal dialog: `grep "a && b" file.txt` (compound operator is inside a quoted string — no false positive)
 
 #### SessionStart Hook - Terminal Tab Title Restore
 


### PR DESCRIPTION
Process substitution (`<(cmd)` / `>(cmd)`) causes Claude Code to issue a separate permission request per inner subshell, multiplying prompts for a single command. This extends the `PermissionRequest` hook to deny process substitution using the same `COMPOUND=1` pattern already used for `&&`, `;`, and newlines, and updates `bash-style.md`, `CLAUDE.md`, and `docs/CONFIGURATION.md` to document the new rule with wrong/right examples.\n\nAgents encountering a process-substitution denial are directed to rewrite using temp files.