### PR TITLE
chore(agents): upgrade opus-tier agents to claude-opus-4-7

### DIFF
--- a/.claude/skills/agent-creator/SKILL.md
+++ b/.claude/skills/agent-creator/SKILL.md
@@ -27,7 +27,7 @@ Start by understanding what the agent should do:
 2. **When should this agent be invoked?** (what user requests or scenarios)
 3. **What should it produce?** (output format, deliverables)
 4. **What tools does it need?** (Read, Write, Edit, Bash, Grep, Glob, Task, etc.)
-5. **What model should power it?** (claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5)
+5. **What model should power it?** (claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5)
 
 ### 2. Research Existing Agents
 
@@ -216,7 +216,7 @@ description: "Security vulnerability detection specialist (OWASP Top 10, secrets
 
 Select based on the agent's needs:
 
-- **claude-opus-4-6**: Complex reasoning, planning, security analysis
+- **claude-opus-4-7**: Complex reasoning, planning, security analysis
 - **claude-sonnet-4-6**: General-purpose work, orchestration, balanced tasks
 - **claude-haiku-4-5**: Fast, simple, straightforward tasks
 
@@ -277,7 +277,7 @@ For agents that analyze but never modify code:
 ---
 name: riskmancer
 description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
-model: claude-opus-4-6
+model: claude-opus-4-7
 level: 3
 disallowedTools: Write, Edit
 ---
@@ -349,7 +349,7 @@ For agents that research and plan but don't execute:
 ---
 name: pathfinder
 description: "Strategic planning consultant with interview workflow"
-model: claude-opus-4-6
+model: claude-opus-4-7
 level: 4
 tools: "Read, Write, Grep, Glob, Bash, Agent"
 ---

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -3,7 +3,7 @@ name: knotcutter
 color: yellow
 description: "Radical simplification specialist for complexity elimination reviews."
 tools: "Read, Grep, Glob, Bash"
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: auto
 level: 3
 mandatory: false

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -2,7 +2,7 @@
 name: pathfinder
 color: blue
 description: "Strategic planning consultant with interview workflow"
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: acceptEdits
 level: 4
 tools: "Read, Write, Grep, Glob, Bash, Agent"

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -2,7 +2,7 @@
 name: riskmancer
 color: orange
 description: "Security vulnerability detection specialist (OWASP, secrets, auth, crypto)."
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -2,7 +2,7 @@
 name: ruinor
 color: red
 description: "Mandatory baseline quality gate reviewer issuing REJECT/REVISE/ACCEPT verdicts."
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash"

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,16 +8,16 @@
 | **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
 | **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | N/A |
 | **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | N/A |
-| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-6 | Specialist (opt-in) |
-| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-6 | N/A |
-| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-sonnet-4.5 | Specialist (opt-in) |
-| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-6 | Mandatory baseline |
-| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-opus-4-6 | Specialist (opt-in) |
-| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-haiku-4-5 | Specialist (opt-in) |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | Specialist (opt-in) |
+| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | N/A |
+| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | Specialist (opt-in) |
+| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | Mandatory baseline |
+| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | Specialist (opt-in) |
+| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | Specialist (opt-in) |
 | **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | N/A |
-| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | (default) | N/A |
-| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-opus-4-6 | N/A |
-| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | (default) | N/A |
+| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
+| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | N/A |
+| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | N/A |
 
 ## When to Use Which Agent
 


### PR DESCRIPTION
Upgrades the four Opus-tier agents (riskmancer, knotcutter, pathfinder, ruinor) from `claude-opus-4-6` to `claude-opus-4-7`, which reached general availability on 2026-04-16. Also fixes six pre-existing model drift entries in `docs/AGENTS.md` and updates the agent-creator skill's guidance and examples to reference the new model. Sonnet-tier and Haiku-tier agents are unchanged.