### PR TITLE
feat(mcp): add @google-cloud/observability-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Currently configured servers:
 - **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) — CloudWatch Metrics, Alarms, and Logs access via `~/.aws` credentials. Uses `wrappers/mcp-cloudwatch.sh` for dynamic AWS profile selection (set with `/set-aws-profile`). Requires `uvx`. Skips setup gracefully if `~/.aws/credentials` does not exist.
 - **Grafana MCP Server** (`mcp-grafana`) — Grafana dashboards, datasources, and incident access. Uses `wrappers/mcp-grafana.sh`, which requires `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` in the shell environment.
 - **GitHub MCP Server** (`@modelcontextprotocol/server-github`) — GitHub repository, issue, PR, and code search access. Requires `GITHUB_PERSONAL_ACCESS_TOKEN` set in `mcp-servers.json` before running `install.sh`. Note: the npm package was archived 2025-05-29; the Docker-based successor (`ghcr.io/github/github-mcp-server`) is not used here to avoid a Docker dependency.
+- **GCP Observability MCP Server** (`@google-cloud/observability-mcp@0.2.3`) — Read-only access to GCP Cloud Logging, Monitoring, Trace, and Error Reporting. Requires Node.js 20+ and the gcloud CLI. Authenticate before running `install.sh`: `gcloud auth application-default login` then `gcloud auth application-default set-quota-project YOUR_PROJECT_ID`.
 
 MCP servers are available in all repositories once configured. For detailed information about hooks, agents, and other configuration options, see [docs/CONFIGURATION.md](/docs/CONFIGURATION.md).
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -76,7 +76,19 @@
     "mcp__cloudwatch__get_metric_data",
     "mcp__cloudwatch__get_metric_metadata",
     "mcp__cloudwatch__analyze_metric",
-    "mcp__cloudwatch__get_recommended_metric_alarms"
+    "mcp__cloudwatch__get_recommended_metric_alarms",
+    "mcp__gcp-observability__list_log_entries",
+    "mcp__gcp-observability__list_log_names",
+    "mcp__gcp-observability__list_buckets",
+    "mcp__gcp-observability__list_views",
+    "mcp__gcp-observability__list_sinks",
+    "mcp__gcp-observability__list_log_scopes",
+    "mcp__gcp-observability__list_metric_descriptors",
+    "mcp__gcp-observability__list_time_series",
+    "mcp__gcp-observability__list_alert_policies",
+    "mcp__gcp-observability__list_traces",
+    "mcp__gcp-observability__get_trace",
+    "mcp__gcp-observability__list_group_stats"
   ],
   "hooks": {
     "PermissionRequest": [

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -32,6 +32,13 @@
       "command": "npx",
       "args": ["--yes", "@modelcontextprotocol/server-github"],
       "_note": "Package archived 2025-05-29. Successor: ghcr.io/github/github-mcp-server (requires Docker). Using npm package for zero-dependency install."
+    },
+    {
+      "name": "gcp-observability",
+      "scope": "user",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["--yes", "@google-cloud/observability-mcp@0.2.3"]
     }
   ]
 }


### PR DESCRIPTION
Adds the `@google-cloud/observability-mcp` server to the MCP configuration, enabling Claude to query GCP Cloud Logging, Cloud Monitoring, Cloud Trace, and Error Reporting directly. The server runs locally via `npx` with no Docker required, and authenticates using Application Default Credentials. Twelve `allowedTools` entries are added to `claude/settings.json` so the relevant tools are pre-approved without prompting.