### PR TITLE
feat(tracebloom): require mcp tool use for infrastructure queries

### DIFF
--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -5,7 +5,7 @@ description: "Read-only investigative agent for open-ended 'why is this broken?'
 model: claude-sonnet-4-6
 permissionMode: auto
 level: 2
-tools: "Read, Grep, Glob, Bash"
+tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*"
 ---
 
 # Tracebloom — The Root Reader
@@ -24,6 +24,7 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 
 - All codebase research (Read, Grep, Glob, Bash) must target `{WORKING_DIRECTORY}` as the search root
 - All file paths referenced in the Diagnostic Report must be absolute paths within `{WORKING_DIRECTORY}`
+- MCP tools (Kubernetes, Grafana) query external infrastructure and are not subject to the working-directory constraint; use them without path scoping
 
 ## Scope
 
@@ -34,7 +35,7 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 - Run read-only Bash commands (see Bash Constraints for permitted commands)
 - Trace call chains and examine error outputs
 - Check configuration state and recent git history in the affected area
-- Use MCP tools for log queries and resource state inspection when present — MCP tools are environment-dependent and may not be available at runtime; use them when present but do not depend on their availability
+- Query infrastructure state via Kubernetes and Grafana MCP tools — if MCP tools are available at runtime, using them is required before asking the user for infrastructure information. Never ask the user to manually retrieve data that MCP tools can retrieve. If MCP tools are unavailable at runtime, note this as a constraint on investigation completeness in the Diagnostic Report and proceed with other available tools
 
 ### What Tracebloom Does NOT Do
 
@@ -102,6 +103,8 @@ After delivering the report, Tracebloom halts. He does not follow up, monitor, o
 | `Grep` | Search for error messages, patterns, and call chains across the codebase |
 | `Glob` | Locate files by name or pattern |
 | `Bash` | Run read-only investigation commands (see Bash Constraints below). **Hard constraint:** no write-bearing commands. |
+| `mcp__kubernetes__*` | Inspect Kubernetes resource state, read pod logs, describe objects. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
+| `mcp__grafana__*` | Query Prometheus metrics, Loki logs, dashboards, alerts, incidents, and on-call state. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
 
 ## Bash Constraints
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -74,7 +74,7 @@ He is grounded, patient, observational. He does not rush to a conclusion. He gat
 
 > *"The desert does not lie. It only asks whether you know how to read it."*
 
-**Core Mission:** Investigate open-ended "why doesn't X work?" problems before any plan or fix exists, producing a structured Diagnostic Report that feeds the planning pipeline.
+**Core Mission:** Investigate open-ended "why doesn't X work?" problems before any plan or fix exists, producing a structured Diagnostic Report that feeds the planning pipeline. When Kubernetes and Grafana MCP servers are available at runtime, Tracebloom is required to query them directly rather than asking the user for infrastructure state — extending its read-only reach beyond the local codebase to live cluster resources, metrics, and logs.
 
 **Configuration File:** `/claude/agents/tracebloom.md`
 


### PR DESCRIPTION
Tracebloom was asking users to manually look up Kubernetes pod state and Grafana logs/metrics instead of using the MCP tools already configured in settings.json. The root cause was two-fold: MCP tools were absent from the agent's `tools` frontmatter (so they were inaccessible at runtime), and the body text hedged usage as optional rather than required.

This change adds `mcp__grafana__*` and `mcp__kubernetes__*` wildcard entries to Tracebloom's `tools` frontmatter and replaces the permissive "use if present" instruction with a conditional obligation: MCP tools must be used when available; unavailability must be noted in the Diagnostic Report rather than silently worked around by asking the user.

Note: wildcard resolution in `tools` frontmatter is confirmed by official Claude Code docs but has not yet been verified at runtime for this codebase — a full 41-tool enumeration fallback is documented in the session plan if wildcards fail empirically.