### PR TITLE
feat(launcher): add GCP Observability project selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ MCP servers are available in all repositories once configured. For detailed info
 
 ### myclaude — Session Launcher
 
-The `myclaude` command is an interactive wizard that configures MCP environment variables and launches Claude with the Dungeon Master agent. Instead of manually exporting environment variables before each session, you run `myclaude` from your shell to select your desired MCPs and their configuration (Grafana cluster + role, AWS profile), then launch a pre-configured Claude session.
+The `myclaude` command is an interactive wizard that configures MCP environment variables and launches Claude with the Dungeon Master agent. Instead of manually exporting environment variables before each session, you run `myclaude` from your shell to select your desired MCPs and their configuration (Grafana cluster + role, AWS profile, GCP project), then launch a pre-configured Claude session.
 
 **Prerequisites:** Run `./install.sh` first to install the launcher to `~/bin/myclaude`.
 
@@ -162,8 +162,8 @@ myclaude
 
 The wizard will present a multi-step flow:
 
-1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana and/or CloudWatch)
-2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch)
+1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana, CloudWatch, and/or GCP Observability)
+2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch; GCP project ID for GCP Observability)
 3. **Launch** — Claude opens with `--agent dungeonmaster` and the correct environment variables set
 
 **Persistence:** Your last-used selections are saved to `~/.config/myclaude/config.json` and pre-fill the wizard on your next run. You can accept them with Enter or change them.
@@ -204,6 +204,19 @@ The launcher reads AWS profiles from `~/.aws/config` (preferred) or `~/.aws/cred
 
 **Note:** This is equivalent to running `/set-aws-profile` in Claude — the launcher and the slash command write to the same dotfile, so they stay in sync.
 
+#### GCP Observability Configuration
+
+Before using GCP Observability, authenticate with Application Default Credentials (ADC):
+
+```bash
+gcloud auth application-default login
+gcloud auth application-default set-quota-project YOUR_PROJECT_ID
+```
+
+When "GCP Observability" is selected, the launcher checks for valid ADC credentials at startup (checking `GOOGLE_APPLICATION_CREDENTIALS` first, then `~/.config/gcloud/application_default_credentials.json`), then prompts for a GCP project ID. The project ID is validated (6-30 chars, lowercase letters/digits/hyphens, starts with a letter, no trailing hyphen, no consecutive hyphens) and stored in `~/.claude/.current-gcp-project` for the MCP wrapper. The previous project is offered as the default on the next run.
+
+**Note:** `GOOGLE_CLOUD_PROJECT` is used by the auth library for project ID resolution only — it does not auto-populate tool call parameters. Specify `resourceNames`, `parent`, `name`, or `projectId` explicitly in each tool call. The wrapper prints the active project to stderr as a context hint for Claude.
+
 #### Environment Variables Set by myclaude
 
 When you select Grafana with Viewer role, the launcher sets:
@@ -222,6 +235,11 @@ GRAFANA_SERVICE_ACCOUNT_TOKEN={editor_token}
 When you select CloudWatch:
 ```
 AWS_PROFILE={profile}
+```
+
+When you select GCP Observability:
+```
+GOOGLE_CLOUD_PROJECT={project_id}
 ```
 
 These variables are passed to `claude --agent dungeonmaster`, and they flow through to all MCP server subprocesses.

--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -37,8 +37,8 @@
       "name": "gcp-observability",
       "scope": "user",
       "transport": "stdio",
-      "command": "npx",
-      "args": ["--yes", "@google-cloud/observability-mcp@0.2.3"]
+      "prereq": "$HOME/.config/gcloud/application_default_credentials.json",
+      "wrapper": "wrappers/mcp-gcp-observability.sh"
     }
   ]
 }

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -58,6 +58,7 @@ The launcher constructs environment variables based on user selections:
 - **Grafana Viewer:** Sets `GRAFANA_DISABLE_WRITE=true`, which `src/wrappers/mcp-grafana.sh` translates to `--disable-write` for the Grafana MCP server.
 - **Grafana Editor:** Does not set `GRAFANA_DISABLE_WRITE` (read-write mode).
 - **CloudWatch:** Writes the selected AWS profile to `~/.claude/.current-aws-profile` (shared with the CloudWatch MCP wrapper).
+- **GCP Observability:** Sets `GOOGLE_CLOUD_PROJECT` in the environment for `google-auth-library` project ID resolution, and writes the project ID to `~/.claude/.current-gcp-project` (shared with `src/wrappers/mcp-gcp-observability.sh`). Note: `GOOGLE_CLOUD_PROJECT` is read by the auth library's `getProjectId()` but does **not** auto-populate tool call parameters — users still need to specify `resourceNames`, `parent`, `name`, or `projectId` in each tool call.
 
 ## Persistence Format
 
@@ -69,6 +70,7 @@ The wizard orchestration lives in `main.ts`. Type definitions are in `types.ts`.
 
 - `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
 - `mcp/cloudwatch.ts` — AWS profile parsing and profile selection
+- `mcp/gcp-observability.ts` — ADC credential check, project ID validation, and project prompt
 
 Shared utilities (cancellation, prompts) are in `utils.ts` and `prompts.ts`. The `env.ts` module builds environment variables; `config.ts` handles persistence; `launch.ts` executes the final Claude command.
 
@@ -80,7 +82,52 @@ Installation is handled by `src/installer/launcher-install.ts`. The process is i
 
 Users with the legacy `~/bin/grafana-mcp` script can continue using it or switch to `myclaude`. The two are independent; there is no automatic migration.
 
+## GCP Observability Configuration
+
+### Prerequisites
+
+Authenticate with Application Default Credentials (ADC) before running the launcher:
+
+```bash
+gcloud auth application-default login
+gcloud auth application-default set-quota-project YOUR_PROJECT_ID
+```
+
+The launcher checks for ADC at startup in this order:
+
+1. `GOOGLE_APPLICATION_CREDENTIALS` env var (if set and the file exists, the check passes)
+2. `~/.config/gcloud/application_default_credentials.json` (the default ADC path)
+
+If neither source provides a valid credential file, the launcher exits with a descriptive error before prompting for a project ID.
+
+### Project ID prompt
+
+When "GCP Observability" is selected in the MCP multiselect, the launcher prompts for a GCP project ID. The previous project is offered as the default. The ID is validated before being accepted:
+
+- 6–30 characters
+- Lowercase letters, digits, and hyphens only
+- Must start with a lowercase letter
+- Must not end with a hyphen
+- Must not contain consecutive hyphens
+
+The validated project ID is written to `~/.claude/.current-gcp-project` (mode 0600) and persisted to `~/.config/myclaude/config.json` for use as the default on the next run. `GOOGLE_CLOUD_PROJECT` is also set in the child process environment for `google-auth-library` project resolution.
+
+### What GOOGLE_CLOUD_PROJECT does and does not do
+
+`GOOGLE_CLOUD_PROJECT` tells `google-auth-library`'s `getProjectId()` which project to use for quota and billing. It does **not** auto-populate tool call parameters such as `resourceNames`, `parent`, `name`, or `projectId`. Claude (and users) must still include the project reference explicitly in each tool call. The wrapper prints `GCP Observability MCP: project '<id>'` to stderr at startup as a context hint.
+
+### Wrapper behavior
+
+`src/wrappers/mcp-gcp-observability.sh` resolves the active project at MCP startup:
+
+1. Reads `~/.claude/.current-gcp-project` (dotfile takes priority over any env var already set)
+2. Validates the project ID against the same rules as the launcher
+3. Exports `GOOGLE_CLOUD_PROJECT` and launches `@google-cloud/observability-mcp@0.2.3` via `npx`
+
+If the dotfile is absent or empty, and no project was set another way, the wrapper exits with a helpful error pointing the user back to the `myclaude` launcher.
+
 ## See Also
 
 - **`src/wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
+- **`src/wrappers/mcp-gcp-observability.sh`** — Bash wrapper that resolves the GCP project from the dotfile and launches the Observability MCP server
 - **`src/installer/launcher-install.ts`** — Installation logic for the launcher

--- a/src/launcher/env.test.ts
+++ b/src/launcher/env.test.ts
@@ -17,12 +17,17 @@ import type { ResolvedConfig, GrafanaCluster } from "./types.js";
 
 const dotfileDir = path.join(os.homedir(), ".claude");
 const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
+const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
 
 let priorDotfileContent: string | null = null;
+let priorGcpDotfileContent: string | null = null;
 
 before(() => {
   if (fs.existsSync(dotfilePath)) {
     priorDotfileContent = fs.readFileSync(dotfilePath, "utf8");
+  }
+  if (fs.existsSync(gcpDotfilePath)) {
+    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, "utf8");
   }
 });
 
@@ -35,6 +40,16 @@ after(() => {
     });
   } else if (fs.existsSync(dotfilePath)) {
     fs.rmSync(dotfilePath);
+  }
+
+  if (priorGcpDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(gcpDotfilePath, priorGcpDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(gcpDotfilePath)) {
+    fs.rmSync(gcpDotfilePath);
   }
 });
 
@@ -115,5 +130,37 @@ describe("buildEnvVars", () => {
     const config: ResolvedConfig = {};
     const env = buildEnvVars(config);
     assert.deepStrictEqual(env, {});
+  });
+
+  it("GCP Observability only: returns GOOGLE_CLOUD_PROJECT", () => {
+    const config: ResolvedConfig = {
+      gcpObservability: { project: "my-gcp-project" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "AWS_PROFILE"),
+      "AWS_PROFILE must not be present when no CloudWatch config",
+    );
+  });
+
+  it("GCP Observability + CloudWatch combined: both keys present", () => {
+    const config: ResolvedConfig = {
+      cloudwatch: { profile: "prod" },
+      gcpObservability: { project: "my-gcp-project" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["AWS_PROFILE"], "prod");
+    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+  });
+
+  it("GCP Observability + Grafana combined: all keys merged", () => {
+    const config: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "viewer" },
+      gcpObservability: { project: "my-gcp-project" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
   });
 });

--- a/src/launcher/env.ts
+++ b/src/launcher/env.ts
@@ -39,5 +39,28 @@ export function buildEnvVars(config: ResolvedConfig): Record<string, string> {
     });
   }
 
+  if (config.gcpObservability) {
+    const project = config.gcpObservability.project;
+    envVars["GOOGLE_CLOUD_PROJECT"] = project;
+
+    // mcp-gcp-observability.sh reads ~/.claude/.current-gcp-project and overrides GOOGLE_CLOUD_PROJECT.
+    // Write the dotfile so both paths agree.
+    // Note: GOOGLE_CLOUD_PROJECT is used by google-auth-library's getProjectId() for project ID resolution.
+    // getProjectId() checks the GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT env var group (GCLOUD_PROJECT first,
+    // then GOOGLE_CLOUD_PROJECT), before credential files or the metadata server.
+    // It does NOT auto-populate tool call parameters.
+    const gcpDotfile = path.join(
+      os.homedir(),
+      ".claude",
+      ".current-gcp-project",
+    );
+    const gcpDotfileDir = path.dirname(gcpDotfile);
+    fs.mkdirSync(gcpDotfileDir, { recursive: true });
+    fs.writeFileSync(gcpDotfile, project + "\n", {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  }
+
   return envVars;
 }

--- a/src/launcher/gcp-observability.test.ts
+++ b/src/launcher/gcp-observability.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  validateGcpProjectId,
+  checkAdcCredentials,
+} from "./mcp/gcp-observability.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), "ai-tpk-gcp-observability-test-"),
+);
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write a file to the temp dir and return its path
+// ---------------------------------------------------------------------------
+
+function writeTempFile(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// validateGcpProjectId
+// ---------------------------------------------------------------------------
+
+describe("validateGcpProjectId", () => {
+  describe("valid inputs", () => {
+    it('accepts "my-project-123"', () => {
+      assert.ok(validateGcpProjectId("my-project-123"));
+    });
+
+    it('accepts "a12345" (6 chars, minimum length)', () => {
+      assert.ok(validateGcpProjectId("a12345"));
+    });
+
+    it('accepts "abcdef-ghijkl-mnopqr-stuvwx-yz" (30 chars, maximum length)', () => {
+      assert.ok(validateGcpProjectId("abcdef-ghijkl-mnopqr-stuvwx-yz"));
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it('rejects "short" (5 chars, below minimum)', () => {
+      assert.ok(!validateGcpProjectId("short"));
+    });
+
+    it('rejects "My-Project" (uppercase letters)', () => {
+      assert.ok(!validateGcpProjectId("My-Project"));
+    });
+
+    it('rejects "1-starts-with-digit" (must start with a letter)', () => {
+      assert.ok(!validateGcpProjectId("1-starts-with-digit"));
+    });
+
+    it('rejects "ends-with-hyphen-" (must not end with a hyphen)', () => {
+      assert.ok(!validateGcpProjectId("ends-with-hyphen-"));
+    });
+
+    it('rejects "has spaces" (spaces not allowed)', () => {
+      assert.ok(!validateGcpProjectId("has spaces"));
+    });
+
+    it('rejects "has_underscores" (underscores not allowed)', () => {
+      assert.ok(!validateGcpProjectId("has_underscores"));
+    });
+
+    it('rejects "" (empty string)', () => {
+      assert.ok(!validateGcpProjectId(""));
+    });
+
+    it("rejects a 31-character string (above maximum length)", () => {
+      assert.ok(!validateGcpProjectId("a".repeat(31)));
+    });
+
+    it('rejects "a--bcdef" (consecutive hyphens)', () => {
+      assert.ok(!validateGcpProjectId("a--bcdef"));
+    });
+
+    it('rejects "abc--def-ghijk" (consecutive hyphens in middle of valid-length string)', () => {
+      assert.ok(!validateGcpProjectId("abc--def-ghijk"));
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAdcCredentials
+// ---------------------------------------------------------------------------
+
+describe("checkAdcCredentials", () => {
+  // Save and restore GOOGLE_APPLICATION_CREDENTIALS for env var isolation
+  let savedEnvCredPath: string | undefined;
+
+  before(() => {
+    savedEnvCredPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  });
+
+  after(() => {
+    if (savedEnvCredPath !== undefined) {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = savedEnvCredPath;
+    } else {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    }
+  });
+
+  it("throws when neither GOOGLE_APPLICATION_CREDENTIALS is set nor default ADC path exists", () => {
+    const missingPath = path.join(tmpDir, "does-not-exist.json");
+    assert.throws(
+      () => checkAdcCredentials(missingPath),
+      (err: unknown) => err instanceof Error,
+    );
+  });
+
+  it("does not throw when default ADC file exists (via adcPath param)", () => {
+    const adcFile = writeTempFile(
+      "adc-credentials.json",
+      '{"type":"authorized_user"}',
+    );
+    assert.doesNotThrow(() => checkAdcCredentials(adcFile));
+  });
+
+  it("does not throw when GOOGLE_APPLICATION_CREDENTIALS points to an existing file (even if default ADC path is missing)", () => {
+    const credFile = writeTempFile(
+      "env-credentials.json",
+      '{"type":"service_account"}',
+    );
+    const missingAdcPath = path.join(tmpDir, "missing-adc.json");
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = credFile;
+    try {
+      assert.doesNotThrow(() => checkAdcCredentials(missingAdcPath));
+    } finally {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    }
+  });
+
+  it("throws when GOOGLE_APPLICATION_CREDENTIALS points to non-existent file AND default ADC path is missing", () => {
+    const missingEnvPath = path.join(tmpDir, "missing-env-cred.json");
+    const missingAdcPath = path.join(tmpDir, "missing-adc-2.json");
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = missingEnvPath;
+    try {
+      assert.throws(
+        () => checkAdcCredentials(missingAdcPath),
+        (err: unknown) => err instanceof Error,
+      );
+    } finally {
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    }
+  });
+
+  it("error message includes GOOGLE_APPLICATION_CREDENTIALS and gcloud auth application-default login", () => {
+    const missingPath = path.join(tmpDir, "missing-for-message-test.json");
+    let caughtError: Error | null = null;
+    try {
+      checkAdcCredentials(missingPath);
+    } catch (err) {
+      if (err instanceof Error) {
+        caughtError = err;
+      }
+    }
+    assert.ok(caughtError !== null, "Expected an error to be thrown");
+    assert.ok(
+      caughtError!.message.includes("GOOGLE_APPLICATION_CREDENTIALS"),
+      "Error message must mention GOOGLE_APPLICATION_CREDENTIALS",
+    );
+    assert.ok(
+      caughtError!.message.includes("gcloud auth application-default login"),
+      "Error message must mention gcloud auth application-default login",
+    );
+  });
+});

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -2,6 +2,10 @@ import { intro, outro, log } from "@clack/prompts";
 import { loadConfig, saveConfig } from "./config.js";
 import { loadGrafanaClusters, configureGrafana } from "./mcp/grafana.js";
 import { loadAwsProfiles, configureCloudWatch } from "./mcp/cloudwatch.js";
+import {
+  checkAdcCredentials,
+  configureGcpObservability,
+} from "./mcp/gcp-observability.js";
 import { selectMcps } from "./prompts.js";
 import { buildEnvVars } from "./env.js";
 import { launchClaude } from "./launch.js";
@@ -66,6 +70,25 @@ async function main(): Promise<void> {
     };
   }
 
+  // GCP Observability configuration
+  if (selectedMcps.includes("gcp-observability")) {
+    try {
+      checkAdcCredentials();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const gcpConfig = await configureGcpObservability(
+      savedConfig.gcpObservability?.project,
+    );
+
+    resolved.gcpObservability = gcpConfig;
+    updatedConfig.gcpObservability = {
+      project: gcpConfig.project,
+    };
+  }
+
   // Persist updated selections
   saveConfig(updatedConfig);
 
@@ -79,6 +102,9 @@ async function main(): Promise<void> {
   }
   if (resolved.cloudwatch) {
     lines.push(`CloudWatch: ${resolved.cloudwatch.profile}`);
+  }
+  if (resolved.gcpObservability) {
+    lines.push(`GCP Observability: ${resolved.gcpObservability.project}`);
   }
   if (lines.length === 0) {
     lines.push("No MCPs configured — launching Claude with current env.");

--- a/src/launcher/mcp/gcp-observability.ts
+++ b/src/launcher/mcp/gcp-observability.ts
@@ -1,0 +1,76 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { text } from "@clack/prompts";
+import type { GcpObservabilityConfig } from "../types.js";
+import { handleCancel } from "../utils.js";
+
+const DEFAULT_ADC_PATH = path.join(
+  os.homedir(),
+  ".config",
+  "gcloud",
+  "application_default_credentials.json",
+);
+
+/**
+ * Validates a GCP project ID against Google Cloud naming rules:
+ * - 6-30 characters
+ * - Lowercase letters, digits, and hyphens only
+ * - Must start with a lowercase letter
+ * - Must not end with a hyphen
+ * - Must not contain consecutive hyphens (conservative safety measure --
+ *   not explicitly prohibited in GCP documentation, but likely rejected
+ *   by GCP's API in practice)
+ */
+export function validateGcpProjectId(projectId: string): boolean {
+  return /^[a-z](?!.*--)[a-z0-9-]{4,28}[a-z0-9]$/.test(projectId);
+}
+
+/**
+ * Checks that GCP Application Default Credentials (ADC) exist on disk.
+ *
+ * Resolution order:
+ * 1. If GOOGLE_APPLICATION_CREDENTIALS env var is set and the file exists, the check passes.
+ * 2. Otherwise, checks the default ADC path (~/.config/gcloud/application_default_credentials.json).
+ * 3. If neither source provides a valid file, throws a descriptive error.
+ */
+export function checkAdcCredentials(adcPath?: string): void {
+  // Check GOOGLE_APPLICATION_CREDENTIALS env var first
+  const envCredPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (envCredPath && fs.existsSync(envCredPath)) {
+    return;
+  }
+
+  const resolvedPath = adcPath ?? DEFAULT_ADC_PATH;
+  if (fs.existsSync(resolvedPath)) {
+    return;
+  }
+
+  throw new Error(
+    `GCP Application Default Credentials not found. Checked:\n` +
+      `  - GOOGLE_APPLICATION_CREDENTIALS env var${envCredPath ? ` (${envCredPath} — file not found)` : " (not set)"}\n` +
+      `  - ${resolvedPath}\n` +
+      `Set GOOGLE_APPLICATION_CREDENTIALS to a valid credential file, or run: gcloud auth application-default login`,
+  );
+}
+
+/**
+ * Prompts the user to enter a GCP project ID for the Observability MCP server.
+ */
+export async function configureGcpObservability(
+  previousProject?: string,
+): Promise<GcpObservabilityConfig> {
+  const projectValue = await text({
+    message: "Enter GCP project ID for Observability:",
+    defaultValue: previousProject,
+    placeholder: previousProject ?? "my-gcp-project-123",
+    validate(value) {
+      if (!validateGcpProjectId(value)) {
+        return "Invalid GCP project ID. Must be 6-30 chars: lowercase letters, digits, hyphens. Must start with a letter, not end with a hyphen, and not contain consecutive hyphens.";
+      }
+    },
+  });
+  handleCancel(projectValue);
+
+  return { project: projectValue as string };
+}

--- a/src/launcher/prompts.ts
+++ b/src/launcher/prompts.ts
@@ -9,6 +9,11 @@ export async function selectMcps(
     options: [
       { value: "grafana", label: "Grafana", hint: "cluster + role" },
       { value: "cloudwatch", label: "CloudWatch", hint: "AWS profile" },
+      {
+        value: "gcp-observability",
+        label: "GCP Observability",
+        hint: "GCP project",
+      },
     ],
     initialValues: previousSelections,
     required: false,

--- a/src/launcher/types.ts
+++ b/src/launcher/types.ts
@@ -17,9 +17,14 @@ export interface CloudWatchConfig {
   profile: string;
 }
 
+export interface GcpObservabilityConfig {
+  project: string;
+}
+
 export interface ResolvedConfig {
   grafana?: GrafanaConfig;
   cloudwatch?: CloudWatchConfig;
+  gcpObservability?: GcpObservabilityConfig;
 }
 
 export interface LauncherConfig {
@@ -30,5 +35,8 @@ export interface LauncherConfig {
   };
   cloudwatch?: {
     profile: string;
+  };
+  gcpObservability?: {
+    project: string;
   };
 }

--- a/src/wrappers/mcp-gcp-observability.sh
+++ b/src/wrappers/mcp-gcp-observability.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve GCP project: dotfile takes priority over env var
+DOTFILE="$HOME/.claude/.current-gcp-project"
+if [[ -f "$DOTFILE" ]] && [[ -s "$DOTFILE" ]]; then
+  IFS= read -r GOOGLE_CLOUD_PROJECT < "$DOTFILE"
+  # Trim leading/trailing whitespace
+  GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT#"${GOOGLE_CLOUD_PROJECT%%[! $'\t']*}"}"
+  GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT%"${GOOGLE_CLOUD_PROJECT##*[! $'\t']}"}"
+fi
+
+# Validate project ID if set
+if [[ -n "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
+  if [[ ! "$GOOGLE_CLOUD_PROJECT" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]] || [[ "$GOOGLE_CLOUD_PROJECT" =~ -- ]]; then
+    printf 'Error: invalid GCP project ID "%s" -- must be 6-30 chars, lowercase letters/digits/hyphens, start with letter, not end with hyphen, no consecutive hyphens\n' "$GOOGLE_CLOUD_PROJECT" >&2
+    exit 1
+  fi
+  export GOOGLE_CLOUD_PROJECT
+  echo "GCP Observability MCP: project '$GOOGLE_CLOUD_PROJECT'" >&2
+  exec npx --yes @google-cloud/observability-mcp@0.2.3 "$@"
+fi
+
+# Neither dotfile nor env var provided a project -- fail helpfully
+printf 'Error: no GCP project set.\n' >&2
+printf 'Set one by running the myclaude launcher, or:\n' >&2
+printf '  echo "my-project-id" > ~/.claude/.current-gcp-project\n\n' >&2
+printf 'To find your project IDs, run: gcloud projects list\n' >&2
+exit 1


### PR DESCRIPTION
Adds a GCP project selection prompt to the myclaude launcher when the gcp-observability MCP is enabled, following the same wrapper pattern as CloudWatch.

The selected project is persisted across sessions, validated against GCP naming rules (6-30 chars, lowercase alphanumeric + hyphens), and written to ~/.claude/.current-gcp-project for the wrapper. GOOGLE_CLOUD_PROJECT is set for auth library project ID resolution; the wrapper also prints the active project to stderr as a context hint for Claude when constructing tool call arguments such as resourceNames or projectId.

ADC credentials are validated at startup, checking GOOGLE_APPLICATION_CREDENTIALS first and falling back to the default ADC path.