### PR TITLE
fix(hooks): auto-approve write/edit calls targeting ~/.ai-tpk/

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -29,6 +29,7 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 Check the workbench before every strike. This is a per-operation invariant — it fires before every Write, Edit, or file-modifying Bash command, not once at task start.
 
 1. **WORKING_DIRECTORY present, path matches** — the target path sits under `WORKING_DIRECTORY`. Proceed normally.
+1b. **WORKING_DIRECTORY present, path targets `~/.ai-tpk/`** — the target path is under `~/.ai-tpk/` (plans, lessons, open-questions, or pr-review-comments). These are user-scoped artifact directories that exist outside any worktree by design. Proceed normally — this is not a boundary violation. This exception applies regardless of the current `WORKING_DIRECTORY` value.
 2. **WORKING_DIRECTORY present, path does not match** — halt immediately. Do not write, edit, or execute the command. Surface a structured report to the Dungeon Master containing: (a) the `WORKING_DIRECTORY` value, (b) the offending path(s) Bitsmith was about to write to, (c) a request for DM to confirm or correct the target paths. Do not proceed until DM responds.
 3. **WORKING_DIRECTORY absent, write-bearing task** — before the first file modification, surface a single confirmation to the Dungeon Master: "No WORKING_DIRECTORY was specified in this delegation. Should I operate in the main working tree?" Do not proceed until confirmed. This fires once per task, not per operation.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -500,6 +500,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     - **If Pathfinder was invoked this session:** derive the open-questions filename from the plan file stem. For example, `~/.ai-tpk/plans/{REPO_SLUG}/20260401-143022-oauth-login.md` → `~/.ai-tpk/plans/{REPO_SLUG}/20260401-143022-oauth-login-open-questions.md`. No worktree prefix is needed — plan files are now at a fixed user-scoped path.
     - **If Pathfinder was NOT invoked this session:** use `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{SESSION_SLUG}-open-questions.md` (e.g., `~/.ai-tpk/plans/{REPO_SLUG}/20260401-143022-rename-env-var-open-questions.md`). No worktree prefix is needed.
 
+    **Delegation note:** When delegating this write to Bitsmith while a worktree is active, include in the delegation prompt: "The target path `~/.ai-tpk/plans/...` is a user-scoped artifact directory outside `WORKING_DIRECTORY`. This is an authorized exception to the Path Mismatch Guard per scenario 1b in Bitsmith's definition."
+
     Instruct Bitsmith to append the reservations under a section titled `## Review Reservations - [session date]` with the specific issues noted. If the target file does not exist, Bitsmith should create it first with the following header (substituting the plan name where applicable):
 
       ```

--- a/claude/hooks/permission-learn.sh
+++ b/claude/hooks/permission-learn.sh
@@ -19,6 +19,51 @@ fi
 TOOL_NAME=$(echo "$STDIN_DATA" | jq -r '.tool_name // ""' 2>/dev/null)
 COMMAND=$(echo "$STDIN_DATA" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
+# --- Write/Edit auto-approve: ~/.ai-tpk/ paths ---
+# Write and Edit tool calls carry a plain file_path string, not a shell command.
+# The Bash safety guards (dangerous keywords, git -c injection, etc.) do NOT apply here
+# because file_path is never executed as a shell command.
+# Symlink escapes are not a threat: Write/Edit cannot create symlinks — only
+# `bash ln -s` can, which requires its own separate permission approval.
+if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
+  FILE_PATH=$(echo "$STDIN_DATA" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
+  if [ -n "$FILE_PATH" ]; then
+    # Expand ~ and $HOME to the actual home directory value (no realpath — it fails
+    # on files that don't exist yet, and realpath -m is GNU-only, not available on macOS)
+    NORMALIZED=$(printf '%s' "$FILE_PATH" | sed "s|^\$HOME|$HOME|")
+    NORMALIZED=$(printf '%s' "$NORMALIZED" | sed "s|^~|$HOME|")
+
+    # Path traversal guard: check for .. as a path component (NOT a raw substring match
+    # to avoid false positives on filenames like "file..backup.md").
+    # Matches: /.., /../, ../, and lone ..  but NOT "file..backup"
+    if printf '%s' "$NORMALIZED" | grep -qE '(^|/)\.\.(\/|$)'; then
+      # Traversal detected — fall through to normal permission dialog
+      exit 0
+    fi
+
+    # Auto-approve if path targets ~/.ai-tpk/
+    if printf '%s' "$NORMALIZED" | grep -q "^$HOME/.ai-tpk/"; then
+      TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      LOG_FILE="$HOME/.claude/permission-requests.log"
+      AGENT_ID=$(echo "$STDIN_DATA" | jq -r '.agent_id // "none"' 2>/dev/null)
+      AGENT_TYPE=$(echo "$STDIN_DATA" | jq -r '.agent_type // "none"' 2>/dev/null)
+      printf '%s | agent_type=%s | agent_id=%s | [auto-approved] write_path=%s\n' \
+        "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$NORMALIZED" >> "$LOG_FILE"
+      jq -n '{
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "allow"
+          }
+        }
+      }'
+      exit 0
+    fi
+  fi
+  # FILE_PATH empty or path not matched — fall through to normal permission dialog
+  exit 0
+fi
+
 if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
   exit 0
 fi

--- a/claude/hooks/test-permission-learn.sh
+++ b/claude/hooks/test-permission-learn.sh
@@ -51,6 +51,13 @@ make_payload() {
   jq -cn --arg cmd "$command" '{tool_name:"Bash",tool_input:{command:$cmd},agent_id:"test-agent",agent_type:"subagent"}'
 }
 
+# Helper: build a JSON payload for a Write or Edit tool call.
+make_write_payload() {
+  local tool_name="$1"
+  local file_path="$2"
+  jq -cn --arg tn "$tool_name" --arg fp "$file_path" '{tool_name:$tn,tool_input:{file_path:$fp},agent_id:"test-agent",agent_type:"subagent"}'
+}
+
 printf '%s\n\n' '=== permission-learn.sh test harness ==='
 
 # --- AUTO-APPROVE cases ---
@@ -184,6 +191,52 @@ test_case \
   "TC-23: git log --source BRANCH — source flag should not trigger keyword guard" \
   "$(make_payload 'git log --source $BRANCH')" \
   "allow"
+
+# --- Write/Edit AUTO-APPROVE cases ---
+printf '\n%s\n' '-- Write/Edit AUTO-APPROVE cases --'
+
+test_case \
+  "TC-W01: Write to ~/.ai-tpk/plans/repo/plan.md — should auto-approve" \
+  "$(make_write_payload 'Write' "~/.ai-tpk/plans/repo/plan.md")" \
+  "allow"
+
+test_case \
+  "TC-W02: Edit to ~/.ai-tpk/lessons/candidates.jsonl — should auto-approve" \
+  "$(make_write_payload 'Edit' "~/.ai-tpk/lessons/candidates.jsonl")" \
+  "allow"
+
+test_case \
+  "TC-W03: Write with \$HOME expansion to ~/.ai-tpk/plans/repo/plan.md — should auto-approve" \
+  "$(make_write_payload 'Write' "\$HOME/.ai-tpk/plans/repo/plan.md")" \
+  "allow"
+
+test_case \
+  "TC-W04: Write with already-expanded absolute path to ~/.ai-tpk/ — should auto-approve" \
+  "$(make_write_payload 'Write' "$HOME/.ai-tpk/plans/repo/plan.md")" \
+  "allow"
+
+# --- Write/Edit FALLTHROUGH cases ---
+printf '\n%s\n' '-- Write/Edit FALLTHROUGH cases --'
+
+test_case \
+  "TC-W05: Write to /tmp/evil.txt — should NOT auto-approve (fallthrough)" \
+  "$(make_write_payload 'Write' '/tmp/evil.txt')" \
+  "fallthrough"
+
+test_case \
+  "TC-W06: Write with path traversal ~/.ai-tpk/../../etc/passwd — should NOT auto-approve (fallthrough)" \
+  "$(make_write_payload 'Write' '~/.ai-tpk/../../etc/passwd')" \
+  "fallthrough"
+
+test_case \
+  "TC-W07: Edit to ~/.claude/settings.json — should NOT auto-approve (fallthrough)" \
+  "$(make_write_payload 'Edit' '~/.claude/settings.json')" \
+  "fallthrough"
+
+test_case \
+  "TC-W08: Write with empty file_path — should NOT auto-approve (fallthrough)" \
+  "$(make_write_payload 'Write' '')" \
+  "fallthrough"
 
 # --- Summary ---
 printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,20 +17,23 @@ Pre-configured marketplaces for plugin discovery:
 
 Hooks allow you to run automated checks or tasks at specific points in your Claude workflow.
 
-#### PermissionRequest Hook - Bash Style Enforcement and Request Logging
+#### PermissionRequest Hook - Bash Style Enforcement, Write/Edit Auto-Approve, and Request Logging
 
-Runs when a Bash command falls outside the `allowedTools` list and requires permission.
+Runs when a tool call falls outside the `allowedTools` list and requires permission. Handles both Bash commands and Write/Edit tool calls.
 
 **Behavior:**
 1. Reads the permission request event from stdin
-2. Extracts the Bash command and strips quoted strings to avoid false positives
-3. Detects compound operators (`&&`, `;`, embedded newlines) and process substitution (`<(`, `>(`) — denies if found
-4. Detects `--no-verify` (and `-n` for `git commit`) on `git commit` and `git push` commands — denies if found
-5. For commands that pass the deny checks: neutralizes simple variable expansions (`$VAR`, `${VAR}`, `~`) and checks if the result matches an `allowedTools` Bash pattern. If it matches, runs five safety guards; auto-approves if all pass
-6. For commands that do not match any allowedTools pattern, or that fail a safety guard: appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
-7. Fails open (no output, exit 0) if `jq` is unavailable
+2. For `Write` and `Edit` tool calls: extracts the `file_path`, normalizes `~` and `$HOME` to the actual home directory, checks for path traversal (`..` as a path component), and auto-approves if the path targets `~/.ai-tpk/`. Falls through to the normal permission dialog for all other paths.
+3. Extracts the Bash command and strips quoted strings to avoid false positives
+4. Detects compound operators (`&&`, `;`, embedded newlines) and process substitution (`<(`, `>(`) — denies if found
+5. Detects `--no-verify` (and `-n` for `git commit`) on `git commit` and `git push` commands — denies if found
+6. For commands that pass the deny checks: neutralizes simple variable expansions (`$VAR`, `${VAR}`, `~`) and checks if the result matches an `allowedTools` Bash pattern. If it matches, runs five safety guards; auto-approves if all pass
+7. For commands that do not match any allowedTools pattern, or that fail a safety guard: appends a log entry to `~/.claude/permission-requests.log` and exits without output, leaving the normal permission dialog in place
+8. Fails open (no output, exit 0) if `jq` is unavailable
 
-**Why auto-approve?** Claude Code classifies commands containing `$VAR`, `${VAR}`, or `~` as "too-complex" and bypasses `allowedTools` pattern matching in `settings.json`, triggering a permission dialog even when the base command (e.g., `git log`, `mkdir`) is already trusted. The hook closes that gap by performing its own pattern match after neutralizing the expansions.
+**Why auto-approve?** Two distinct gaps are closed by this hook:
+- **Bash with variable expansions:** Claude Code classifies commands containing `$VAR`, `${VAR}`, or `~` as "too-complex" and bypasses `allowedTools` pattern matching in `settings.json`, triggering a permission dialog even when the base command (e.g., `git log`, `mkdir`) is already trusted. The hook closes that gap by performing its own pattern match after neutralizing the expansions.
+- **Write/Edit to `~/.ai-tpk/`:** Claude Code's internal permission matcher does not reliably expand `~` before comparing the requested path against the `Write(~/.ai-tpk/**)` / `Edit(~/.ai-tpk/**)` patterns in `settings.json`, triggering a permission dialog on every write to plan, lesson, and open-questions files. The hook closes that gap by performing its own path normalization and matching at runtime.
 
 **Safety guards (auto-approve path only):**
 
@@ -56,9 +59,10 @@ All guards operate on single-quote-stripped input so that dangerous constructs i
 ```
 2026-04-09T14:27:44Z | agent_type=Bitsmith | agent_id=abc123 | [auto-approved] command=git log --format=$FORMAT
 2026-04-09T14:27:50Z | agent_type=Bitsmith | agent_id=abc123 | command=docker ps
+2026-04-09T14:27:55Z | agent_type=Bitsmith | agent_id=abc123 | [auto-approved] write_path=/home/alice/.ai-tpk/plans/repo/plan.md
 ```
 
-Auto-approved entries include the `[auto-approved]` marker; commands falling through to the permission dialog have no marker.
+Auto-approved entries include the `[auto-approved]` marker; commands and file writes falling through to the permission dialog have no marker. Write/Edit auto-approvals use `write_path=` instead of `command=`.
 
 **Examples:**
 - Denied: `git status && git diff` (contains `&&` — agent is told to split into separate calls)
@@ -71,6 +75,8 @@ Auto-approved entries include the `[auto-approved]` marker; commands falling thr
 - Auto-approved: `mkdir -p $HOME/.config` (matches `mkdir *`)
 - Auto-approved: `ls ~/projects` (matches `ls *`, tilde is a simple expansion)
 - Auto-approved: `gh pr list --repo $REPO` (matches `gh pr *`)
+- Auto-approved: `Write to ~/.ai-tpk/plans/repo/plan.md` (matches user-scoped artifact path; `~` expanded at runtime)
+- Auto-approved: `Edit to $HOME/.ai-tpk/lessons/candidates.jsonl` (matches user-scoped artifact path; `$HOME` expanded at runtime)
 - Logged + normal dialog: `docker ps` (single command not in allowedTools)
 - Logged + normal dialog: `grep "a && b" file.txt` (compound operator inside a quoted string — no false positive on deny; no allowedTools pattern match — falls through)
 - Logged + normal dialog: `gh extension install $PKG` (no matching allowedTools pattern for `gh extension`)
@@ -78,6 +84,7 @@ Auto-approved entries include the `[auto-approved]` marker; commands falling thr
 - Logged + normal dialog: `git -c core.editor="vi" diff` (safety guard: `git -c` config injection)
 - Logged + normal dialog: `python3 -c "code"` (safety guard: `python3 -c`)
 - Logged + normal dialog: `sudo rm -rf $DIR` (safety guard: dangerous keyword `sudo`)
+- Logged + normal dialog: `Write to /tmp/output.txt` (path not in allowed set — falls through to normal dialog)
 - Allowed: `echo -n hello`, `git log -n 5` (context-aware: `-n` only blocked in `git commit` context)
 
 #### SessionStart Hook - Terminal Tab Title Restore


### PR DESCRIPTION
## Problem

The `allowedTools` tilde patterns in `settings.json` (e.g., `Write(~/.ai-tpk/**)`) do not reliably match when Claude Code resolves the target path to its absolute form before evaluating permissions. This causes Write and Edit calls that target `~/.ai-tpk/` to trigger the interactive permission prompt even when they should be unconditionally allowed.

## Solution

Extend `permission-learn.sh` to intercept Write and Edit tool calls at the hook level. The hook now:

1. Detects `Write` or `Edit` tool calls by inspecting `tool_name` in the hook input.
2. Extracts the target file path from `tool_input.file_path`.
3. Normalizes `~` and `$HOME` prefixes to the resolved absolute home directory at runtime.
4. Auto-approves (exits 0 with `{"decision":"approve"}`) any path that falls under `~/.ai-tpk/`.

This approach is immune to the tilde-resolution inconsistency because the normalization happens in the hook itself, after Claude Code has already decided to invoke the hook.

## Changes

| File | Change |
|------|--------|
| `claude/hooks/permission-learn.sh` | Write/Edit auto-approve logic for `~/.ai-tpk/` paths |
| `claude/hooks/test-permission-learn.sh` | 8 new test cases (TC-W01–TC-W08) covering the new logic |
| `claude/agents/bitsmith.md` | Scenario 1b added to Path Mismatch Guard: worktree writes to `~/.ai-tpk/` are now recognized as valid and not blocked |
| `claude/agents/dungeonmaster.md` | Delegation note in Phase 5a clarifying that `~/.ai-tpk/` writes are handled at hook level |
| `docs/CONFIGURATION.md` | Documentation updated to describe Write/Edit hook behavior |

## Test plan

- [ ] Run `claude/hooks/test-permission-learn.sh` — all tests including TC-W01 through TC-W08 must pass
- [ ] Install the updated hook via `install.sh` and verify a Write call to `~/.ai-tpk/plans/` is auto-approved without an interactive prompt
- [ ] Verify a Write call to a path outside `~/.ai-tpk/` still goes through normal permission flow
- [ ] Confirm `npm run lint` and `npm run format:check` pass (already verified in CI gate)