### PR TITLE
ci: replace lockfile assertion with --frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.30.3
+          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Assert lockfile unchanged
-        run: git diff --exit-code pnpm-lock.yaml
+        run: pnpm install --frozen-lockfile
 
       - name: Type check
         run: pnpm exec tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-tpk",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@clack/prompts": "^0.9.0",
     "yaml": "^2.7.0"


### PR DESCRIPTION
Consolidates lockfile validation into the install step. pnpm install --frozen-lockfile fails immediately if the lockfile is out of sync with package.json, making the separate git diff --exit-code assertion step redundant. This is the idiomatic pnpm CI pattern and provides the same guarantee with less ceremony.