### PR TITLE
fix(merged): auto-select session plan files using SESSION_TS in Step 10a

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,16 +270,11 @@ Agent-produced files (Pathfinder plans, Everwise lessons) accumulate in `~/.ai-t
 
 ### `/merged` Command — Post-Merge Plan Cleanup
 
-When you run `/merged` after a PR is merged, the command now offers to delete associated plan files:
+When you run `/merged` after a PR is merged, the command offers to delete associated plan files from `~/.ai-tpk/plans/{repo-slug}/`. Cleanup is session-aware:
 
-```bash
-/merged
-```
-
-The command automatically detects the current repository and offers to remove plan files from `~/.ai-tpk/plans/{repo-slug}/`. You can:
-- **Delete all:** Remove all plan files for this repo
-- **Select:** Choose which plan files to delete by number
-- **Skip:** Keep all plan files
+- **Session files** (prefixed with the current session timestamp) are identified automatically and presented together for a simple yes/no confirmation.
+- **Other files** (from previous sessions) are offered separately with a yes/no/select prompt so you can keep, bulk-delete, or individually pick what to remove.
+- If the session timestamp is unavailable (e.g. `/merged` was run in a new session), all files are listed together with a single yes/no/select prompt.
 
 This is useful for removing planning artifacts after a feature is shipped.
 

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -163,15 +163,38 @@ Derive the current repo slug by running: `git rev-parse --show-toplevel`
 Take the basename of the result. Store it as `<repo-slug>`.
 
 Check whether any plan files exist for this repo:
-`ls ~/.ai-tpk/plans/<repo-slug>/`
+`ls -1 ~/.ai-tpk/plans/<repo-slug>/`
 
 If the directory is empty or does not exist, skip this step silently and proceed to Step 11.
 
-If files exist, display them and ask:
-`"Found <count> plan file(s) for this repository in ~/.ai-tpk/plans/<repo-slug>/. Would you like to delete them? (yes / no / select)"`
+If files exist, apply the following partitioning logic:
 
-- **yes**: Delegate to Bitsmith to delete all files in `~/.ai-tpk/plans/<repo-slug>/` using `rm` (one call per file, not chained).
-- **select**: Display a numbered list of the files. Ask the user to enter the numbers of files to delete (comma-separated). Delegate the selected deletions to Bitsmith.
+**Partition: session files vs. other files**
+
+Check whether `SESSION_TS` is present in your conversation memory (it should have been set
+in Phase 0 of the DM workflow that created the worktree for this session).
+
+- **If `SESSION_TS` is available:** Files whose names begin with `{SESSION_TS}-` are
+  "session files". All remaining files are "other files".
+- **If `SESSION_TS` is not available** (e.g., `/merged` was run in a new session):
+  All files are treated as "other files". Skip the session-files prompt below and
+  proceed directly to the other-files prompt.
+
+**Session files prompt (when SESSION_TS is available and session files exist):**
+
+List the session files by name. Ask:
+`"Found <count> plan file(s) from this session in ~/.ai-tpk/plans/<repo-slug>/: <list>. Delete them? (yes / no)"`
+
+- **yes**: Delegate to Bitsmith to delete the session files using `rm` (one call per file, not chained).
+- **no**: Skip silently.
+
+**Other files prompt (when non-session files exist):**
+
+List the other files by name. Ask:
+`"Found <count> additional plan file(s) from other sessions in ~/.ai-tpk/plans/<repo-slug>/. Would you like to delete them? (yes / no / select)"`
+
+- **yes**: Delegate to Bitsmith to delete all other files using `rm` (one call per file, not chained).
+- **select**: Display a numbered list of the other files. Ask the user to enter the numbers of files to delete (comma-separated). Delegate the selected deletions to Bitsmith.
 - **no**: Skip silently.
 
 (Per DM delegation policy, file deletions must be delegated to Bitsmith.)
@@ -182,4 +205,4 @@ Print a summary:
 - **Worktree removed:** `<worktree-path>`
 - **Branch deleted:** `<branch>` (or "skipped — detached HEAD" or "skipped — see warning above" if Step 8 was skipped or failed)
 - **Current branch:** main (up to date)
-- **Plan files cleaned:** `<list of deleted plan files, or "none deleted" if Step 10a was skipped or user declined>`
+- **Plan files cleaned:** `<list of deleted plan files grouped as "session: ..." and "other: ...", or "none deleted" if Step 10a was skipped or user declined>`

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -177,8 +177,10 @@ in Phase 0 of the DM workflow that created the worktree for this session).
 - **If `SESSION_TS` is available:** Files whose names begin with `{SESSION_TS}-` are
   "session files". All remaining files are "other files".
 - **If `SESSION_TS` is not available** (e.g., `/merged` was run in a new session):
-  All files are treated as "other files". Skip the session-files prompt below and
-  proceed directly to the other-files prompt.
+  All files are treated as undifferentiated. Skip the session-files prompt and the
+  other-files prompt below. Instead, display all files and ask:
+  `"Found <count> plan file(s) for this repository in ~/.ai-tpk/plans/<repo-slug>/. Would you like to delete them? (yes / no / select)"`
+  Proceed with yes/no/select behaviour as described in the other-files prompt.
 
 **Session files prompt (when SESSION_TS is available and session files exist):**
 


### PR DESCRIPTION
The \`/merged\` command was presenting all plan files for the repository and asking the user to manually identify which ones belonged to the current session. Step 10a now uses \`SESSION_TS\` — already held in DM conversation memory — to auto-identify session files by prefix, presenting them with a simple yes/no prompt. Non-session files from other sessions retain the original yes/no/select interaction. When \`SESSION_TS\` is unavailable (e.g. \`/merged\` is run in a fresh session), a neutral fallback preserves the original behaviour.