### PR TITLE
feat(hooks): reset tab title to repo name on fresh session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ When you want a human-readable summary of past sessions, invoke the Talekeeper n
 
 ### Terminal Tab Rename
 Terminal tab titles are automatically managed via a two-hook system:
-- **SessionStart Hook** — Restores previously stored session titles for resumed sessions (instant, no AI call)
+- **SessionStart Hook** — Restores previously stored session titles for resumed sessions (instant, no AI call); resets the tab to the repo or directory name for fresh sessions (e.g., after `/new`) so the previous session's stale title does not persist
 - **Stop Hook** — Generates a contextual 2–5 word title from the first user prompt and assistant response after the first turn completes; stores it for future resume
 
 This provides immediate context recognition when resuming sessions and automatic title generation based on what you actually worked on, without manual naming. Titles are stored in `~/.claude/session-titles/` and persist across terminal restarts. Sessions started with `--name` flag preserve their explicit title without AI override.

--- a/claude/hooks/lib-tab-rename.sh
+++ b/claude/hooks/lib-tab-rename.sh
@@ -64,3 +64,17 @@ _tab_rename_set_title() {
     fi
   fi
 }
+
+# _tab_rename_default_title DIR
+# Derives a neutral session title from DIR: repo basename if in a git repo,
+# directory basename otherwise. Returns the title via stdout.
+# Note: uses empty _repo_name (not exit status) as failure signal, because
+# `local x=$(cmd)` always returns 0 from local — masking $? of the inner command.
+# The ${_repo_name:-$_dir_name} fallback is therefore driven by empty string, not $?.
+_tab_rename_default_title() {
+  local _dir_name
+  local _repo_name
+  _dir_name=$(basename "$1")
+  _repo_name=$(git -C "$1" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {} 2>/dev/null)
+  printf '%s' "${_repo_name:-$_dir_name}"
+}

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# session-start.sh -- Restores a previously stored session title for resumed sessions.
-# Title generation is handled by the Stop hook (tab-rename-stop.sh).
+# session-start.sh -- On resume: restores previously stored session title. On fresh start: resets tab to neutral default.
 # Fires on: SessionStart (async)
 # Installed to: ~/.claude/hooks/session-start.sh
 
@@ -35,6 +34,18 @@ TITLE_DIR="$HOME/.claude/session-titles"
 TITLE_FILE="$TITLE_DIR/$SESSION_ID"
 
 if [ ! -f "$TITLE_FILE" ]; then
+  # No stored title for this session (fresh session, e.g. /new).
+  # Reset tab to a neutral default so the previous session's title does not persist.
+  # Note: consecutive /new invocations each produce a new SESSION_ID with no stored
+  # title, so this branch fires correctly for each fresh start in sequence.
+  _tab_rename_detect_terminal
+  if [ -z "$TERMINAL" ]; then
+    exit 0
+  fi
+  TITLE=$(_tab_rename_default_title "$CWD")
+  if [ -n "$TITLE" ]; then
+    _tab_rename_set_title "$TITLE"
+  fi
   exit 0
 fi
 

--- a/claude/hooks/tab-rename-stop.sh
+++ b/claude/hooks/tab-rename-stop.sh
@@ -71,13 +71,13 @@ LAST_RESPONSE=$(echo "$STDIN_DATA" | jq -r '.last_assistant_message // ""' 2>/de
 LAST_RESPONSE="${LAST_RESPONSE:0:500}"
 
 # Gather lightweight project context
-DIR_NAME=$(basename "$CWD")
-REPO_NAME=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null | xargs -I{} basename {} 2>/dev/null)
+# DRY: calls _tab_rename_default_title; behavior unchanged
+REPO_NAME=$(_tab_rename_default_title "$CWD")
 
 # Generate AI title via claude -p (pipe mode does not fire session hooks; --bare strips the default system prompt)
 TITLE=$(claude -p --bare --model haiku \
   --system-prompt "Respond with ONLY 2-5 words. No punctuation, no quotes, no explanation. Generate a short natural-language title summarizing this coding session based on the user's request and the assistant's work." \
-  "Project: ${REPO_NAME:-$DIR_NAME}, User asked: ${FIRST_PROMPT}, Assistant did: ${LAST_RESPONSE}" \
+  "Project: ${REPO_NAME}, User asked: ${FIRST_PROMPT}, Assistant did: ${LAST_RESPONSE}" \
   </dev/null 2>/dev/null)
 if [ $? -ne 0 ] || [ -z "$TITLE" ]; then
   exit 0

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,11 +100,11 @@ Auto-approved entries include the `[auto-approved]` marker; calls falling throug
 
 #### SessionStart Hook - Terminal Tab Title Restore
 
-Runs at the start of every Claude Code session to restore a previously stored terminal tab title for resumed sessions. Title generation is handled by the Stop hook (`tab-rename-stop.sh`).
+Runs at the start of every Claude Code session. For resumed sessions, restores the previously stored tab title. For fresh sessions (e.g., after `/new`), resets the tab to the repo or directory name so the previous session's stale title does not persist until the Stop hook generates a new one. Title generation from conversation content is handled by the Stop hook (`tab-rename-stop.sh`).
 
-**Purpose:** Restores a previously stored terminal tab title when resuming a session. Script: `claude/hooks/session-start.sh`.
+**Purpose:** Ensures the tab title always reflects the current session on startup — either a stored title for resumed sessions or a neutral repo/directory default for fresh sessions. Script: `claude/hooks/session-start.sh`.
 
-**Non-obvious behaviors:** `--name` override is detected via process ancestry (walks up to 3 levels); `-n` is intentionally excluded to avoid false positives. New sessions exit silently — title generation is deferred to the Stop hook after the first exchange.
+**Non-obvious behaviors:** `--name` override is detected via process ancestry (walks up to 3 levels); `-n` is intentionally excluded to avoid false positives. Fresh-session neutral title is derived from the git repo basename when inside a repo, or the directory basename otherwise — matching the context used by the Stop hook. The neutral default is not persisted to `~/.claude/session-titles/`, so the Stop hook's single-fire guard is not tripped and the AI-generated title replaces it after the first exchange.
 
 **Supported terminals and detection:**
 


### PR DESCRIPTION
When /new starts a fresh Claude Code session, the previous session's AI-generated tab title was retained until the new session's first response. This change resets the tab immediately on SessionStart to the repo or directory name, so users always see a neutral title for a new session rather than a stale one from the old session. The _tab_rename_default_title helper is extracted to lib-tab-rename.sh and shared with tab-rename-stop.sh to eliminate duplication.