### PR TITLE
fix(bash-style): use multiple -m flags instead of command substitution in git commits

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -22,6 +22,7 @@ The `validate-before-pr` skill MUST be invoked before any PR creation. It runs l
 
 - Never chain commands using `&&` or `;`, and never use process substitution (`<(...)` / `>(...)`). Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
 - Always issue each command as a separate, standalone Bash call.
+- Never use command substitution (`$(...)`) or heredoc temp-file patterns in git commit commands. Use multiple `-m` flags instead: `git commit -m "type(scope): subject" -m "Body paragraph."`. Each `-m` value becomes a separate paragraph. See `claude/references/bash-style.md` for details.
 
 ## Think Before Coding
 

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -68,6 +68,53 @@ Do not use `git commit --no-verify`, `git commit -n`, or `git push --no-verify`.
 
 If a pre-commit or pre-push hook fails, investigate and fix the underlying issue rather than bypassing it.
 
+## Rule: No Command Substitution in Git Commits
+
+Never use command substitution (`$(...)`) or heredoc-based temp-file patterns in `git commit` commands. Both patterns trigger permission dialogs that break unattended agent operation.
+
+Use multiple `-m` flags on a single `git commit` command instead. Git allows `-m` to be repeated; each value becomes a separate paragraph (separated by a blank line in the resulting message).
+
+**Enforcement:** `permission-learn.sh` Guard 5 (`is_simple_expansion_only`) blocks auto-approval for any command containing `$(`. The command falls through to the interactive permission dialog instead of being auto-approved. (This is not a hard deny -- the dialog still allows manual approval, but it breaks unattended operation.)
+
+**Wrong -- command substitution in commit:**
+```bash
+git commit -m "$(cat <<'EOF'
+feat(api): add batch endpoint
+
+Implements batch processing for bulk operations.
+EOF
+)"
+```
+
+**Wrong -- heredoc temp-file pattern (also triggers permission dialogs):**
+```bash
+cat > /tmp/claude-commit-msg.txt <<'EOF'
+feat(api): add batch endpoint
+
+Implements batch processing for bulk operations.
+EOF
+```
+```bash
+git commit -F /tmp/claude-commit-msg.txt
+```
+
+The temp-file approach fails for three reasons: `cat` is not in the auto-approve allowlist, `>` redirection fails Guard 5, and the multi-line heredoc body triggers the compound-command hard deny (newline count > 0).
+
+**Right -- multiple `-m` flags (subject only):**
+```bash
+git commit -m "feat(api): add batch endpoint"
+```
+
+**Right -- multiple `-m` flags (subject + body):**
+```bash
+git commit -m "feat(api): add batch endpoint" -m "Implements batch processing for bulk operations."
+```
+
+**Right -- multiple `-m` flags (subject + body + footer):**
+```bash
+git commit -m "feat(api): add batch endpoint" -m "Implements batch processing for bulk operations." -m "BREAKING CHANGE: removes legacy single-item endpoint"
+```
+
 ## Rationale
 
 Compound commands:
@@ -82,6 +129,11 @@ Process substitution additionally:
 Skipping hooks (`--no-verify`):
 - Masks real issues such as lint failures, secrets in commits, or malformed messages
 - Leads to commits that violate project standards and are harder to audit or revert
+
+Command substitution in git commits:
+- The `$(cat <<'EOF'...)` pattern contains `$(` which blocks auto-approval in `permission-learn.sh`, triggering a manual permission dialog on every commit
+- The temp-file heredoc alternative (`cat > /tmp/... <<'EOF'` + `git commit -F`) fails multiple guards: `cat` is not in the allowlist, `>` fails Guard 5, and multi-line heredocs trigger the compound-command hard deny
+- Multiple `-m` flags on a single `git commit` command achieve the same result while passing all auto-approval guards
 
 ## Applies To
 

--- a/claude/skills/commit-message-guide/SKILL.md
+++ b/claude/skills/commit-message-guide/SKILL.md
@@ -179,3 +179,7 @@ None of this information adds value.
 4. **Ensure the body adds value** - when in doubt, omit the body
 5. **Include only relevant context** in the body
 6. **NEVER add AI attribution** - no tool attribution of any kind
+7. **Use multiple `-m` flags for commits** -- never use `$(...)` or heredoc patterns in git commit commands:
+   - Subject only: `git commit -m "type(scope): subject"`
+   - Subject + body: `git commit -m "type(scope): subject" -m "Body paragraph."`
+   - Subject + body + footer: `git commit -m "type(scope): subject" -m "Body paragraph." -m "BREAKING CHANGE: description"`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -191,7 +191,7 @@ Claude Code loads instructions at two levels:
 
 **Behavioral constraints** — directives that govern how Claude Code behaves before and during execution:
 
-- **Bash Command Style** — prohibits command chaining (`&&`, `;`) and process substitution; each command must be issued as a standalone Bash call
+- **Bash Command Style** — prohibits command chaining (`&&`, `;`), process substitution, and command substitution (`$(...)`) or heredoc patterns in git commit commands; each command must be issued as a standalone Bash call; git commits must use multiple `-m` flags instead of shell constructs
 - **Think Before Coding** — requires surfacing ambiguous interpretations before acting, disclosing non-obvious assumptions, proposing simpler alternatives when they exist, and stopping to ask rather than guessing when context is insufficient
 
 ### Project-Level Instructions (.claude/CLAUDE.md)
@@ -221,7 +221,7 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 ### Available References
 
-- **`bash-style.md`** — Required Bash command style for all agents with Bash tool access. Defines three enforced rules: no compound commands (`&&`, `;`), no process substitution (`<(`, `>(`), and no `--no-verify` on git commands. The PermissionRequest hook enforces all three rules automatically.
+- **`bash-style.md`** — Required Bash command style for all agents with Bash tool access. Defines four enforced rules: no compound commands (`&&`, `;`), no process substitution (`<(`, `>(`), no `--no-verify` on git commands, and no command substitution (`$(...)`) or heredoc patterns in git commit commands (use multiple `-m` flags instead). The PermissionRequest hook enforces the first three rules automatically; the fourth is an instruction-level override of Claude Code's built-in commit pattern.
 
 - **`implementation-standards.md`** — Shared behavioral norms for implementation, planning, and review agents: Minimal Diff, YAGNI, and Test-First Protocol. Bitsmith, Pathfinder, Ruinor, and Knotcutter cite this as the canonical source. Each agent may elaborate with role-specific depth in its own definition file.
 


### PR DESCRIPTION
## Problem

Agents were using the built-in Claude Code commit pattern:

```bash
git commit -m "$(cat <<'EOF'
type(scope): subject

Body paragraph.
EOF
)"
```

This pattern contains `$(` which triggers Guard 5 (`is_simple_expansion_only`) in `permission-learn.sh`. Guard 5 blocks auto-approval for any command containing `$(`, so every commit falls through to the interactive permission dialog rather than being auto-approved. This breaks unattended agent operation.

The heredoc temp-file alternative (`cat > /tmp/... <<'EOF'` + `git commit -F`) also fails: `cat` is not in the auto-approve allowlist, `>` redirection fails Guard 5, and multi-line heredoc bodies trigger the compound-command hard deny.

## Solution

Add an explicit instruction-level override across three documents directing agents to use multiple `-m` flags instead:

```bash
git commit -m "type(scope): subject" -m "Body paragraph."
```

Git allows `-m` to be repeated; each value becomes a separate paragraph in the resulting message. This pattern contains no `$(`, no redirection, and no multi-line content — it passes all auto-approval guards.

## Changes

- **`claude/CLAUDE.md`** — adds a bullet to the Bash Command Style section prohibiting `$(...)` and heredoc patterns in git commit commands
- **`claude/references/bash-style.md`** — adds a full rule block (Rule: No Command Substitution in Git Commits) with correct/incorrect examples and rationale
- **`claude/skills/commit-message-guide/SKILL.md`** — adds step 7 to the When Creating Commits checklist requiring multiple `-m` flags
- **`docs/CONFIGURATION.md`** — updates two reference descriptions to reflect the fourth enforced rule
