### PR TITLE
chore(settings): allow write and edit to ~/.ai-tpk/**

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,7 @@
 {
   "allowedTools": [
+    "Write(~/.ai-tpk/**)",
+    "Edit(~/.ai-tpk/**)",
     "Bash(git *)",
     "Bash(gh pr *)",
     "Bash(gh issue *)",


### PR DESCRIPTION
Pre-approves `Write` and `Edit` tool calls for `~/.ai-tpk/**` in the user-scope `allowedTools` list. Subagents (e.g. Pathfinder, Everwise) write plan files, lessons, and session artifacts to this directory and previously prompted for permission on every invocation.