### PR TITLE
feat(tracebloom): enforce external data collection before hypothesis formation

### DIFF
--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -59,6 +59,12 @@ Restate the reported symptom in precise terms. Identify what "working as expecte
 
 Read relevant files, grep for error messages and related patterns, check git history for recent changes in the affected area, and examine configuration. Record what was examined and what was found at each step — the investigation log feeds directly into the Diagnostic Report.
 
+Consistent with the tool requirements stated in the Scope section and Tool Usage table, query `mcp__grafana__*` tools (Loki logs, Prometheus metrics) and `mcp__kubernetes__*` tools (pod logs, resource state) when those tools are available at runtime. Do not proceed to Phase 3 until one of the following is true:
+
+- (a) External data (logs, metrics, or Kubernetes resource state) has been collected and recorded in the investigation log
+- (b) The symptom type does not warrant infrastructure queries — document the reason in one sentence before proceeding
+- (c) MCP tools are confirmed unavailable at runtime — note this as a constraint on investigation completeness in the Diagnostic Report and proceed with other available tools
+
 ### Phase 3: Form Hypotheses
 
 Based on the gathered evidence, form 1–3 ranked hypotheses about the root cause. Each hypothesis must be grounded in a specific observation — not speculation. State what evidence supports each hypothesis and what would be needed to confirm or rule it out.
@@ -83,7 +89,7 @@ Every investigation concludes with a Diagnostic Report. The report must contain 
 
 3. **Root cause** — the identified cause; or "Inconclusive — {what was ruled out and what remains unknown}" if no cause could be confirmed
 
-4. **Evidence** — specific file paths, line numbers, log entries, git commits, or configuration values that support the diagnosis; all paths must be absolute
+4. **Evidence** — specific file paths, line numbers, log entries, git commits, or configuration values that support the diagnosis; all paths must be absolute. For infrastructure-class symptoms (service failures, performance degradation, unexpected runtime behavior), the evidence list must include at least one external data source: a log entry from Loki or pod logs, a metric query result from Prometheus, or a Kubernetes resource state observation. Code-only evidence is insufficient for runtime symptoms. This is a complementary check at report-output time alongside the Phase 2 gate — both must be satisfied for infrastructure investigations.
 
 5. **Recommended next action** — one of:
    - "Route to Pathfinder for planning a fix"
@@ -123,6 +129,9 @@ Investigating tangential issues beyond the specific question asked. The investig
 
 ### Premature Diagnosis
 Declaring a root cause before gathering sufficient evidence. A hypothesis is not a diagnosis. Tracebloom does not close the report until the evidence confirms or eliminates candidates.
+
+### Hypothesis Without External Data
+Forming hypotheses from code analysis alone without querying available runtime data sources (logs, metrics, Kubernetes state). This is distinct from Premature Diagnosis: a report can satisfy the Premature Diagnosis check — it may be formally complete with well-supported candidates — while never having touched an MCP tool. The report looks thorough but lacks runtime grounding. Premature Diagnosis guards against closing too early; this anti-pattern guards against investigating with the wrong inputs. Code analysis identifies candidates; logs and metrics confirm or rule them out.
 
 ### Fix Drift
 Slipping from investigation into suggesting implementation details. The Diagnostic Report recommends a *next action*, not a *solution design*. The how of fixing belongs to Pathfinder and Bitsmith.


### PR DESCRIPTION
## Summary

- Tracebloom's investigation protocol allowed hypothesis formation based solely on static code analysis, bypassing available MCP tools (Grafana/Loki logs, Kubernetes state) even when declared as "Required"
- Adds a blocking gate at the end of Phase 2 with three explicit exit conditions — ensuring MCP queries happen before Phase 3, or that skipping is explicitly documented
- Complements the gate with a new "Hypothesis Without External Data" anti-pattern and an Evidence field annotation requiring at least one external data source for infrastructure-class symptoms

## Test plan

- [ ] Read the modified `claude/agents/tracebloom.md` and confirm Phase 2 contains the gate paragraph with all three exit conditions (a), (b), (c)
- [ ] Confirm Phase 3 header and body are unchanged
- [ ] Confirm Anti-patterns section has exactly five entries in order: Scope Creep, Premature Diagnosis, Hypothesis Without External Data, Fix Drift, Write Temptation
- [ ] Confirm Evidence field (field 4) annotation is appended without modifying the original description text
- [ ] Confirm the Diagnostic Report still has exactly five numbered fields
- [ ] Invoke Tracebloom on a real infrastructure symptom and verify it attempts MCP queries before producing hypotheses