### PR TITLE
feat(settings): allow cloudwatch mcp read-only tools in allowedTools

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -65,7 +65,18 @@
     "mcp__kubernetes__kubectl_logs",
     "mcp__kubernetes__explain_resource",
     "mcp__kubernetes__list_api_resources",
-    "mcp__kubernetes__ping"
+    "mcp__kubernetes__ping",
+    "mcp__cloudwatch__describe_log_groups",
+    "mcp__cloudwatch__analyze_log_group",
+    "mcp__cloudwatch__execute_log_insights_query",
+    "mcp__cloudwatch__get_logs_insight_query_results",
+    "mcp__cloudwatch__cancel_logs_insight_query",
+    "mcp__cloudwatch__get_active_alarms",
+    "mcp__cloudwatch__get_alarm_history",
+    "mcp__cloudwatch__get_metric_data",
+    "mcp__cloudwatch__get_metric_metadata",
+    "mcp__cloudwatch__analyze_metric",
+    "mcp__cloudwatch__get_recommended_metric_alarms"
   ],
   "hooks": {
     "PermissionRequest": [


### PR DESCRIPTION
Adds 11 CloudWatch MCP tool entries to the `allowedTools` array in `claude/settings.json`, covering log group discovery, Insights queries, metrics retrieval, and alarm inspection. This allows Claude Code sessions to use the CloudWatch MCP server's read-only surface without triggering manual approval prompts. No write-capable tools are included — the set is strictly observability and diagnostic operations.