### PR TITLE
feat(launcher): show gcp project list instead of free-text prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ gcloud auth application-default login
 gcloud auth application-default set-quota-project YOUR_PROJECT_ID
 ```
 
-When "GCP Observability" is selected, the launcher checks for valid ADC credentials at startup (checking `GOOGLE_APPLICATION_CREDENTIALS` first, then `~/.config/gcloud/application_default_credentials.json`), then prompts for a GCP project ID. The project ID is validated (6-30 chars, lowercase letters/digits/hyphens, starts with a letter, no trailing hyphen, no consecutive hyphens) and stored in `~/.claude/.current-gcp-project` for the MCP wrapper. The previous project is offered as the default on the next run.
+When "GCP Observability" is selected, the launcher runs `gcloud projects list` to fetch accessible projects, checks for valid ADC credentials (checking `GOOGLE_APPLICATION_CREDENTIALS` first, then `~/.config/gcloud/application_default_credentials.json`), then shows a `select()` prompt with the available project IDs. The previously used project is pre-selected when it is still present in the list. The selected project ID is stored in `~/.claude/.current-gcp-project` for the MCP wrapper and persisted for the next run. If `gcloud` is not installed, not authenticated, or returns no projects, a descriptive error is shown and the launcher exits.
 
 **Note:** `GOOGLE_CLOUD_PROJECT` is used by the auth library for project ID resolution only — it does not auto-populate tool call parameters. Specify `resourceNames`, `parent`, `name`, or `projectId` explicitly in each tool call. The wrapper prints the active project to stderr as a context hint for Claude.
 

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -70,7 +70,7 @@ The wizard orchestration lives in `main.ts`. Type definitions are in `types.ts`.
 
 - `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
 - `mcp/cloudwatch.ts` — AWS profile parsing and profile selection
-- `mcp/gcp-observability.ts` — ADC credential check, project ID validation, and project prompt
+- `mcp/gcp-observability.ts` — GCP project list fetching (`loadGcpProjects`), ADC credential check, project ID validation utility, and project selection prompt
 
 Shared utilities (cancellation, prompts) are in `utils.ts` and `prompts.ts`. The `env.ts` module builds environment variables; `config.ts` handles persistence; `launch.ts` executes the final Claude command.
 
@@ -100,17 +100,13 @@ The launcher checks for ADC at startup in this order:
 
 If neither source provides a valid credential file, the launcher exits with a descriptive error before prompting for a project ID.
 
-### Project ID prompt
+### Project selection
 
-When "GCP Observability" is selected in the MCP multiselect, the launcher prompts for a GCP project ID. The previous project is offered as the default. The ID is validated before being accepted:
+When "GCP Observability" is selected in the MCP multiselect, the launcher first runs `gcloud projects list --format=value(projectId) --sort-by=projectId` to fetch the set of accessible projects, then checks ADC credentials, then presents a `select()` prompt listing the available project IDs. If the previously used project is still in the list it is pre-selected; otherwise the first project in the list is selected.
 
-- 6–30 characters
-- Lowercase letters, digits, and hyphens only
-- Must start with a lowercase letter
-- Must not end with a hyphen
-- Must not contain consecutive hyphens
+If `gcloud` is not on `PATH`, exits non-zero, or returns no projects, a descriptive error is logged and the launcher exits before showing the ADC check or the prompt.
 
-The validated project ID is written to `~/.claude/.current-gcp-project` (mode 0600) and persisted to `~/.config/myclaude/config.json` for use as the default on the next run. `GOOGLE_CLOUD_PROJECT` is also set in the child process environment for `google-auth-library` project resolution.
+The selected project ID is written to `~/.claude/.current-gcp-project` (mode 0600) and persisted to `~/.config/myclaude/config.json` for use as the default on the next run. `GOOGLE_CLOUD_PROJECT` is also set in the child process environment for `google-auth-library` project resolution.
 
 ### What GOOGLE_CLOUD_PROJECT does and does not do
 

--- a/src/launcher/gcp-observability.test.ts
+++ b/src/launcher/gcp-observability.test.ts
@@ -6,7 +6,9 @@ import * as os from "node:os";
 import {
   validateGcpProjectId,
   checkAdcCredentials,
+  loadGcpProjects,
 } from "./mcp/gcp-observability.js";
+import type { GcloudRunner } from "./mcp/gcp-observability.js";
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
@@ -175,6 +177,97 @@ describe("checkAdcCredentials", () => {
     assert.ok(
       caughtError!.message.includes("gcloud auth application-default login"),
       "Error message must mention gcloud auth application-default login",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadGcpProjects
+// ---------------------------------------------------------------------------
+
+const runnerNotFound: GcloudRunner = () => {
+  const err = new Error("spawnSync gcloud ENOENT") as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return { status: null, stdout: "", stderr: "", error: err };
+};
+
+const runnerNonZeroExit: GcloudRunner = () => ({
+  status: 1,
+  stdout: "",
+  stderr: "ERROR: (gcloud.projects.list) not authenticated",
+});
+
+const runnerEmptyOutput: GcloudRunner = () => ({
+  status: 0,
+  stdout: "   \n  \n  ",
+  stderr: "",
+});
+
+const runnerValidOutput: GcloudRunner = () => ({
+  status: 0,
+  stdout: "alpha-project\ncharlie-project\nbravo-project\n",
+  stderr: "",
+});
+
+const runnerWhitespaceOutput: GcloudRunner = () => ({
+  status: 0,
+  stdout: "\nmy-project\n\nanother-project\n\n",
+  stderr: "",
+});
+
+const runnerTimeout: GcloudRunner = () => ({
+  status: null,
+  stdout: "",
+  stderr: "",
+  signal: "SIGTERM",
+});
+
+describe("loadGcpProjects", () => {
+  it("throws when gcloud is not found on PATH", () => {
+    assert.throws(
+      () => loadGcpProjects(runnerNotFound),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("gcloud CLI not found"),
+    );
+  });
+
+  it("throws with stderr when gcloud exits non-zero", () => {
+    assert.throws(
+      () => loadGcpProjects(runnerNonZeroExit),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("gcloud projects list failed") &&
+        err.message.includes("not authenticated"),
+    );
+  });
+
+  it("throws when gcloud returns empty output", () => {
+    assert.throws(
+      () => loadGcpProjects(runnerEmptyOutput),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("No GCP projects found"),
+    );
+  });
+
+  it("returns project IDs in the order provided by gcloud", () => {
+    const projects = loadGcpProjects(runnerValidOutput);
+    assert.deepStrictEqual(projects, [
+      "alpha-project",
+      "charlie-project",
+      "bravo-project",
+    ]);
+  });
+
+  it("handles trailing newlines and filters empty lines", () => {
+    const projects = loadGcpProjects(runnerWhitespaceOutput);
+    assert.deepStrictEqual(projects, ["my-project", "another-project"]);
+  });
+
+  it("throws when gcloud times out", () => {
+    assert.throws(
+      () => loadGcpProjects(runnerTimeout),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("timed out after 15s"),
     );
   });
 });

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -5,6 +5,7 @@ import { loadAwsProfiles, configureCloudWatch } from "./mcp/cloudwatch.js";
 import {
   checkAdcCredentials,
   configureGcpObservability,
+  loadGcpProjects,
 } from "./mcp/gcp-observability.js";
 import { selectMcps } from "./prompts.js";
 import { buildEnvVars } from "./env.js";
@@ -72,6 +73,14 @@ async function main(): Promise<void> {
 
   // GCP Observability configuration
   if (selectedMcps.includes("gcp-observability")) {
+    let projects;
+    try {
+      projects = loadGcpProjects();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
     try {
       checkAdcCredentials();
     } catch (err) {
@@ -80,6 +89,7 @@ async function main(): Promise<void> {
     }
 
     const gcpConfig = await configureGcpObservability(
+      projects,
       savedConfig.gcpObservability?.project,
     );
 

--- a/src/launcher/mcp/gcp-observability.ts
+++ b/src/launcher/mcp/gcp-observability.ts
@@ -1,9 +1,72 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { text } from "@clack/prompts";
+import { spawnSync } from "node:child_process";
+import { select } from "@clack/prompts";
 import type { GcpObservabilityConfig } from "../types.js";
 import { handleCancel } from "../utils.js";
+
+export interface GcloudResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  signal?: string;
+  error?: Error;
+}
+
+export type GcloudRunner = () => GcloudResult;
+
+function defaultGcloudRunner(): GcloudResult {
+  const result = spawnSync(
+    "gcloud",
+    ["projects", "list", "--format=value(projectId)", "--sort-by=projectId"],
+    { encoding: "utf8", timeout: 15000 },
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    signal: result.signal ?? undefined,
+    error: result.error,
+  };
+}
+
+export function loadGcpProjects(runner?: GcloudRunner): string[] {
+  const result = (runner ?? defaultGcloudRunner)();
+
+  if (result.status === null && result.signal === "SIGTERM") {
+    throw new Error(
+      "gcloud projects list timed out after 15s. Check your network connection or try running `gcloud projects list` manually.",
+    );
+  }
+
+  if (result.error) {
+    const isNotFound =
+      (result.error as NodeJS.ErrnoException).code === "ENOENT";
+    throw new Error(
+      isNotFound
+        ? "gcloud CLI not found. Install it from https://cloud.google.com/sdk/docs/install or ensure it is on your PATH."
+        : `Failed to run gcloud CLI (${result.error.message}). Ensure gcloud is installed and on your PATH.`,
+    );
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `gcloud projects list failed (exit ${result.status}):\n${result.stderr.trim()}`,
+    );
+  }
+
+  if (result.stdout.trim() === "") {
+    throw new Error(
+      "No GCP projects found. Ensure you have access to at least one project, or run: gcloud auth login",
+    );
+  }
+
+  return result.stdout
+    .trim()
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+}
 
 const DEFAULT_ADC_PATH = path.join(
   os.homedir(),
@@ -55,20 +118,21 @@ export function checkAdcCredentials(adcPath?: string): void {
 }
 
 /**
- * Prompts the user to enter a GCP project ID for the Observability MCP server.
+ * Prompts the user to select a GCP project ID for the Observability MCP server.
  */
 export async function configureGcpObservability(
+  projects: string[],
   previousProject?: string,
 ): Promise<GcpObservabilityConfig> {
-  const projectValue = await text({
-    message: "Enter GCP project ID for Observability:",
-    defaultValue: previousProject,
-    placeholder: previousProject ?? "my-gcp-project-123",
-    validate(value) {
-      if (!validateGcpProjectId(value)) {
-        return "Invalid GCP project ID. Must be 6-30 chars: lowercase letters, digits, hyphens. Must start with a letter, not end with a hyphen, and not contain consecutive hyphens.";
-      }
-    },
+  const projectValue = await select({
+    message: "Select GCP project for Observability:",
+    options: projects.map((p) => ({ value: p, label: p })),
+    // Intentionally more defensive than the CloudWatch pattern: guards against a
+    // stale previousProject that is no longer present in the current project list.
+    initialValue:
+      previousProject && projects.includes(previousProject)
+        ? previousProject
+        : projects[0],
   });
   handleCancel(projectValue);
 


### PR DESCRIPTION
GCP Observability configuration now fetches available projects via `gcloud projects list` and presents a `select()` prompt, replacing the manual text entry where users typed a project ID with regex validation. Matches the pattern already used for CloudWatch (AWS profile list) and Grafana (cluster list).

Adds `loadGcpProjects()` with an injectable `GcloudRunner` for testability, a 15-second `spawnSync` timeout to prevent hangs on network issues, and ENOENT-aware error messaging for missing `gcloud` installations. The previous project is pre-selected when it remains in the list.