### PR TITLE
feat(claude-md): add Think Before Coding constraint section

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -22,3 +22,10 @@ The `validate-before-pr` skill MUST be invoked before any PR creation. It runs l
 
 - Never chain commands using `&&` or `;`, and never use process substitution (`<(...)` / `>(...)`). Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
 - Always issue each command as a separate, standalone Bash call.
+
+## Think Before Coding
+
+- When an instruction is ambiguous, present the plausible interpretations and ask which one is intended. Do not silently pick one.
+- Before starting work, surface any non-obvious assumptions you are making so the user can correct them.
+- If a simpler approach exists than what was requested, say so before proceeding.
+- When you are confused or lack sufficient context, stop and ask. Do not guess.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -137,11 +137,18 @@ Claude Code loads instructions at two levels:
 
 ### User-Global Instructions (claude/CLAUDE.md)
 
-`claude/CLAUDE.md` is installed to `~/.claude/CLAUDE.md` by the installer and loaded by Claude Code at session start for every project. It mandates three skills that apply globally across all work:
+`claude/CLAUDE.md` is installed to `~/.claude/CLAUDE.md` by the installer and loaded by Claude Code at session start for every project. It contains two types of global constraints:
+
+**Mandatory skills** — three skills that apply globally across all work:
 
 - **`commit-message-guide`** — required for all git commits; conventional commit format is enforced, no exceptions
 - **`open-pull-request`** — required for all pull requests and merge requests; no other PR creation method is allowed
 - **`validate-before-pr`** — runs lint and format checks as a mandatory gate before PR creation; must pass before open-pull-request can be invoked
+
+**Behavioral constraints** — directives that govern how Claude Code behaves before and during execution:
+
+- **Bash Command Style** — prohibits command chaining (`&&`, `;`) and process substitution; each command must be issued as a standalone Bash call
+- **Think Before Coding** — requires surfacing ambiguous interpretations before acting, disclosing non-obvious assumptions, proposing simpler alternatives when they exist, and stopping to ask rather than guessing when context is insufficient
 
 ### Project-Level Instructions (.claude/CLAUDE.md)
 


### PR DESCRIPTION
Adds a "Think Before Coding" behavioral constraint section to the user-scope \`claude/CLAUDE.md\`, addressing a gap identified by Reisannin: no existing artifact governed Claude Code's own behavior when receiving ambiguous direct instructions. The four directives — surface interpretations, disclose assumptions, propose simpler alternatives, and stop to ask rather than guess — complement the existing Mandatory Skills and Bash Command Style sections. \`docs/CONFIGURATION.md\` updated to reflect the restructured sections.