### PR TITLE
feat(commands): standardize dm completion report format per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Agent definitions can reference shared behavioral vocabulary defined in `claude/
 - **`claude/references/verdict-taxonomy.md`** — Shared verdict labels (REJECT, REVISE, ACCEPT-WITH-RESERVATIONS, ACCEPT) and severity scales. Agents load this reference when issuing verdicts to ensure consistent evaluation vocabulary.
 - **`claude/references/worktree-protocol.md`** — Shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. Agents load this reference when operating in isolated worktrees to ensure consistent path handling.
 - **`claude/references/dm-routing-examples.md`** — 11 worked routing examples for the Dungeon Master, covering multi-step plans, trivial changes, user flags, explore-options, worktrees, intake, investigation, scope confirmation, advisory queries, and ops reports. The DM loads this reference at runtime rather than embedding the examples inline in its system prompt.
+- **`claude/references/completion-templates.md`** — Four rigid per-command completion report templates (A: Constructive, B: Investigative, C: Operational PR, D: Post-Merge) and a shared Common Fields block. The DM output contract and `/open-pr`, `/merged`, `/merge-pr` commands all reference this file to ensure consistent, parseable completion output across sessions.
 
 When modifying these reference files, changes apply automatically to all agents that load them, eliminating the need to update redundant constraints across multiple agent definitions.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -527,14 +527,14 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     Quill must only be invoked after Phase 4 implementation review is fully complete and all reviewers have issued ACCEPT or ACCEPT-WITH-RESERVATIONS. If any Bitsmith implementation work is needed after Quill completes, that work must re-enter Phase 4 (Implementation Review) before the session can be declared complete — do not treat post-documentation Bitsmith invocations as pre-reviewed work.
 
     **5c — Completion summary:**
-    - confirm the requested outcome was actually achieved
-    - summarize completed work (plan, reviews, execution, validation)
-    - note any unfinished items or follow-ups
-    - Reservations logged: yes/no -- [file path or "N/A if no ACCEPT-WITH-RESERVATIONS verdicts"]
-    - if Quill was invoked in 5b, include a line noting that documentation was updated; otherwise note that documentation update was skipped (no planning session)
-    - Worktree status (path, branch, cleanup action taken, or 'skipped' if no worktree)
-    - Token usage: read the session's enriched chronicle file — glob `logs/talekeeper-*.jsonl` in the worktree root (or repo root if no worktree is active) and select the file most recently modified during this session. Sum `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` across all entries using `jq`. Report as: "Tokens: {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read" (divide raw counts by 1000, round to 1 decimal). If the chronicle file is not found, unreadable, or contains no token data, report "Token usage: unavailable".
-    - if notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
+    Format the completion summary using the appropriate template from `claude/references/completion-templates.md`: Template A (Constructive) for constructive sessions, Template B (Investigative) for investigative sessions.
+
+    To obtain the values for the template:
+    - **Token usage:** read the session's enriched chronicle file — glob `logs/talekeeper-*.jsonl` in the worktree root (or repo root if no worktree is active) and select the file most recently modified during this session. Sum `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` across all entries using `jq`. Report as: "{input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read" (divide raw counts by 1000, round to 1 decimal). If the chronicle file is not found, unreadable, or contains no token data, report "unavailable".
+    - **Reservations logged:** populate from Phase 5a — "yes — {file path}" if ACCEPT-WITH-RESERVATIONS was issued and the file was written; "no" otherwise.
+    - **Documentation:** "updated by Quill" if Quill was invoked in 5b; "skipped (no planning session)" otherwise.
+
+    If notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
 
     **5d — Worktree log:**
     Log: "Branch `{WORKTREE_BRANCH}` is ready at `{WORKTREE_PATH}`. Run `/open-pr` to create a pull request, or handle cleanup manually."
@@ -640,23 +640,16 @@ Write the advisory report to disk. This is a single file write — no code chang
 
 ## Output contract
 
-When responding back to the main thread, structure your result as:
+Completion reports must use the rigid per-command templates defined in `claude/references/completion-templates.md`. Each template is a verbatim format — reproduce the template exactly, substituting only `{placeholder}` values. Do not rearrange, rename, or omit fields unless the template explicitly marks a field as conditional.
 
-- Goal
-- Plan status (created, reviewed, approved/revised)
-- Plan review summary:
-  - Ruinor verdict (always included)
-  - Specialist reviews invoked (if any): Riskmancer / Windwarden / Knotcutter / Truthhammer verdicts
-  - Reason specialists were invoked (Ruinor recommendation, user flag, or keyword detection)
-- Execution status (tasks completed, artifacts changed)
-- Implementation review summary:
-  - Ruinor verdict (always included)
-  - Specialist reviews invoked (if any): Riskmancer / Windwarden / Knotcutter / Truthhammer verdicts
-- Final validation
-- Documentation: updated by Quill / skipped (no planning session)
-- Worktree: `{path}` on branch `{branch}` — {cleanup action taken} / skipped (no worktree)
-- Token usage: {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read (or "unavailable")
-- Risks / follow-ups
+Template assignments by pipeline:
+
+| Pipeline | Template |
+|----------|----------|
+| Constructive (`/feature` and similar) | Template A — Constructive |
+| Investigative (`/bug` and similar) | Template B — Investigative |
+| PR creation (`/open-pr`) | Template C — Operational PR |
+| Post-merge cleanup (`/merged`, `/merge-pr`) | Template D — Post-Merge |
 
 For advisory sessions (`INTENT: advisory`), use this simplified structure instead:
 

--- a/claude/commands/merge-pr.md
+++ b/claude/commands/merge-pr.md
@@ -127,6 +127,16 @@ its Step 0 shortcut (session-context path) instead of running the full discovery
 (Steps 1–5). If no worktree session context is available (e.g., bare branch checkout without
 a worktree), do not synthesize these values — let `/merged` run its normal discovery flow.
 
+**PR metadata propagation for Template D:** Before executing `/merged`, record the following
+values in session memory so that `/merged` can populate Template D's conditional fields:
+- `MERGED_PR_NUMBER` — the PR number from Step 4
+- `MERGED_PR_TITLE` — the PR title from Step 4
+- `MERGE_METHOD: squash`
+
+When `/merged` runs, it checks for `MERGED_PR_NUMBER` in session memory. If present, it
+includes the `PR` and `Merge method` lines in Template D using these values. If absent
+(standalone `/merged` run), those lines are omitted entirely.
+
 Execute `/merged`. The `/merged` command handles: worktree removal, local branch deletion,
 checkout of main, pull latest, and session plan file cleanup. No additional cleanup is needed
 in this command.

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -186,8 +186,12 @@ Store the list of deleted file names for use in Step 11's summary.
 
 ## Step 11 — Report final summary
 
-Print a summary:
-- **Worktree removed:** `<worktree-path>`
-- **Branch deleted:** `<branch>` (or "skipped — detached HEAD" or "skipped — see warning above" if Step 8 was skipped or failed)
+Format the summary using Template D (Post-Merge Cleanup) from `claude/references/completion-templates.md`.
+
+Populate the fields as follows:
+- **PR** and **Merge method:** Include these lines only when `MERGED_PR_NUMBER` is present in session context (i.e., `/merged` was chained from `/merge-pr`). Omit both lines when `/merged` is run standalone.
+- **Worktree removed:** `<worktree-path>`, or "N/A" if no worktree was found.
+- **Branch deleted:** `<branch>`, or "skipped (detached HEAD)" if Step 8 was skipped, or "skipped (see warning)" if Step 8 failed.
 - **Current branch:** main (up to date)
-- **Plan files cleaned:** `<list of deleted session plan files, or "none" if Step 10a was skipped>`
+- **Plan files cleaned:** the list of deleted file names from Step 10a, or "none" if Step 10a found no files, or "skipped (no SESSION_TS)" if Step 10a was skipped entirely.
+- **Token usage:** read the session's enriched chronicle file (glob `logs/talekeeper-*.jsonl` in the repo root, select most recently modified). Sum `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` using `jq`. Report as "{input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read". If unavailable, report "unavailable".

--- a/claude/commands/open-pr.md
+++ b/claude/commands/open-pr.md
@@ -6,3 +6,18 @@ First, invoke the `validate-before-pr` skill. Run its lint and format checks. On
 
 Follow the `open-pull-request` skill exactly — conventional branch naming, conventional PR title,
 draft mode, assigned to @me, pre-flight checklist. Do not use any shortcut or simplified workflow.
+
+## Completion Report
+
+On successful PR creation, format the completion summary using Template C (Operational PR) from `claude/references/completion-templates.md`.
+
+Populate the fields as follows:
+- **PR** number, title: from the `gh pr create` output.
+- **URL:** from the `gh pr create` output.
+- **Branch:** the current branch pointing to `main`.
+- **Status:** "draft" if the PR was opened in draft mode; "ready" if opened as ready for review.
+- **Checks:** report whether `validate-before-pr` passed or failed.
+- **Worktree** and **Token usage:** use the Common Fields format defined in `completion-templates.md`.
+- **Next action:** a contextual suggestion, e.g., "Run /merge-pr when CI passes."
+
+This section is reached only on success. If `validate-before-pr` fails or `gh pr create` fails, the existing error-reporting behavior applies — no completion report is produced.

--- a/claude/references/completion-templates.md
+++ b/claude/references/completion-templates.md
@@ -1,0 +1,117 @@
+# Completion Report Templates
+
+These templates are referenced by `dungeonmaster.md` and command files. Each template is a verbatim markdown block — the DM must reproduce the template exactly, substituting only the `{placeholder}` values. Do not rearrange fields, rename labels, or omit lines (unless the template marks a line as conditional with "only when" or "omit if").
+
+---
+
+## Common Fields
+
+These three fields appear at the end of Templates A, B, and C. Reproduce them verbatim, substituting placeholder values.
+
+```
+**Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
+**Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
+**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+```
+
+**Note on Template D:** Templates A–C reuse the Common Fields block verbatim. Template D uses a specialized subset (Token usage only) due to its post-cleanup context where the Worktree has already been removed and Next action is not applicable. The Worktree field is replaced by the more specific "Worktree removed" field in Template D.
+
+---
+
+## Template A — Constructive (`/feature`)
+
+Used for constructive pipeline sessions (e.g., sessions driven by `/feature`).
+
+```
+## Completion Report — Constructive
+
+**Goal:** {one-sentence goal}
+
+**Plan:** {plan file path} — {created | revised (N rounds)}
+**Plan review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"} | Trigger: {Ruinor recommendation | user flag | keyword detection | N/A}
+**Execution:** {N}/{M} steps completed | Files changed: {count}
+**Validation:** {outcome — e.g., "all plan steps completed and passed Ruinor review" | "N steps skipped — see Risks"}
+**Implementation review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"}
+**Reservations logged:** {yes — file path | no}
+**Documentation:** {updated by Quill | skipped (no planning session)}
+
+**Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
+**Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
+**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+
+**Risks / follow-ups:**
+- {item, or "None identified"}
+```
+
+---
+
+## Template B — Investigative (`/bug`)
+
+Used for investigative pipeline sessions (e.g., sessions driven by `/bug`). Extends Template A with investigation fields at the top. The `Plan`, `Plan review`, and related fields support "skipped (trivial fix)" variants when Tracebloom routes directly to Bitsmith.
+
+```
+## Completion Report — Investigative
+
+**Symptom:** {user-reported symptom, one sentence}
+**Investigation:** Tracebloom — {root cause summary, one sentence} | Verdict: {route to Pathfinder | trivial fix | inconclusive | no bug found}
+
+**Goal:** {one-sentence goal, derived from investigation}
+
+**Plan:** {plan file path} — {created | revised (N rounds)} | skipped (trivial fix)
+**Plan review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"} | skipped (trivial fix)
+**Execution:** {N}/{M} steps completed | Files changed: {count}
+**Validation:** {outcome — e.g., "all plan steps completed and passed Ruinor review" | "N steps skipped — see Risks"}
+**Implementation review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"}
+**Reservations logged:** {yes — file path | no}
+**Documentation:** {updated by Quill | skipped (no planning session)}
+
+**Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
+**Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
+**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+
+**Risks / follow-ups:**
+- {item, or "None identified"}
+```
+
+---
+
+## Template C — Operational PR (`/open-pr`)
+
+Used after a pull request is successfully created by `/open-pr`.
+
+```
+## Completion Report — PR Opened
+
+**PR:** #{number} — {title}
+**URL:** {PR URL}
+**Branch:** `{branch}` -> `main`
+**Status:** draft | ready
+**Checks:** validate-before-pr {passed | failed}
+
+**Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
+**Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
+**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+```
+
+---
+
+## Template D — Post-Merge (`/merged`, `/merge-pr`)
+
+Used after post-merge cleanup by `/merged` (whether standalone or chained from `/merge-pr`).
+
+This template does not use the Common Fields block. The "Worktree" field is replaced by the more specific "Worktree removed" field, and "Next action" does not apply after a merge cleanup.
+
+The `PR` and `Merge method` lines are conditional: include them only when `MERGED_PR_NUMBER` is present in session context (i.e., `/merged` was chained from `/merge-pr`). Omit both lines when `/merged` is run standalone.
+
+```
+## Completion Report — Post-Merge Cleanup
+
+**PR:** #{MERGED_PR_NUMBER} — {MERGED_PR_TITLE}  ← only when MERGED_PR_NUMBER is present in session context; omit if standalone /merged
+**Merge method:** squash  ← only when MERGED_PR_NUMBER is present in session context; omit if standalone /merged
+**Worktree removed:** `{worktree-path}` | N/A
+**Branch deleted:** `{branch}` | skipped (detached HEAD) | skipped (see warning)
+**Current branch:** main (up to date)
+**Plan files cleaned:** {list of deleted files} | none | skipped (no SESSION_TS)
+
+**Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
+```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -211,6 +211,8 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`worktree-protocol.md`** — Shared rules for interpreting the `WORKING_DIRECTORY:` context block. Agents that operate in isolated git worktrees load this reference to ensure consistent path handling across all file operations and bash commands.
 
+- **`completion-templates.md`** — Four rigid per-command completion report templates and a shared Common Fields block. Defines what the DM must emit at the end of each pipeline: Template A (Constructive, `/feature`), Template B (Investigative, `/bug`), Template C (Operational PR, `/open-pr`), and Template D (Post-Merge, `/merged` and `/merge-pr`). The DM output contract references this file; templates are verbatim formats with no formatting discretion left to the model.
+
 When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
 
 ## Skills (`claude/skills/`)


### PR DESCRIPTION
## Summary

- Introduces `claude/references/completion-templates.md` with four per-command rigid templates (A–D) covering the `/feature`, `/bug`, `/open-pr`, and `/merged` pipelines
- Updates `claude/agents/dungeonmaster.md` so the DM output contract references the new templates instead of a loose bullet list
- Updates operational commands (`/open-pr`, `/merged`, `/merge-pr`) to reference their respective templates directly, with shared fields (Worktree, Token usage, Next action) using identical labels across all templates that include them

## Test plan

- [ ] Trigger a `/feature` flow end-to-end and confirm the DM completion report matches Template A exactly
- [ ] Trigger a `/bug` flow end-to-end and confirm the DM completion report matches Template B exactly
- [ ] Trigger a `/open-pr` flow and confirm the completion report matches Template C (Worktree, Token usage, Next action labels present)
- [ ] Trigger a `/merged` flow and confirm the completion report matches Template D (same shared field labels)
- [ ] Confirm `merge-pr` references its template correctly in the command file
- [ ] Verify `completion-templates.md` is installed correctly by `install.sh` (copied to `~/.claude/references/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)