### PR TITLE
feat(launcher): add kubernetes cluster selection via kubectx

### DIFF
--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -59,6 +59,7 @@ The launcher constructs environment variables based on user selections:
 - **Grafana Editor:** Does not set `GRAFANA_DISABLE_WRITE` (read-write mode).
 - **CloudWatch:** Writes the selected AWS profile to `~/.claude/.current-aws-profile` (shared with the CloudWatch MCP wrapper).
 - **GCP Observability:** Sets `GOOGLE_CLOUD_PROJECT` in the environment for `google-auth-library` project ID resolution, and writes the project ID to `~/.claude/.current-gcp-project` (shared with `src/mcp/wrappers/mcp-gcp-observability.sh`). Note: `GOOGLE_CLOUD_PROJECT` is read by the auth library's `getProjectId()` but does **not** auto-populate tool call parameters — users still need to specify `resourceNames`, `parent`, `name`, or `projectId` in each tool call.
+- **Kubernetes:** Sets `K8S_CONTEXT` to the selected context name, which takes priority over the active context in `~/.kube/config` when other kubeconfig env vars are present. Also writes `~/.claude/.current-kube-context`.
 
 ## Persistence Format
 
@@ -70,7 +71,8 @@ The wizard orchestration lives in `main.ts`. Type definitions are in `types.ts`.
 
 - `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
 - `mcp/cloudwatch.ts` — AWS profile parsing and profile selection
-- `mcp/gcp-observability.ts` — GCP project list fetching (`loadGcpProjects`), ADC credential check, project ID validation utility, and project selection prompt
+- `mcp/gcp-observability.ts` — ADC credential check, project ID validation, and project prompt
+- `mcp/kubernetes.ts` — `kubectx` context listing, selection prompt, and context switching
 
 Shared utilities (cancellation, prompts) are in `utils.ts` and `prompts.ts`. The `env.ts` module builds environment variables; `config.ts` handles persistence; `launch.ts` executes the final Claude command.
 
@@ -122,8 +124,31 @@ The selected project ID is written to `~/.claude/.current-gcp-project` (mode 060
 
 If the dotfile is absent or empty, and no project was set another way, the wrapper exits with a helpful error pointing the user back to the `myclaude` launcher.
 
+## Kubernetes Configuration
+
+### Prerequisites
+
+`kubectx` must be installed and on `PATH`. A valid `~/.kube/config` with at least one context must exist. The launcher does not install `kubectx` — if it is absent, the launcher exits with a descriptive error pointing to the install instructions.
+
+### Context selection and switching
+
+When "Kubernetes" is selected in the MCP multiselect, the launcher runs `kubectx` (no arguments) to list available contexts and presents a `select` prompt. The previously saved context is offered as the default; if none is saved, the current active context from `kubectl config current-context` is used as the fallback, then the first context in the list.
+
+If the selected context differs from the saved previous context, the launcher runs `kubectx <selected>` to switch the active context in `~/.kube/config` before launching Claude. Re-selecting the same context skips the switch. The switch happens in `main.ts` immediately after the prompt, before `buildEnvVars` is called — see `mcp/kubernetes.ts` (`switchContext`) for the exact behavior.
+
+### What env var and dotfile are written
+
+`buildEnvVars` in `env.ts` sets `K8S_CONTEXT` to the selected context name. The Kubernetes MCP server (`mcp-server-kubernetes`) reads this to determine which context to use, overriding whatever context is currently active in `~/.kube/config`. This override matters when `KUBECONFIG` or other kubeconfig env vars are present in the environment.
+
+`~/.claude/.current-kube-context` is also written (mode 0600) for symmetry with the CloudWatch and GCP patterns, and to support potential future wrapper scripts or slash commands that need the selected context at runtime.
+
+### Persistence
+
+The selected context is saved under `kubernetes.context` in `~/.config/myclaude/config.json` and offered as the default on the next run.
+
 ## See Also
 
 - **`src/mcp/wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
 - **`src/mcp/wrappers/mcp-gcp-observability.sh`** — Bash wrapper that resolves the GCP project from the dotfile and launches the Observability MCP server
+- **`src/launcher/mcp/kubernetes.ts`** — `kubectx` context listing, selection prompt, and context switching logic
 - **`src/installer/launcher-install.ts`** — Installation logic for the launcher

--- a/src/launcher/env.test.ts
+++ b/src/launcher/env.test.ts
@@ -18,9 +18,11 @@ import type { ResolvedConfig, GrafanaCluster } from "./types.js";
 const dotfileDir = path.join(os.homedir(), ".claude");
 const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
 const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
+const kubeDotfilePath = path.join(dotfileDir, ".current-kube-context");
 
 let priorDotfileContent: string | null = null;
 let priorGcpDotfileContent: string | null = null;
+let priorKubeDotfileContent: string | null = null;
 
 before(() => {
   if (fs.existsSync(dotfilePath)) {
@@ -28,6 +30,9 @@ before(() => {
   }
   if (fs.existsSync(gcpDotfilePath)) {
     priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, "utf8");
+  }
+  if (fs.existsSync(kubeDotfilePath)) {
+    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, "utf8");
   }
 });
 
@@ -50,6 +55,16 @@ after(() => {
     });
   } else if (fs.existsSync(gcpDotfilePath)) {
     fs.rmSync(gcpDotfilePath);
+  }
+
+  if (priorKubeDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(kubeDotfilePath, priorKubeDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(kubeDotfilePath)) {
+    fs.rmSync(kubeDotfilePath);
   }
 });
 
@@ -162,5 +177,46 @@ describe("buildEnvVars", () => {
     const env = buildEnvVars(config);
     assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
     assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+  });
+
+  it("Kubernetes only: returns K8S_CONTEXT", () => {
+    const config: ResolvedConfig = {
+      kubernetes: { context: "my-cluster" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["K8S_CONTEXT"], "my-cluster");
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "AWS_PROFILE"),
+      "AWS_PROFILE must not be present when no CloudWatch config",
+    );
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "GOOGLE_CLOUD_PROJECT"),
+      "GOOGLE_CLOUD_PROJECT must not be present when no GCP config",
+    );
+    // Verify the dotfile was written with the correct content
+    assert.strictEqual(
+      fs.readFileSync(kubeDotfilePath, "utf8"),
+      "my-cluster\n",
+    );
+  });
+
+  it("Kubernetes + CloudWatch combined: both keys present", () => {
+    const config: ResolvedConfig = {
+      cloudwatch: { profile: "prod" },
+      kubernetes: { context: "production-cluster" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["AWS_PROFILE"], "prod");
+    assert.strictEqual(env["K8S_CONTEXT"], "production-cluster");
+  });
+
+  it("Kubernetes + GCP Observability combined: both keys present", () => {
+    const config: ResolvedConfig = {
+      gcpObservability: { project: "my-gcp-project" },
+      kubernetes: { context: "staging-cluster" },
+    };
+    const env = buildEnvVars(config);
+    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+    assert.strictEqual(env["K8S_CONTEXT"], "staging-cluster");
   });
 });

--- a/src/launcher/env.ts
+++ b/src/launcher/env.ts
@@ -62,5 +62,28 @@ export function buildEnvVars(config: ResolvedConfig): Record<string, string> {
     });
   }
 
+  if (config.kubernetes) {
+    const context = config.kubernetes.context;
+    // K8S_CONTEXT: explicit context override for mcp-server-kubernetes.
+    // Takes higher priority than ~/.kube/config active context, ensuring the
+    // selected context is respected even when other kubeconfig env vars
+    // (KUBECONFIG, K8S_SERVER, etc.) are present in the environment.
+    envVars["K8S_CONTEXT"] = context;
+
+    // Write dotfile for symmetry with cloudwatch/gcp patterns and potential
+    // future use by wrapper scripts or slash commands.
+    const kubeDotfile = path.join(
+      os.homedir(),
+      ".claude",
+      ".current-kube-context",
+    );
+    const kubeDotfileDir = path.dirname(kubeDotfile);
+    fs.mkdirSync(kubeDotfileDir, { recursive: true });
+    fs.writeFileSync(kubeDotfile, context + "\n", {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  }
+
   return envVars;
 }

--- a/src/launcher/kubernetes.test.ts
+++ b/src/launcher/kubernetes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseKubectxOutput } from "./mcp/kubernetes.js";
+
+// Note: loadKubectxContexts() and switchContext() invoke spawnSync("kubectx", ...)
+// which requires kubectx on PATH. Their error paths (ENOENT, non-zero exit, empty
+// output) are integration-tested manually. parseKubectxOutput() covers the parsing
+// logic that is pure and unit-testable.
+
+describe("parseKubectxOutput", () => {
+  it("parses a standard kubectx output with multiple contexts", () => {
+    const stdout = "production\nstaging\ndevelopment\n";
+    assert.deepEqual(parseKubectxOutput(stdout), [
+      "production",
+      "staging",
+      "development",
+    ]);
+  });
+
+  it("handles empty string (no contexts)", () => {
+    assert.deepEqual(parseKubectxOutput(""), []);
+  });
+
+  it("filters blank lines", () => {
+    const stdout = "production\n\nstaging\n";
+    assert.deepEqual(parseKubectxOutput(stdout), ["production", "staging"]);
+  });
+
+  it("trims whitespace from context names", () => {
+    const stdout = "  production  \n  staging  \n";
+    assert.deepEqual(parseKubectxOutput(stdout), ["production", "staging"]);
+  });
+
+  it("handles a single context", () => {
+    assert.deepEqual(parseKubectxOutput("my-cluster\n"), ["my-cluster"]);
+  });
+});

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -7,6 +7,11 @@ import {
   configureGcpObservability,
   loadGcpProjects,
 } from "./mcp/gcp-observability.js";
+import {
+  loadKubectxContexts,
+  configureKubernetes,
+  switchContext,
+} from "./mcp/kubernetes.js";
 import { selectMcps } from "./prompts.js";
 import { buildEnvVars } from "./env.js";
 import { launchClaude } from "./launch.js";
@@ -99,8 +104,40 @@ async function main(): Promise<void> {
     };
   }
 
+  // Kubernetes configuration
+  if (selectedMcps.includes("kubernetes")) {
+    let contexts;
+    try {
+      contexts = loadKubectxContexts();
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    const k8sConfig = await configureKubernetes(
+      contexts,
+      savedConfig.kubernetes?.context,
+    );
+
+    resolved.kubernetes = k8sConfig;
+    updatedConfig.kubernetes = { context: k8sConfig.context };
+  }
+
   // Persist updated selections
   saveConfig(updatedConfig);
+
+  // Switch Kubernetes context AFTER config is persisted (avoids inconsistency if switchContext fails)
+  if (resolved.kubernetes !== undefined) {
+    try {
+      switchContext(
+        resolved.kubernetes.context,
+        savedConfig.kubernetes?.context,
+      );
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
 
   // Build env vars summary for outro
   const envVars = buildEnvVars(resolved);
@@ -115,6 +152,9 @@ async function main(): Promise<void> {
   }
   if (resolved.gcpObservability) {
     lines.push(`GCP Observability: ${resolved.gcpObservability.project}`);
+  }
+  if (resolved.kubernetes) {
+    lines.push(`Kubernetes: ${resolved.kubernetes.context}`);
   }
   if (lines.length === 0) {
     lines.push("No MCPs configured — launching Claude with current env.");

--- a/src/launcher/mcp/kubernetes.ts
+++ b/src/launcher/mcp/kubernetes.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from "node:child_process";
+import { select } from "@clack/prompts";
+import type { KubernetesConfig } from "../types.js";
+import { handleCancel } from "../utils.js";
+
+/**
+ * Parses stdout from `kubectx` (no args) into a list of context names.
+ * Filters empty lines and trims whitespace.
+ */
+export function parseKubectxOutput(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Runs `kubectx` (no args) to list all available Kubernetes contexts.
+ * Throws if kubectx is not found, exits non-zero, or returns no contexts.
+ */
+export function loadKubectxContexts(): string[] {
+  const result = spawnSync("kubectx", [], { encoding: "utf8" });
+  if (result.error) {
+    throw new Error(
+      `Failed to run kubectx: ${result.error.message}\nEnsure kubectx is installed and available on your PATH.`,
+    );
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() ?? "";
+    throw new Error(
+      `kubectx exited with status ${result.status}${stderr ? `: ${stderr}` : ""}.`,
+    );
+  }
+  const contexts = parseKubectxOutput(result.stdout ?? "");
+  if (contexts.length === 0) {
+    throw new Error(
+      "No Kubernetes contexts found. Run `kubectl config get-contexts` to check your kubeconfig.",
+    );
+  }
+  return contexts;
+}
+
+/**
+ * Returns the name of the currently active Kubernetes context using
+ * `kubectl config current-context`. Returns an empty string if unavailable
+ * (e.g., kubectl not installed, no current context set).
+ */
+export function getCurrentContext(): string {
+  const result = spawnSync("kubectl", ["config", "current-context"], {
+    encoding: "utf8",
+  });
+  if (result.error || result.status !== 0) {
+    return "";
+  }
+  return result.stdout?.trim() ?? "";
+}
+
+/**
+ * Switches the active Kubernetes context using kubectx.
+ * No-op if `selected === previous` (unchanged selection).
+ * Throws if kubectx exits non-zero.
+ */
+export function switchContext(selected: string, previous?: string): void {
+  if (selected === previous) {
+    return;
+  }
+  const result = spawnSync("kubectx", [selected], { encoding: "utf8" });
+  if (result.error) {
+    throw new Error(`Failed to run kubectx: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() ?? "";
+    throw new Error(
+      `kubectx exited with status ${result.status} when switching to "${selected}"${stderr ? `: ${stderr}` : ""}.`,
+    );
+  }
+}
+
+/**
+ * Prompts the user to select a Kubernetes context.
+ * Pre-selects `previousContext` if provided, then falls back to the current
+ * active context, then to the first available context.
+ */
+export async function configureKubernetes(
+  contexts: string[],
+  previousContext?: string,
+): Promise<KubernetesConfig> {
+  const initialValue = previousContext || getCurrentContext() || contexts[0];
+
+  const options = contexts.map((ctx) => ({ value: ctx, label: ctx }));
+
+  const selected = await select({
+    message: "Select Kubernetes context:",
+    options,
+    initialValue,
+  });
+  handleCancel(selected);
+
+  return { context: selected as string };
+}

--- a/src/launcher/prompts.ts
+++ b/src/launcher/prompts.ts
@@ -14,6 +14,7 @@ export async function selectMcps(
         label: "GCP Observability",
         hint: "GCP project",
       },
+      { value: "kubernetes", label: "Kubernetes", hint: "cluster context" },
     ],
     initialValues: previousSelections,
     required: false,

--- a/src/launcher/types.ts
+++ b/src/launcher/types.ts
@@ -21,10 +21,15 @@ export interface GcpObservabilityConfig {
   project: string;
 }
 
+export interface KubernetesConfig {
+  context: string;
+}
+
 export interface ResolvedConfig {
   grafana?: GrafanaConfig;
   cloudwatch?: CloudWatchConfig;
   gcpObservability?: GcpObservabilityConfig;
+  kubernetes?: KubernetesConfig;
 }
 
 export interface LauncherConfig {
@@ -38,5 +43,8 @@ export interface LauncherConfig {
   };
   gcpObservability?: {
     project: string;
+  };
+  kubernetes?: {
+    context: string;
   };
 }


### PR DESCRIPTION
Adds an interactive Kubernetes context selector to the session launcher. When Kubernetes is selected as an MCP, the user picks a context from those listed by \`kubectx\`; if the selection differs from the previous session, the launcher runs \`kubectx <selected>\` to switch the active context in \`~/.kube/config\`. The \`K8S_CONTEXT\` env var is also set explicitly so the MCP server uses the correct cluster even when other kubeconfig env vars are in the environment.