### PR TITLE
fix(hooks): use cmux rename-workspace and warn on failure

### DIFF
--- a/claude/hooks/lib-tab-rename.sh
+++ b/claude/hooks/lib-tab-rename.sh
@@ -54,10 +54,13 @@ _tab_rename_set_title() {
   elif [ "$TERMINAL" = "iterm2" ]; then
     printf '\033]0;%s\007' "$TITLE" 2>/dev/null
   elif [ "$TERMINAL" = "cmux" ]; then
-    if command -v cmux &>/dev/null; then
-      cmux rename-tab "$TITLE" 2>/dev/null
+    if command -v cmux >/dev/null 2>&1; then
+      if ! cmux rename-workspace "$TITLE" 2>/dev/null; then
+        printf 'tab-rename: cmux rename-workspace failed — workspace name may not have changed\n' >&2
+      fi
     else
-      printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+      printf 'tab-rename: cmux not found in PATH — falling back to OSC escape sequence\n' >&2
+      printf '\033]0;%s\007' "$TITLE"
     fi
   fi
 }


### PR DESCRIPTION
The cmux rename hook was silently calling the wrong subcommand — rename-tab targets tmux pane tab labels in terminal emulators, not cmux workspace names. The correct subcommand is rename-workspace, which operates on the cmux workspace layer where session names are actually tracked.

The hook now calls rename-workspace and emits stderr warnings if the command fails or if cmux is not found in PATH, making silent failures visible without blocking the hook chain.