### PR TITLE
feat(commands): add /build-and-install repo-scope command

### DIFF
--- a/.claude/commands/build-and-install.md
+++ b/.claude/commands/build-and-install.md
@@ -1,0 +1,33 @@
+---
+description: Rebuild dist/installer.js, reinstall all project artifacts to ~/.claude/, and optionally clean stale backups
+---
+
+You are rebuilding and reinstalling all project artifacts. Follow every step below in order.
+Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+
+## Step 1 — Resolve repo root
+
+Run: `git rev-parse --show-toplevel`
+
+Store the result as `<repo-root>`. Use this path as the base for all subsequent commands.
+This guards against cwd being reset between Bash calls.
+
+## Step 2 — Build
+
+Run `pnpm build` from `<repo-root>`.
+
+If the command exits with a non-zero status, report the error output and stop. Do not proceed
+to the install step.
+
+## Step 3 — Install
+
+Run `./install.sh` from `<repo-root>`.
+
+If the command exits with a non-zero status, report the error output and stop. Do not proceed
+to the clean-backups step.
+
+## Step 4 — Clean backups
+
+Run `./clean-backups.sh` from `<repo-root>`.
+
+If it exits non-zero, report the error output.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Keep AI tool configurations version-controlled and portable across machines. The
 │   └── commands/        # Slash commands for Claude Code
 ├── .claude/         # Project-scope Claude Code config (this repo only)
 │   ├── CLAUDE.md         # Project-level instructions (scope clarification guard)
+│   ├── commands/        # Repo-scoped slash commands (e.g., /build-and-install)
 │   └── skills/          # Project-scoped skills
 ├── cursor/          # Cursor configurations (coming soon)
 ├── docs/            # Documentation
@@ -262,7 +263,7 @@ Over time the installer may accumulate multiple timestamped backups for the same
 ./clean-backups.sh
 ```
 
-The script scans the same directories as `recover.sh` (`~/.claude` and `~/.cursor`), groups backups by their original file path, and shows a summary of everything it would delete before asking for confirmation. Original paths that have only one backup are left untouched. Nothing is deleted unless you explicitly confirm with `y`.
+The script scans the same directories as `recover.sh` (`~/.claude` and `~/.cursor`), groups backups by their original file path, and displays the list of files it will delete before proceeding immediately. Original paths that have only one backup are left untouched.
 
 ## Cleaning Up Agent Artifacts
 
@@ -562,7 +563,7 @@ When making changes to this repository:
 
 1. **Setup** — Follow the Development Setup section above to install dependencies and build the bundle
 2. **Make changes** — Edit TypeScript files in `src/installer/` or `src/launcher/`, or configuration files in `claude/`
-3. **Build** — Run `pnpm run build` to rebuild the installer bundle
+3. **Build and reinstall** — Run `pnpm run build` to rebuild the installer bundle, then `./install.sh` to deploy to `~/.claude/`, then `./clean-backups.sh` to remove stale backups. The `/build-and-install` repo-scope slash command automates all three steps in sequence.
 4. **Test** — Run `pnpm test` to execute the test suite
 5. **Lint and format** — Run `pnpm run format` to auto-fix formatting, then `pnpm run lint` to verify code quality
 6. **Commit and push** — The pre-push hook (Lefthook) automatically runs linting and format checks; they must pass before pushing

--- a/clean-backups.sh
+++ b/clean-backups.sh
@@ -77,18 +77,6 @@ for f in "${to_delete[@]}"; do
 done
 printf "\n%d file(s) will be deleted.\n\n" "${#to_delete[@]}"
 
-printf "${YELLOW}Proceed? [y/N]:${NC} "
-read -r input || true
-
-case "$input" in
-  y|Y)
-    ;;
-  *)
-    printf "${YELLOW}Aborted. Nothing deleted.${NC}\n"
-    exit 0
-    ;;
-esac
-
 for f in "${to_delete[@]}"; do
   rm -r "$f"
   printf "${GREEN}Deleted:${NC} %s\n" "$f"


### PR DESCRIPTION
Adds a `/build-and-install` repo-scope slash command that runs `pnpm build`, `./install.sh`, and `./clean-backups.sh` in sequence — giving developers a single command to rebuild and reinstall all project artifacts after making changes.

Also removes the interactive `Proceed? [y/N]` confirmation from `clean-backups.sh` so the script runs non-interactively, and updates README documentation accordingly.