### PR TITLE
fix(commands): remove interactive prompts from /merged plan-file cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,13 +271,13 @@ Agent-produced files (Pathfinder plans, Everwise lessons) accumulate in `~/.ai-t
 
 ### `/merged` Command — Post-Merge Plan Cleanup
 
-When you run `/merged` after a PR is merged, the command offers to delete associated plan files from `~/.ai-tpk/plans/{repo-slug}/`. Cleanup is session-aware:
+When you run `/merged` after a PR is merged, the command silently auto-deletes plan files from `~/.ai-tpk/plans/{repo-slug}/` that belong to the current session (matched by session timestamp prefix). No prompt is shown for these files.
 
-- **Session files** (prefixed with the current session timestamp) are identified automatically and presented together for a simple yes/no confirmation.
-- **Other files** (from previous sessions) are offered separately with a yes/no/select prompt so you can keep, bulk-delete, or individually pick what to remove.
-- If the session timestamp is unavailable (e.g. `/merged` was run in a new session), all files are listed together with a single yes/no/select prompt.
+If the session timestamp is unavailable (e.g. `/merged` was run in a new session without worktree context), no plan files are touched and no prompt is shown.
 
-This is useful for removing planning artifacts after a feature is shipped.
+Files from other sessions are never mentioned or deleted by `/merged`. Use `/clean-ai-tpk-artifacts` for cross-session cleanup.
+
+This is useful for removing planning artifacts after a feature is shipped without any interruption to the cleanup flow.
 
 ### `/clean-ai-tpk-artifacts` Command — Age-Based Cleanup
 
@@ -387,7 +387,7 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |
 | `/sync-pr` | Rebases the current PR branch onto `refs/remotes/origin/main` and force-pushes with `--force-with-lease`, keeping open PRs in sync with main's latest changes without manual git gymnastics. |
 | `/clean-the-desk` | Cleans up stale local branches (whose upstream PRs have been merged) and removes their associated git worktrees. Prompts for confirmation before any destructive action. |
-| `/merged` | Cleans up after a merged PR: uses session context or remote-gone detection to auto-select the target branch, removes the worktree, deletes the local branch, checks out main, pulls the latest, and optionally removes associated plan files from `~/.ai-tpk/plans/{repo-slug}/`. Confirms all destructive actions with the user. |
+| `/merged` | Cleans up after a merged PR: uses session context or remote-gone detection to auto-select the target branch, removes the worktree, deletes the local branch, checks out main, pulls the latest, and silently auto-deletes current-session plan files from `~/.ai-tpk/plans/{repo-slug}/`. Confirms all destructive actions with the user. |
 | `/clean-ai-tpk-artifacts` | Deletes plan and lesson files older than N days (default 14) from `~/.ai-tpk/`. By default scoped to the current repository's plans; use `--all` flag to clean across all repositories. Prompts for confirmation before deletion. |
 | `/merge-pr` | Syncs the current PR branch with main, waits for all required CI checks to pass, squash-merges the PR, deletes the remote branch, and automatically chains into `/merged` for post-merge cleanup. |
 | `/address-pr-comments` | Reviews and replies to unresolved inline GitHub PR review comments — fetches threads via GraphQL, reads current file state, categorizes each comment (FIX, COMPROMISE, PUSH-BACK, ALREADY-ADDRESSED, ACKNOWLEDGE), proposes a reply for user approval, and posts approved replies via the REST API. Saves a session summary to `~/.ai-tpk/pr-review-comments/` with resume support across sessions. |

--- a/claude/commands/merge-pr.md
+++ b/claude/commands/merge-pr.md
@@ -128,7 +128,7 @@ its Step 0 shortcut (session-context path) instead of running the full discovery
 a worktree), do not synthesize these values — let `/merged` run its normal discovery flow.
 
 Execute `/merged`. The `/merged` command handles: worktree removal, local branch deletion,
-checkout of main, pull latest, and plan file cleanup offer. No additional cleanup is needed
+checkout of main, pull latest, and session plan file cleanup. No additional cleanup is needed
 in this command.
 
 If `/merged` encounters errors, its own error handling will report them. Do not wrap

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -157,47 +157,30 @@ Delegate to Bitsmith to run (from `<main-path>`): `git pull origin main`
 If this fails, report the error but do not treat it as fatal — the local checkout is already
 on `main`.
 
-## Step 10a — Offer plan file cleanup
+## Step 10a — Auto-clean session plan files
+
+Check whether `SESSION_TS` is present in your conversation memory.
+
+**If SESSION_TS is not available** (e.g., `/merged` was run in a new session without
+worktree context): Skip this step silently. Do not list, prompt about, or delete any
+plan files. Do not run `git rev-parse`, `ls`, or any other command. Proceed to Step 11.
+
+**If SESSION_TS is available:**
 
 Derive the current repo slug by running: `git rev-parse --show-toplevel`
 Take the basename of the result. Store it as `<repo-slug>`.
 
-Check whether any plan files exist for this repo:
-`ls -1 ~/.ai-tpk/plans/<repo-slug>/`
+List files matching the session timestamp in the plan directory:
+`ls -1 ~/.ai-tpk/plans/<repo-slug>/{SESSION_TS}-* 2>/dev/null`
 
-If the directory is empty or does not exist, skip this step silently and proceed to Step 11.
+If no files match (command produces no output or the directory does not exist), skip
+this step silently and proceed to Step 11.
 
-If files exist, apply the following partitioning logic:
+If matching files exist, delegate to Bitsmith to delete each file using `rm` (one call
+per file, not chained). Do not prompt the user. Do not mention or touch any files that
+do not match `{SESSION_TS}-*`.
 
-**Partition: session files vs. other files**
-
-Check whether `SESSION_TS` is present in your conversation memory (it should have been set
-in Phase 0 of the DM workflow that created the worktree for this session).
-
-- **If `SESSION_TS` is available:** Files whose names begin with `{SESSION_TS}-` are
-  "session files". All remaining files are "other files".
-- **If `SESSION_TS` is not available** (e.g., `/merged` was run in a new session):
-  All files are treated as undifferentiated. Skip the session-files prompt and the
-  other-files prompt below. Instead, display all files and ask:
-  `"Found <count> plan file(s) for this repository in ~/.ai-tpk/plans/<repo-slug>/. Would you like to delete them? (yes / no / select)"`
-  Proceed with yes/no/select behaviour as described in the other-files prompt.
-
-**Session files prompt (when SESSION_TS is available and session files exist):**
-
-List the session files by name. Ask:
-`"Found <count> plan file(s) from this session in ~/.ai-tpk/plans/<repo-slug>/: <list>. Delete them? (yes / no)"`
-
-- **yes**: Delegate to Bitsmith to delete the session files using `rm` (one call per file, not chained).
-- **no**: Skip silently.
-
-**Other files prompt (when non-session files exist):**
-
-List the other files by name. Ask:
-`"Found <count> additional plan file(s) from other sessions in ~/.ai-tpk/plans/<repo-slug>/. Would you like to delete them? (yes / no / select)"`
-
-- **yes**: Delegate to Bitsmith to delete all other files using `rm` (one call per file, not chained).
-- **select**: Display a numbered list of the other files. Ask the user to enter the numbers of files to delete (comma-separated). Delegate the selected deletions to Bitsmith.
-- **no**: Skip silently.
+Store the list of deleted file names for use in Step 11's summary.
 
 (Per DM delegation policy, file deletions must be delegated to Bitsmith.)
 
@@ -207,4 +190,4 @@ Print a summary:
 - **Worktree removed:** `<worktree-path>`
 - **Branch deleted:** `<branch>` (or "skipped — detached HEAD" or "skipped — see warning above" if Step 8 was skipped or failed)
 - **Current branch:** main (up to date)
-- **Plan files cleaned:** `<list of deleted plan files grouped as "session: ..." and "other: ...", or "none deleted" if Step 10a was skipped or user declined>`
+- **Plan files cleaned:** `<list of deleted session plan files, or "none" if Step 10a was skipped>`


### PR DESCRIPTION
Step 10a of `/merged` previously prompted users before deleting plan files in every code path — including an interactive question about files belonging to other sessions. Users expect the command to know what to delete and act without asking.

This change removes all three prompt paths: current-session plan files (matching `{SESSION_TS}-*`) are now auto-deleted silently, and the step is skipped entirely with zero I/O when `SESSION_TS` is unavailable. Files from other sessions are never mentioned or touched.

`README.md` updated to reflect the new silent cleanup behavior.