### PR TITLE
feat(hooks): auto-approve allowedTools-matched bash commands with variable expansions

### DIFF
--- a/claude/hooks/permission-learn.sh
+++ b/claude/hooks/permission-learn.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # permission-learn.sh — PermissionRequest hook
-# Denies compound Bash commands and process substitution; logs single-command requests for manual review.
+# Auto-approves single Bash commands whose allowedTools pattern matches and all safety guards pass.
+# Denies compound commands, process substitution, and --no-verify.
+# Logs every decision; falls through to the normal permission dialog for unmatched commands.
 # Fails open if jq is unavailable.
 
 # Read hook payload from stdin
@@ -25,11 +27,175 @@ fi
 AGENT_ID=$(echo "$STDIN_DATA" | jq -r '.agent_id // "none"' 2>/dev/null)
 AGENT_TYPE=$(echo "$STDIN_DATA" | jq -r '.agent_type // "none"' 2>/dev/null)
 
-# Strip quoted strings to avoid false positives on literal && or ; inside strings.
-# Double-quote stripping first (removes any single quotes nested inside double-quoted strings),
-# then single-quote stripping second.
+# Strip ALL quoted strings for compound-operator detection only. Both single- and
+# double-quoted content may contain literal &&, ;, etc. that are not operators.
+# WARNING: Do NOT use $STRIPPED for security checks — see $SECURITY_STRIPPED below.
 STRIPPED=$(printf '%s' "$COMMAND" | sed 's/"[^"]*"//g')
 STRIPPED=$(printf '%s' "$STRIPPED" | sed "s/'[^']*'//g")
+
+# Security-sensitive stripping: remove only single-quoted strings (whose content is
+# truly literal in bash). Double-quoted content is preserved because $(), backticks,
+# and $VAR all expand inside double quotes — security checks must see them.
+SECURITY_STRIPPED=$(printf '%s' "$COMMAND" | sed "s/'[^']*'//g")
+
+# --- Helper functions ---
+
+# matches_allowed_tools NEUTRALIZED_CMD
+# Returns 0 (true) if the command matches an allowedTools Bash(...) glob pattern.
+# SYNC: Keep this list in sync with allowedTools in claude/settings.json
+matches_allowed_tools() {
+  local cmd="$1"
+  case "$cmd" in
+    git\ *)              return 0 ;;
+    gh\ pr\ *)           return 0 ;;
+    gh\ issue\ *)        return 0 ;;
+    gh\ run\ *)          return 0 ;;
+    gh\ repo\ view\ *)   return 0 ;;
+    gh\ repo\ clone\ *)  return 0 ;;
+    gh\ release\ view\ *) return 0 ;;
+    gh\ auth\ switch\ *) return 0 ;;
+    mkdir\ *)            return 0 ;;
+    rm\ *)               return 0 ;;
+    cp\ *)               return 0 ;;
+    mv\ *)               return 0 ;;
+    touch\ *)            return 0 ;;
+    ls\ *)               return 0 ;;
+    cd\ *)               return 0 ;;
+    npm\ *)              return 0 ;;
+    npx\ *)              return 0 ;;
+    pnpm\ *)             return 0 ;;
+    yarn\ *)             return 0 ;;
+    python\ *)           return 0 ;;
+    python3\ *)          return 0 ;;
+    *\ --help)           return 0 ;;
+    *\ --version)        return 0 ;;
+    *)                   return 1 ;;
+  esac
+}
+
+# is_simple_expansion_only CMD_STRING
+# Returns 0 (true) if the command contains no complex shell constructs beyond
+# simple variable expansions ($VAR, ${VAR}) and tilde (~).
+# Returns 1 (false) if backticks, $(...), pipes, redirections, or other complex
+# constructs are found.
+# IMPORTANT: Receive $SECURITY_STRIPPED (single-quote-stripped only), NOT $STRIPPED,
+# so that dangerous constructs inside double quotes are visible.
+is_simple_expansion_only() {
+  local cmd="$1"
+
+  # Reject backtick command substitution
+  if printf '%s' "$cmd" | grep -q '`'; then
+    return 1
+  fi
+
+  # Reject $(...) command substitution
+  if printf '%s' "$cmd" | grep -qF '$('; then
+    return 1
+  fi
+
+  # Reject pipes (but not ||, which is a compound operator caught earlier)
+  if printf '%s' "$cmd" | grep -qE '\|[^|]'; then
+    return 1
+  fi
+  if printf '%s' "$cmd" | grep -qE '[^|]\|$'; then
+    return 1
+  fi
+
+  # Reject redirections: >, >>, <, 2>, &>, etc.
+  if printf '%s' "$cmd" | grep -qE '[0-9]*[<>]'; then
+    return 1
+  fi
+
+  # After removing simple expansions and tildes, remaining text should contain
+  # no dollar signs (which would indicate complex expansions like ${var:-default},
+  # ${var//pattern/replace}, $((arithmetic)), etc.)
+  local neutralized
+  neutralized=$(printf '%s' "$cmd" | sed -E 's/\$\{[A-Za-z_][A-Za-z0-9_]*\}//g')
+  neutralized=$(printf '%s' "$neutralized" | sed -E 's/\$[A-Za-z_][A-Za-z0-9_]*//g')
+  neutralized=$(printf '%s' "$neutralized" | sed 's/~//g')
+
+  if printf '%s' "$neutralized" | grep -q '\$'; then
+    return 1
+  fi
+
+  return 0
+}
+
+# has_dangerous_keywords CMD_STRING
+# Returns 0 (true) if the command contains dangerous keywords (eval, exec, source,
+# sudo) as standalone words. Uses whitespace-delimited matching to avoid false
+# positives on flags like --exec-path, --source, --no-exec.
+# Must receive $SECURITY_STRIPPED (single-quote-stripped only).
+has_dangerous_keywords() {
+  local cmd="$1"
+  if printf '%s' "$cmd" | grep -qE '(^| )(eval|exec|source|sudo)( |$)'; then
+    return 0
+  fi
+  return 1
+}
+
+# has_git_config_injection CMD_STRING
+# Returns 0 (true) if the command is a git command using -c (config override).
+# git -c key=value can configure external command execution for ssh, pager, diff,
+# editor, and aliases starting with !, enabling arbitrary command execution.
+# Matches both standalone -c and concatenated -ckey=val forms.
+# Must receive $SECURITY_STRIPPED (single-quote-stripped only).
+has_git_config_injection() {
+  local cmd="$1"
+  local base
+  base=$(printf '%s' "$cmd" | awk '{print $1}')
+  if [ "$base" = "git" ]; then
+    if printf '%s' "$cmd" | grep -qE '(^| )-c'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# has_python_code_exec CMD_STRING
+# Returns 0 (true) if the command is a python/python3 invocation with -c (inline
+# code execution). python -c can execute arbitrary system commands, read/write files,
+# and make network requests.
+# Must receive $SECURITY_STRIPPED (single-quote-stripped only).
+has_python_code_exec() {
+  local cmd="$1"
+  local base
+  base=$(printf '%s' "$cmd" | awk '{print $1}')
+  if [ "$base" = "python" ] || [ "$base" = "python3" ]; then
+    if printf '%s' "$cmd" | grep -qE '(^| )-c( |$)'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# has_npx_arbitrary_package CMD_STRING
+# Returns 0 (true) if the command is an npx invocation. npx auto-downloads packages,
+# making it unsafe to auto-approve without knowing which package is being run.
+# All npx commands are blocked from auto-approve.
+# Must receive $SECURITY_STRIPPED (single-quote-stripped only).
+has_npx_arbitrary_package() {
+  local cmd="$1"
+  local base
+  base=$(printf '%s' "$cmd" | awk '{print $1}')
+  if [ "$base" = "npx" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# neutralize_expansions CMD_STRING
+# Replaces $VAR, ${VAR}, and ~ with placeholder literals so the result can be
+# matched against allowedTools glob patterns.
+neutralize_expansions() {
+  local cmd="$1"
+  # Replace ${VAR} first (more specific), then $VAR
+  cmd=$(printf '%s' "$cmd" | sed 's/\${[A-Za-z_][A-Za-z0-9_]*}/XVARX/g')
+  cmd=$(printf '%s' "$cmd" | sed 's/\$[A-Za-z_][A-Za-z0-9_]*/XVARX/g')
+  cmd=$(printf '%s' "$cmd" | sed 's|~/|/home/placeholder/|g')
+  cmd=$(printf '%s' "$cmd" | sed 's|^~$|/home/placeholder|g')
+  printf '%s' "$cmd"
+}
 
 # Check for compound operators in the stripped command
 COMPOUND=0
@@ -83,6 +249,60 @@ if [ "$NOVERIFY" -eq 1 ]; then
     }
   }'
   exit 0
+fi
+
+# --- Auto-approve: allowedTools pattern match + safety guards ---
+# Neutralize simple expansions ($VAR, ${VAR}, ~) with placeholder literals,
+# then check if the result matches an allowedTools Bash(...) pattern.
+NEUTRALIZED=$(neutralize_expansions "$COMMAND")
+
+if matches_allowed_tools "$NEUTRALIZED"; then
+  # Safety guards — all operate on $SECURITY_STRIPPED (single-quote-stripped only)
+  # so that dangerous constructs inside double quotes remain visible.
+  SAFE=1
+
+  # Guard 1: Dangerous keywords (eval, exec, source, sudo)
+  if has_dangerous_keywords "$SECURITY_STRIPPED"; then
+    SAFE=0
+  fi
+
+  # Guard 2: git -c config injection
+  if has_git_config_injection "$SECURITY_STRIPPED"; then
+    SAFE=0
+  fi
+
+  # Guard 3: python/python3 -c arbitrary code execution
+  if has_python_code_exec "$SECURITY_STRIPPED"; then
+    SAFE=0
+  fi
+
+  # Guard 4: npx arbitrary package download/execution
+  if has_npx_arbitrary_package "$SECURITY_STRIPPED"; then
+    SAFE=0
+  fi
+
+  # Guard 5: Complex shell constructs (backticks, $(...), pipes, redirections,
+  # complex parameter expansions)
+  if ! is_simple_expansion_only "$SECURITY_STRIPPED"; then
+    SAFE=0
+  fi
+
+  if [ "$SAFE" -eq 1 ]; then
+    # All checks passed — auto-approve and log.
+    TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    LOG_FILE="$HOME/.claude/permission-requests.log"
+    printf '%s | agent_type=%s | agent_id=%s | [auto-approved] command=%s\n' \
+      "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >> "$LOG_FILE"
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: {
+          behavior: "allow"
+        }
+      }
+    }'
+    exit 0
+  fi
 fi
 
 # Single command — log the request for manual review, then exit 0 with no JSON

--- a/claude/hooks/test-permission-learn.sh
+++ b/claude/hooks/test-permission-learn.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# test-permission-learn.sh — Shell test harness for permission-learn.sh
+# Feeds JSON payloads to the hook and asserts expected output.
+# Usage: bash claude/hooks/test-permission-learn.sh  (from repo root)
+#        bash test-permission-learn.sh               (from hooks directory)
+# Exits 1 if any test fails.
+
+HOOK="$(dirname "$0")/permission-learn.sh"
+
+if [ ! -f "$HOOK" ]; then
+  printf 'ERROR: Hook not found at %s\n' "$HOOK"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# test_case DESCRIPTION JSON_PAYLOAD EXPECTED
+# EXPECTED is one of: allow | deny | fallthrough
+test_case() {
+  local description="$1"
+  local payload="$2"
+  local expected="$3"
+
+  local output
+  output=$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)
+
+  local result
+  if printf '%s' "$output" | grep -q '"allow"'; then
+    result="allow"
+  elif printf '%s' "$output" | grep -q '"deny"'; then
+    result="deny"
+  else
+    result="fallthrough"
+  fi
+
+  if [ "$result" = "$expected" ]; then
+    printf 'PASS  %s\n' "$description"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL  %s\n' "$description"
+    printf '      expected=%s  got=%s\n' "$expected" "$result"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Helper: build a JSON payload for a Bash tool call (compact single-line output
+# so the hook's "read -r" receives the full JSON in one read).
+make_payload() {
+  local command="$1"
+  jq -cn --arg cmd "$command" '{tool_name:"Bash",tool_input:{command:$cmd},agent_id:"test-agent",agent_type:"subagent"}'
+}
+
+printf '%s\n\n' '=== permission-learn.sh test harness ==='
+
+# --- AUTO-APPROVE cases ---
+printf '%s\n' '-- AUTO-APPROVE cases --'
+
+test_case \
+  "TC-01: git log with HOME variable matches git *" \
+  "$(make_payload 'git log $HOME/repo')" \
+  "allow"
+
+test_case \
+  "TC-02: ls with tilde matches ls *" \
+  "$(make_payload 'ls ~/projects')" \
+  "allow"
+
+test_case \
+  "TC-03: mkdir -p with variable matches mkdir *" \
+  "$(make_payload 'mkdir -p $HOME/.config')" \
+  "allow"
+
+test_case \
+  "TC-04: cp with two variables matches cp *" \
+  "$(make_payload 'cp $SRC $DST')" \
+  "allow"
+
+test_case \
+  "TC-05: mv with two variables matches mv *" \
+  "$(make_payload 'mv $OLD $NEW')" \
+  "allow"
+
+test_case \
+  "TC-06: git push with variable branch matches git *" \
+  "$(make_payload 'git push origin $BRANCH')" \
+  "allow"
+
+test_case \
+  "TC-07: gh pr create with variable title matches gh pr *" \
+  "$(make_payload 'gh pr create --title $TITLE')" \
+  "allow"
+
+test_case \
+  "TC-08: git log with braced expansion matches git *" \
+  "$(make_payload 'git diff ${BRANCH}')" \
+  "allow"
+
+test_case \
+  "TC-08b: python3 script with variable — python3 should be auto-approved (not -c)" \
+  "$(make_payload 'python3 script.py $ARGS')" \
+  "allow"
+
+# --- FALLTHROUGH cases ---
+printf '\n%s\n' '-- FALLTHROUGH cases --'
+
+test_case \
+  "TC-09: git log with dollar-paren in double quotes — command substitution" \
+  "$(make_payload 'git log --format="$(date)"')" \
+  "fallthrough"
+
+test_case \
+  "TC-10: git log with backtick in double quotes — backtick substitution" \
+  "$(make_payload 'git log --format="`date`"')" \
+  "fallthrough"
+
+test_case \
+  "TC-11: git -c with space — git config injection" \
+  "$(make_payload 'git -c core.sshCommand=curl push $REMOTE')" \
+  "fallthrough"
+
+test_case \
+  "TC-12: git -c concatenated (no space) — git config injection" \
+  "$(make_payload 'git -ccore.pager=malicious log $BRANCH')" \
+  "fallthrough"
+
+test_case \
+  "TC-13: python -c with double-quoted code — python code exec" \
+  "$(make_payload 'python -c "$CODE"')" \
+  "fallthrough"
+
+test_case \
+  "TC-14: python -c with single-quoted code — python code exec" \
+  "$(make_payload "python -c 'import os; os.system(\"rm -rf /\")'") " \
+  "fallthrough"
+
+test_case \
+  "TC-15: npx arbitrary package — npx guard" \
+  "$(make_payload 'npx $PACKAGE')" \
+  "fallthrough"
+
+test_case \
+  "TC-16: gh extension install — not in allowedTools" \
+  "$(make_payload 'gh extension install $EXT')" \
+  "fallthrough"
+
+test_case \
+  "TC-17: gh api endpoint — not in allowedTools" \
+  "$(make_payload 'gh api $ENDPOINT')" \
+  "fallthrough"
+
+test_case \
+  "TC-18: cat file — cat not in allowedTools" \
+  "$(make_payload 'cat $FILE')" \
+  "fallthrough"
+
+test_case \
+  "TC-19: git log with unquoted command substitution" \
+  "$(make_payload 'git log $(date +%Y)')" \
+  "fallthrough"
+
+# --- DENY cases ---
+printf '\n%s\n' '-- DENY cases --'
+
+test_case \
+  "TC-20: git status && git push — compound command" \
+  "$(make_payload 'git status && git push')" \
+  "deny"
+
+test_case \
+  "TC-21: git commit -n — --no-verify shorthand" \
+  "$(make_payload 'git commit -n')" \
+  "deny"
+
+# --- AUTO-APPROVE: F-4 dangerous keyword false positive verification ---
+printf '\n%s\n' '-- F-4 false positive correction (should AUTO-APPROVE) --'
+
+test_case \
+  "TC-22: git log --exec-path=/usr/bin BRANCH — exec-path should not trigger keyword guard" \
+  "$(make_payload 'git log --exec-path=/usr/bin $BRANCH')" \
+  "allow"
+
+test_case \
+  "TC-23: git log --source BRANCH — source flag should not trigger keyword guard" \
+  "$(make_payload 'git log --source $BRANCH')" \
+  "allow"
+
+# --- Summary ---
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,12 +16,12 @@
     "Bash(ls *)",
     "Bash(cd *)",
     "Bash(npm *)",
-    "Bash(npx *)",
     "Bash(pnpm *)",
     "Bash(yarn *)",
     "Bash(* --help)",
     "Bash(* --version)",
     "Bash(python *)",
+    "Bash(python3 *)",
     "mcp__grafana__search_dashboards",
     "mcp__grafana__get_dashboard_by_uid",
     "mcp__grafana__get_dashboard_summary",
@@ -117,6 +117,7 @@
       }
     ]
   },
+  "_comment_allowedTools": "Bash patterns are mirrored in claude/hooks/permission-learn.sh matches_allowed_tools(). Update both when changing Bash tool patterns.",
   "defaultMode": "dontAsk",
   "enabledPlugins": {},
   "extraKnownMarketplaces": {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,13 +24,27 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 **Behavior:**
 1. Reads the permission request event from stdin
 2. Extracts the Bash command and strips quoted strings to avoid false positives
-3. Detects compound operators (`&&`, `;`, embedded newlines) and process substitution (`<(`, `>(`)
-4. Detects `--no-verify` (and `-n` for `git commit`) on `git commit` and `git push` commands
-5. Denies permission if any banned syntax is found, returning a message directing the agent to split the command into separate Bash calls, replace process substitution with temp files, or fix the underlying hook failure instead of bypassing it
-6. For single commands, appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
+3. Detects compound operators (`&&`, `;`, embedded newlines) and process substitution (`<(`, `>(`) — denies if found
+4. Detects `--no-verify` (and `-n` for `git commit`) on `git commit` and `git push` commands — denies if found
+5. For commands that pass the deny checks: neutralizes simple variable expansions (`$VAR`, `${VAR}`, `~`) and checks if the result matches an `allowedTools` Bash pattern. If it matches, runs five safety guards; auto-approves if all pass
+6. For commands that do not match any allowedTools pattern, or that fail a safety guard: appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
 7. Fails open (no output, exit 0) if `jq` is unavailable
 
-**Purpose:** Enforces the bash style rules defined in `claude/references/bash-style.md` at the permission stage. Keeps the human permission checkpoint intact for any single command not already covered by `allowedTools`, while providing a log for manual review of what commands are being requested.
+**Why auto-approve?** Claude Code classifies commands containing `$VAR`, `${VAR}`, or `~` as "too-complex" and bypasses `allowedTools` pattern matching in `settings.json`, triggering a permission dialog even when the base command (e.g., `git log`, `mkdir`) is already trusted. The hook closes that gap by performing its own pattern match after neutralizing the expansions.
+
+**Safety guards (auto-approve path only):**
+
+| Guard | What it blocks |
+|-------|---------------|
+| Dangerous keywords | `eval`, `exec`, `source`, `sudo` as standalone words (whitespace-delimited to avoid false positives on `--exec-path`, `--source`) |
+| `git -c` injection | `git -c key=val` config overrides that can redirect git to arbitrary executables |
+| `python -c` / `python3 -c` | Inline code execution arguments |
+| `npx` | All `npx` commands (arbitrary package download cannot be distinguished from local project scripts) |
+| Complex constructs | Backticks, `$(...)`, pipes, redirections, and complex parameter expansions beyond `$VAR`/`${VAR}` |
+
+All guards operate on single-quote-stripped input so that dangerous constructs inside double-quoted strings (e.g., `--format="$(date)"`) remain visible and are caught.
+
+**Purpose:** Enforces the bash style rules defined in `claude/references/bash-style.md` at the permission stage. Eliminates disruptive permission dialogs for trusted commands that contain simple variable expansions, while keeping the human permission checkpoint intact for commands that are not covered by `allowedTools` or that fail a safety guard.
 
 **Configuration:**
 - Script: `claude/hooks/permission-learn.sh`
@@ -40,18 +54,30 @@ Runs when a Bash command falls outside the `allowedTools` list and requires perm
 
 **Log format** (`~/.claude/permission-requests.log`):
 ```
-2026-04-09T14:27:44Z | agent_type=Bitsmith | agent_id=abc123 | command=npm install express
+2026-04-09T14:27:44Z | agent_type=Bitsmith | agent_id=abc123 | [auto-approved] command=git log --format=$FORMAT
+2026-04-09T14:27:50Z | agent_type=Bitsmith | agent_id=abc123 | command=docker ps
 ```
 
-**Example:**
+Auto-approved entries include the `[auto-approved]` marker; commands falling through to the permission dialog have no marker.
+
+**Examples:**
 - Denied: `git status && git diff` (contains `&&` — agent is told to split into separate calls)
 - Denied: `cd repo ; npm install` (contains `;`)
 - Denied: `diff <(sort a.txt) <(sort b.txt)` (process substitution — agent is told to use temp files)
 - Denied: `git commit --no-verify -m "msg"` (bypasses pre-commit hooks)
 - Denied: `git commit -n -m "msg"` (short form of `--no-verify` for `git commit`)
 - Denied: `git push --no-verify` (bypasses pre-push hooks)
+- Auto-approved: `git log --format=$FORMAT` (matches `git *`, simple expansion only, no safety guard triggered)
+- Auto-approved: `mkdir -p $HOME/.config` (matches `mkdir *`)
+- Auto-approved: `ls ~/projects` (matches `ls *`, tilde is a simple expansion)
+- Auto-approved: `gh pr list --repo $REPO` (matches `gh pr *`)
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
-- Logged + normal dialog: `grep "a && b" file.txt` (compound operator is inside a quoted string — no false positive)
+- Logged + normal dialog: `grep "a && b" file.txt` (compound operator inside a quoted string — no false positive on deny; no allowedTools pattern match — falls through)
+- Logged + normal dialog: `gh extension install $PKG` (no matching allowedTools pattern for `gh extension`)
+- Logged + normal dialog: `git log --format="$(date)"` (safety guard: `$(...)` inside double quotes)
+- Logged + normal dialog: `git -c core.editor="vi" diff` (safety guard: `git -c` config injection)
+- Logged + normal dialog: `python3 -c "code"` (safety guard: `python3 -c`)
+- Logged + normal dialog: `sudo rm -rf $DIR` (safety guard: dangerous keyword `sudo`)
 - Allowed: `echo -n hello`, `git log -n 5` (context-aware: `-n` only blocked in `git commit` context)
 
 #### SessionStart Hook - Terminal Tab Title Restore


### PR DESCRIPTION
Subagents were receiving permission dialogs for routine bash commands like
`git push origin $BRANCH` or `ls ~/projects` because Claude Code's bash AST
parser classifies commands containing `$VAR`, `${VAR}`, or `~` as
"too-complex" and bypasses `allowedTools` pattern matching entirely.

The `PermissionRequest` hook now neutralizes simple expansions and matches
the result against `allowedTools` patterns, auto-approving commands that
pass five safety guards: command substitution detection, dangerous keyword
check, `git -c` config injection guard, `python -c` code-exec guard, and
`npx` arbitrary-package guard. Commands that fail any guard fall through to
the normal permission dialog unchanged.

`Bash(npx *)` removed from `allowedTools` (defense-in-depth: hook guard
alone is the right barrier for package downloads). `Bash(python3 *)` added
to align with hook's existing `python3` case. Includes a 24-case shell test
harness at `claude/hooks/test-permission-learn.sh`.