### PR TITLE
feat(launcher): add startup summary screen with quick-launch

### DIFF
--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -26,6 +26,32 @@ After installation via `./install.sh`, the launcher is available as:
 myclaude
 ```
 
+## Startup Behavior
+
+**First run** (no saved config): the wizard goes straight to MCP selection. Choices are saved to `~/.config/myclaude/config.json` after you complete the flow.
+
+**Subsequent runs** (saved config exists): a summary screen is shown before any prompts.
+
+```
+┌  myclaude — Session Launcher
+│
+◆  Current Configuration
+│  Grafana: cluster prod-us-east, role viewer
+│  CloudWatch: profile my-aws-profile
+└
+◆  What would you like to do?
+│  ● Launch  (start Claude with current config)
+│  ○ Configure  (change MCP settings)
+└
+```
+
+| Action    | Key                | Effect                                                                     |
+| --------- | ------------------ | -------------------------------------------------------------------------- |
+| Launch    | Enter              | Launches Claude immediately with the saved config. Config is not re-saved. |
+| Configure | Arrow-down + Enter | Enters the full MCP selection flow. Config is re-saved on completion.      |
+
+If the saved Grafana cluster ID no longer exists in `~/.config/grafana-clusters.yaml`, the launch path is skipped and the configure flow starts automatically with a warning.
+
 ## Testing
 
 Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`env.test.ts`, `config.test.ts`, `utils.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
@@ -67,7 +93,7 @@ User selections are saved to `~/.config/myclaude/config.json` with mode 0600. If
 
 ## Architecture
 
-The wizard orchestration lives in `main.ts`. Type definitions are in `types.ts`. MCP-specific logic is split across:
+The wizard orchestration lives in `main.ts`. The summary screen gate (`promptSummaryAction`) is in `summary.ts`; the logic that reconstructs a `ResolvedConfig` from persisted data without re-prompting is in `resolve.ts`. Type definitions are in `types.ts`. MCP-specific logic is split across:
 
 - `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
 - `mcp/cloudwatch.ts` — AWS profile parsing and profile selection

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -16,12 +16,103 @@ import {
 import { selectMcps } from "./prompts.js";
 import { buildEnvVars } from "./env.js";
 import { tryLoad } from "./utils.js";
+import { promptSummaryAction } from "./summary.js";
+import { buildResolvedFromSaved } from "./resolve.js";
 import type { ResolvedConfig, LauncherConfig } from "./types.js";
+
+function launchClaude(
+  resolved: ResolvedConfig,
+  savedConfig: LauncherConfig,
+): never {
+  // Switch Kubernetes context AFTER config is persisted (avoids inconsistency if switchContext fails)
+  if (resolved.kubernetes !== undefined) {
+    tryLoad(
+      () =>
+        switchContext(
+          resolved.kubernetes!.context,
+          savedConfig.kubernetes?.context,
+        ),
+      "kubernetes-switch",
+    );
+  }
+
+  // Build env vars summary for outro
+  const envVars = buildEnvVars(resolved);
+  const summaryParts: Array<{
+    config: unknown;
+    label: string;
+    detail: string;
+  }> = [
+    {
+      config: resolved.grafana,
+      label: "Grafana",
+      detail: resolved.grafana
+        ? `${resolved.grafana.cluster.name} (${resolved.grafana.role})`
+        : "",
+    },
+    {
+      config: resolved.cloudwatch,
+      label: "CloudWatch",
+      detail: resolved.cloudwatch?.profile ?? "",
+    },
+    {
+      config: resolved.gcpObservability,
+      label: "GCP Observability",
+      detail: resolved.gcpObservability?.project ?? "",
+    },
+    {
+      config: resolved.kubernetes,
+      label: "Kubernetes",
+      detail: resolved.kubernetes?.context ?? "",
+    },
+  ];
+  const lines = summaryParts
+    .filter((p) => p.config)
+    .map((p) => `${p.label}: ${p.detail}`);
+  if (lines.length === 0) {
+    lines.push("No MCPs configured — launching Claude with current env.");
+  }
+
+  outro(`Launching: ${lines.join(" · ")}`);
+
+  // Launch Claude with merged env vars
+  const env = { ...process.env, ...envVars };
+  const result = spawnSync("claude", ["--agent", "dungeonmaster"], {
+    stdio: "inherit",
+    env,
+  });
+  process.exit(result.status ?? 1);
+}
 
 async function main(): Promise<void> {
   intro("myclaude — Session Launcher");
 
   const savedConfig = loadConfig();
+
+  // Summary screen: show current config and let user choose to launch or configure
+  const hasExistingConfig = savedConfig.selectedMcps.length > 0;
+
+  if (hasExistingConfig) {
+    const action = await promptSummaryAction(savedConfig);
+
+    if (action === "launch") {
+      const resolved = buildResolvedFromSaved(savedConfig);
+      if (resolved === null) {
+        // Fall through to configure flow.
+        // Warning already logged by buildResolvedFromSaved (e.g., stale Grafana cluster).
+      } else {
+        // Direct launch: no config was modified, so do NOT call saveConfig.
+        // The direct-launch path intentionally does not call saveConfig because
+        // no configuration was modified. Only the configure path (below) persists
+        // changes. This prevents an implementer from accidentally inserting a
+        // saveConfig call here or moving it into launchClaude where it would be
+        // called on both paths.
+        launchClaude(resolved, savedConfig);
+      }
+    }
+    // If action === "configure", fall through to existing menu flow below.
+    // If resolved === null (stale config), also fall through to configure flow.
+  }
 
   // MCP selection
   const selectedMcps = await selectMcps(savedConfig.selectedMcps);
@@ -94,67 +185,9 @@ async function main(): Promise<void> {
     updatedConfig.kubernetes = { context: k8sConfig.context };
   }
 
-  // Persist updated selections
+  // Persist updated selections (configure path only -- user changed config)
   saveConfig(updatedConfig);
-
-  // Switch Kubernetes context AFTER config is persisted (avoids inconsistency if switchContext fails)
-  if (resolved.kubernetes !== undefined) {
-    tryLoad(
-      () =>
-        switchContext(
-          resolved.kubernetes!.context,
-          savedConfig.kubernetes?.context,
-        ),
-      "kubernetes-switch",
-    );
-  }
-
-  // Build env vars summary for outro
-  const envVars = buildEnvVars(resolved);
-  const summaryParts: Array<{
-    config: unknown;
-    label: string;
-    detail: string;
-  }> = [
-    {
-      config: resolved.grafana,
-      label: "Grafana",
-      detail: resolved.grafana
-        ? `${resolved.grafana.cluster.name} (${resolved.grafana.role})`
-        : "",
-    },
-    {
-      config: resolved.cloudwatch,
-      label: "CloudWatch",
-      detail: resolved.cloudwatch?.profile ?? "",
-    },
-    {
-      config: resolved.gcpObservability,
-      label: "GCP Observability",
-      detail: resolved.gcpObservability?.project ?? "",
-    },
-    {
-      config: resolved.kubernetes,
-      label: "Kubernetes",
-      detail: resolved.kubernetes?.context ?? "",
-    },
-  ];
-  const lines = summaryParts
-    .filter((p) => p.config)
-    .map((p) => `${p.label}: ${p.detail}`);
-  if (lines.length === 0) {
-    lines.push("No MCPs configured — launching Claude with current env.");
-  }
-
-  outro(`Launching: ${lines.join(" · ")}`);
-
-  // Launch Claude with merged env vars
-  const env = { ...process.env, ...envVars };
-  const result = spawnSync("claude", ["--agent", "dungeonmaster"], {
-    stdio: "inherit",
-    env,
-  });
-  process.exit(result.status ?? 1);
+  launchClaude(resolved, updatedConfig);
 }
 
 main().catch((err: unknown) => {

--- a/src/launcher/resolve.test.ts
+++ b/src/launcher/resolve.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { buildResolvedFromSaved } from "./resolve.js";
+import type { LauncherConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Temp directory for fixture YAML files
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-resolve-test-"));
+
+before(() => {
+  // tmpDir already created above via mkdtempSync
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// YAML fixture helpers
+// ---------------------------------------------------------------------------
+
+function writeGrafanaFixture(
+  clusters: Array<{
+    id: string;
+    name: string;
+    url: string;
+    viewer_token: string;
+    editor_token: string;
+  }>,
+): string {
+  const lines = ["clusters:"];
+  for (const c of clusters) {
+    lines.push(`  - id: "${c.id}"`);
+    lines.push(`    name: "${c.name}"`);
+    lines.push(`    url: "${c.url}"`);
+    lines.push(`    viewer_token: "${c.viewer_token}"`);
+    lines.push(`    editor_token: "${c.editor_token}"`);
+  }
+  const filePath = path.join(tmpDir, `grafana-${Date.now()}.yaml`);
+  fs.writeFileSync(filePath, lines.join("\n"), {
+    mode: 0o600,
+    encoding: "utf8",
+  });
+  return filePath;
+}
+
+const fakeCluster = {
+  id: "prod-eu",
+  name: "Production EU",
+  url: "https://grafana.prod-eu.example.com",
+  viewer_token: "viewer-tok-abc",
+  editor_token: "editor-tok-xyz",
+};
+
+// ---------------------------------------------------------------------------
+// buildResolvedFromSaved
+// ---------------------------------------------------------------------------
+
+describe("buildResolvedFromSaved", () => {
+  it("returns {} when selectedMcps is empty", () => {
+    const config: LauncherConfig = { selectedMcps: [] };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, {});
+  });
+
+  it("returns { cloudwatch: { profile } } for cloudwatch-only config", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch"],
+      cloudwatch: { profile: "my-profile" },
+    };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, { cloudwatch: { profile: "my-profile" } });
+  });
+
+  it("returns { gcpObservability: { project } } for gcp-only config", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["gcp-observability"],
+      gcpObservability: { project: "my-gcp-project" },
+    };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, {
+      gcpObservability: { project: "my-gcp-project" },
+    });
+  });
+
+  it("returns { kubernetes: { context } } for kubernetes-only config", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["kubernetes"],
+      kubernetes: { context: "staging-cluster" },
+    };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, {
+      kubernetes: { context: "staging-cluster" },
+    });
+  });
+
+  it("skips MCPs whose config sub-object is missing", () => {
+    const config: LauncherConfig = {
+      // cloudwatch in selectedMcps but no cloudwatch sub-object
+      selectedMcps: ["cloudwatch", "kubernetes"],
+      kubernetes: { context: "dev-cluster" },
+    };
+    const result = buildResolvedFromSaved(config);
+    // cloudwatch skipped, kubernetes included
+    assert.deepStrictEqual(result, { kubernetes: { context: "dev-cluster" } });
+  });
+
+  it("returns correct ResolvedConfig with grafana cluster when cluster is found in fixture", () => {
+    const fixturePath = writeGrafanaFixture([fakeCluster]);
+    const config: LauncherConfig = {
+      selectedMcps: ["grafana"],
+      grafana: { clusterId: "prod-eu", role: "viewer" },
+    };
+    const result = buildResolvedFromSaved(config, fixturePath);
+    assert.ok(result !== null, "expected non-null result");
+    assert.deepStrictEqual(result!.grafana, {
+      cluster: {
+        id: fakeCluster.id,
+        name: fakeCluster.name,
+        url: fakeCluster.url,
+        viewer_token: fakeCluster.viewer_token,
+        editor_token: fakeCluster.editor_token,
+      },
+      role: "viewer",
+    });
+  });
+
+  it("returns null when grafana cluster ID is not in fixture (stale ID)", () => {
+    const fixturePath = writeGrafanaFixture([fakeCluster]);
+    const config: LauncherConfig = {
+      selectedMcps: ["grafana"],
+      grafana: { clusterId: "stale-cluster-id", role: "viewer" },
+    };
+    const result = buildResolvedFromSaved(config, fixturePath);
+    assert.strictEqual(result, null);
+  });
+
+  it("returns null when grafana YAML fixture file does not exist", () => {
+    const missingPath = path.join(tmpDir, "nonexistent-grafana.yaml");
+    const config: LauncherConfig = {
+      selectedMcps: ["grafana"],
+      grafana: { clusterId: "prod-eu", role: "editor" },
+    };
+    const result = buildResolvedFromSaved(config, missingPath);
+    assert.strictEqual(result, null);
+  });
+
+  it("combines multiple MCPs in a single resolved config", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch", "gcp-observability", "kubernetes"],
+      cloudwatch: { profile: "prod" },
+      gcpObservability: { project: "gcp-prod" },
+      kubernetes: { context: "prod-cluster" },
+    };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, {
+      cloudwatch: { profile: "prod" },
+      gcpObservability: { project: "gcp-prod" },
+      kubernetes: { context: "prod-cluster" },
+    });
+  });
+});

--- a/src/launcher/resolve.ts
+++ b/src/launcher/resolve.ts
@@ -1,0 +1,73 @@
+import { log } from "@clack/prompts";
+import { loadGrafanaClusters } from "./mcp/grafana.js";
+import type { ResolvedConfig, LauncherConfig } from "./types.js";
+
+export function buildResolvedFromSaved(
+  config: LauncherConfig,
+  grafanaClustersPath?: string,
+): ResolvedConfig | null {
+  const resolved: ResolvedConfig = {};
+
+  for (const name of config.selectedMcps) {
+    switch (name) {
+      case "grafana": {
+        if (config.grafana === undefined) {
+          // Sub-object missing — silently skip
+          break;
+        }
+        let clusters;
+        try {
+          clusters = loadGrafanaClusters(grafanaClustersPath);
+        } catch (err) {
+          log.warn(
+            `Could not load Grafana clusters: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
+          );
+          return null;
+        }
+        const cluster = clusters.find(
+          (c) => c.id === config.grafana!.clusterId,
+        );
+        if (cluster === undefined) {
+          log.warn(
+            `Grafana cluster "${config.grafana.clusterId}" not found in clusters file. Falling through to configure flow.`,
+          );
+          return null;
+        }
+        resolved.grafana = { cluster, role: config.grafana.role };
+        break;
+      }
+
+      case "cloudwatch": {
+        if (config.cloudwatch === undefined) {
+          break;
+        }
+        resolved.cloudwatch = { profile: config.cloudwatch.profile };
+        break;
+      }
+
+      case "gcp-observability": {
+        if (config.gcpObservability === undefined) {
+          break;
+        }
+        resolved.gcpObservability = {
+          project: config.gcpObservability.project,
+        };
+        break;
+      }
+
+      case "kubernetes": {
+        if (config.kubernetes === undefined) {
+          break;
+        }
+        resolved.kubernetes = { context: config.kubernetes.context };
+        break;
+      }
+
+      default:
+        // Unknown MCP — silently skip in resolved config
+        break;
+    }
+  }
+
+  return resolved;
+}

--- a/src/launcher/summary.test.ts
+++ b/src/launcher/summary.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatSummaryLines } from "./summary.js";
+import type { LauncherConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// formatSummaryLines
+// ---------------------------------------------------------------------------
+
+describe("formatSummaryLines", () => {
+  it("returns ['No MCPs configured.'] when selectedMcps is empty", () => {
+    const config: LauncherConfig = { selectedMcps: [] };
+    assert.deepStrictEqual(formatSummaryLines(config), ["No MCPs configured."]);
+  });
+
+  it("returns correct line for cloudwatch with profile", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch"],
+      cloudwatch: { profile: "prod" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "CloudWatch: profile prod",
+    ]);
+  });
+
+  it("returns correct line for grafana with clusterId and role", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["grafana"],
+      grafana: { clusterId: "prod-eu", role: "viewer" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "Grafana: cluster prod-eu, role viewer",
+    ]);
+  });
+
+  it("returns correct line for gcp-observability with project", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["gcp-observability"],
+      gcpObservability: { project: "my-project" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "GCP Observability: project my-project",
+    ]);
+  });
+
+  it("returns correct line for kubernetes with context", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["kubernetes"],
+      kubernetes: { context: "staging-cluster" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "Kubernetes: context staging-cluster",
+    ]);
+  });
+
+  it("returns one line per MCP in order when multiple MCPs are selected", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch", "kubernetes"],
+      cloudwatch: { profile: "dev" },
+      kubernetes: { context: "dev-cluster" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "CloudWatch: profile dev",
+      "Kubernetes: context dev-cluster",
+    ]);
+  });
+
+  it("returns '(not yet configured)' when grafana is in selectedMcps but sub-object is missing", () => {
+    const config: LauncherConfig = { selectedMcps: ["grafana"] };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "Grafana: (not yet configured)",
+    ]);
+  });
+
+  it("returns '(not yet configured)' when cloudwatch is in selectedMcps but sub-object is missing", () => {
+    const config: LauncherConfig = { selectedMcps: ["cloudwatch"] };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "CloudWatch: (not yet configured)",
+    ]);
+  });
+
+  it("returns '(not yet configured)' when gcp-observability is in selectedMcps but sub-object is missing", () => {
+    const config: LauncherConfig = { selectedMcps: ["gcp-observability"] };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "GCP Observability: (not yet configured)",
+    ]);
+  });
+
+  it("returns '(not yet configured)' when kubernetes is in selectedMcps but sub-object is missing", () => {
+    const config: LauncherConfig = { selectedMcps: ["kubernetes"] };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "Kubernetes: (not yet configured)",
+    ]);
+  });
+
+  it("returns four correct lines when all four MCPs are configured", () => {
+    const config: LauncherConfig = {
+      selectedMcps: [
+        "grafana",
+        "cloudwatch",
+        "gcp-observability",
+        "kubernetes",
+      ],
+      grafana: { clusterId: "prod-us", role: "editor" },
+      cloudwatch: { profile: "prod" },
+      gcpObservability: { project: "gcp-prod" },
+      kubernetes: { context: "prod-cluster" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "Grafana: cluster prod-us, role editor",
+      "CloudWatch: profile prod",
+      "GCP Observability: project gcp-prod",
+      "Kubernetes: context prod-cluster",
+    ]);
+  });
+
+  it("returns '<name>: (unknown MCP)' for an unknown MCP name", () => {
+    const config: LauncherConfig = { selectedMcps: ["future-mcp"] };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "future-mcp: (unknown MCP)",
+    ]);
+  });
+
+  it("handles a mix of known and unknown MCP names correctly", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch", "future-mcp", "kubernetes"],
+      cloudwatch: { profile: "staging" },
+      kubernetes: { context: "staging-cluster" },
+    };
+    assert.deepStrictEqual(formatSummaryLines(config), [
+      "CloudWatch: profile staging",
+      "future-mcp: (unknown MCP)",
+      "Kubernetes: context staging-cluster",
+    ]);
+  });
+});

--- a/src/launcher/summary.ts
+++ b/src/launcher/summary.ts
@@ -1,0 +1,61 @@
+import { note, select } from "@clack/prompts";
+import { handleCancel } from "./prompts.js";
+import type { LauncherConfig } from "./types.js";
+
+export function formatSummaryLines(config: LauncherConfig): string[] {
+  if (config.selectedMcps.length === 0) {
+    return ["No MCPs configured."];
+  }
+
+  return config.selectedMcps.map((name) => {
+    switch (name) {
+      case "grafana":
+        if (config.grafana === undefined) {
+          return "Grafana: (not yet configured)";
+        }
+        return `Grafana: cluster ${config.grafana.clusterId}, role ${config.grafana.role}`;
+
+      case "cloudwatch":
+        if (config.cloudwatch === undefined) {
+          return "CloudWatch: (not yet configured)";
+        }
+        return `CloudWatch: profile ${config.cloudwatch.profile}`;
+
+      case "gcp-observability":
+        if (config.gcpObservability === undefined) {
+          return "GCP Observability: (not yet configured)";
+        }
+        return `GCP Observability: project ${config.gcpObservability.project}`;
+
+      case "kubernetes":
+        if (config.kubernetes === undefined) {
+          return "Kubernetes: (not yet configured)";
+        }
+        return `Kubernetes: context ${config.kubernetes.context}`;
+
+      default:
+        return `${name}: (unknown MCP)`;
+    }
+  });
+}
+
+export async function promptSummaryAction(
+  config: LauncherConfig,
+): Promise<"launch" | "configure"> {
+  const lines = formatSummaryLines(config);
+  note(lines.join("\n"), "Current Configuration");
+  const result = await select({
+    message: "What would you like to do?",
+    options: [
+      {
+        value: "launch",
+        label: "Launch",
+        hint: "start Claude with current config",
+      },
+      { value: "configure", label: "Configure", hint: "change MCP settings" },
+    ],
+    initialValue: "launch",
+  });
+  handleCancel(result);
+  return result as "launch" | "configure";
+}


### PR DESCRIPTION
The launcher now shows a note-box summary of the current MCP configuration at startup. Pressing Enter launches Claude immediately; selecting Configure enters the full menu flow. Grafana clusters are re-resolved from YAML at launch time so no secrets are persisted in saved config. First-run behavior (no saved config) is unchanged.