### PR TITLE
fix(cloudwatch): allow dots in profile names and deduplicate dot/underscore variants

### DIFF
--- a/claude/commands/set-aws-profile.md
+++ b/claude/commands/set-aws-profile.md
@@ -13,6 +13,8 @@ List available AWS profiles from `~/.aws/config` or `~/.aws/credentials` and let
    - If `~/.aws/config` does not exist, fall back to `~/.aws/credentials`:
      - Include every `[<name>]` section header as a profile name (including `[default]`)
      - Note: credentials file uses bare section names with no `profile` prefix
+     - Deduplicate: treat `.` and `_` as equivalent when comparing names — if two entries differ only by `.` vs `_` in the same position(s), show only the first occurrence and suppress the duplicate
+     - Sort the final list alphabetically
    - If neither file exists or contains no profiles, tell the user and stop.
 
 2. **Show the current active profile** (if any): read `~/.claude/.current-aws-profile` — if it exists and is non-empty, display its first line as the current profile next to "(active)". If the file does not exist, note "no profile currently set."

--- a/src/launcher/cloudwatch.test.ts
+++ b/src/launcher/cloudwatch.test.ts
@@ -131,7 +131,7 @@ aws_access_key_id = AKIA...
       "[default]\n[foo-bar]\n[baz_qux]\n",
       "credentials",
     );
-    assert.deepStrictEqual(profiles, ["default", "foo-bar", "baz_qux"]);
+    assert.deepStrictEqual(profiles, ["baz_qux", "default", "foo-bar"]);
   });
 
   it("returns empty array for content with no section headers", () => {
@@ -140,6 +140,50 @@ aws_access_key_id = AKIA...
       "credentials",
     );
     assert.deepStrictEqual(profiles, []);
+  });
+
+  it("deduplicates entries that differ only by . vs _ — keeps first occurrence", () => {
+    const content = `
+[default]
+aws_access_key_id = AKIA...
+
+[foo.bar]
+aws_access_key_id = AKIA...
+
+[foo_bar]
+aws_access_key_id = AKIA...
+
+[baz]
+aws_access_key_id = AKIA...
+`;
+    const profiles = parseProfileSections(content, "credentials");
+    assert.deepStrictEqual(profiles, ["baz", "default", "foo.bar"]);
+  });
+
+  it("deduplicates entries that differ only by . vs _ — underscore-first ordering", () => {
+    const content = `
+[default]
+aws_access_key_id = AKIA...
+
+[foo_bar]
+aws_access_key_id = AKIA...
+
+[foo.bar]
+aws_access_key_id = AKIA...
+
+[baz]
+aws_access_key_id = AKIA...
+`;
+    const profiles = parseProfileSections(content, "credentials");
+    assert.ok(
+      profiles.includes("foo_bar"),
+      "foo_bar should be kept (first occurrence)",
+    );
+    assert.ok(
+      !profiles.includes("foo.bar"),
+      "foo.bar should be removed (duplicate)",
+    );
+    assert.deepStrictEqual(profiles, ["baz", "default", "foo_bar"]);
   });
 });
 

--- a/src/launcher/mcp/cloudwatch.ts
+++ b/src/launcher/mcp/cloudwatch.ts
@@ -44,6 +44,18 @@ export function parseProfileSections(
     }
   }
 
+  if (format === "credentials") {
+    const seen = new Set<string>();
+    return profiles
+      .filter((p) => {
+        const key = p.replace(/\./g, "_");
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .toSorted();
+  }
+
   return profiles;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "ES2023.Array"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "strict": true,

--- a/wrappers/mcp-cloudwatch.sh
+++ b/wrappers/mcp-cloudwatch.sh
@@ -12,9 +12,9 @@ fi
 
 # Validate profile name if set
 if [[ -n "${AWS_PROFILE:-}" ]]; then
-  # Valid AWS profile names: letters, digits, hyphens, underscores only (per AWS SDKref)
-  if [[ ! "$AWS_PROFILE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-    printf 'Error: invalid AWS profile name "%s" -- must match [a-zA-Z0-9_-]+\n' "$AWS_PROFILE" >&2
+  # Valid AWS profile names: letters, digits, hyphens, underscores, dots (per AWS SDKref)
+  if [[ ! "$AWS_PROFILE" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+    printf 'Error: invalid AWS profile name "%s" -- must match [a-zA-Z0-9_.-]+\n' "$AWS_PROFILE" >&2
     exit 1
   fi
   export AWS_PROFILE
@@ -32,7 +32,9 @@ if [[ -f "$HOME/.aws/config" ]]; then
     | sed 's/^\[profile //;s/^\[//;s/\]$//' >&2
 elif [[ -f "$HOME/.aws/credentials" ]]; then
   grep -E '^\[[^]]+\]' "$HOME/.aws/credentials" \
-    | sed 's/^\[//;s/\]$//' >&2
+    | sed 's/^\[//;s/\]$//' \
+    | awk '{key=$0; gsub(/\./, "_", key); if(!seen[key]++) print $0}' \
+    | sort >&2
 else
   printf '  (no ~/.aws/config or ~/.aws/credentials found)\n' >&2
 fi


### PR DESCRIPTION
AWS profile names can legitimately contain dots (e.g. \`foo.bar\`), but the CloudWatch MCP wrapper was rejecting them with a validation error, preventing the server from starting. Additionally, the AWS SDK treats \`foo.bar\` and \`foo_bar\` as the same credential block when reading \`~/.aws/credentials\`, so presenting both names in the profile picker was confusing and could cause a failed-state launch.

The shell wrapper's profile name regex now permits dots, and both the TypeScript launcher and the shell debug listing deduplicate credentials-file profiles whose names differ only in \`.\` vs \`_\`, keeping the first occurrence and sorting the result alphabetically.