### PR TITLE
refactor(dungeonmaster): implement Phase 0 idempotency and deferred worktree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ These directories are created automatically when you run `install.sh`.
 
 ### Parallel Sessions via Git Worktrees
 
-The Dungeon Master now supports true parallel development workflows using Git worktrees. Each session automatically creates an isolated worktree on a dedicated branch (e.g., `.worktrees/dm-add-oauth-login/` on `dm/add-oauth-login`), enabling multiple simultaneous `claude --agent dungeonmaster` terminals to work on unrelated issues without git conflicts or interference.
+The Dungeon Master now supports true parallel development workflows using Git worktrees. Each constructive or investigative session automatically creates an isolated worktree on a dedicated branch using conventional commit prefixes (e.g., `.worktrees/feat-add-oauth-login/` on `feat/add-oauth-login`), enabling multiple simultaneous `claude --agent dungeonmaster` terminals to work on unrelated issues without git conflicts or interference. Advisory sessions (`/ask`, `/ops`) never create a worktree.
 
 **Key benefits:**
 - Run multiple DungeonMaster sessions simultaneously on the same repository
@@ -337,7 +337,7 @@ The Dungeon Master now supports true parallel development workflows using Git wo
 - At completion, the branch is preserved and a log line points you to `/open-pr` for next steps
 - Manual cleanup with `git worktree remove` when you are done
 
-Use `--no-worktree` flag to suppress worktree creation and operate in the main working tree (backwards compatible). See [docs/WORKTREE_ISOLATION.md](/docs/WORKTREE_ISOLATION.md) for comprehensive guide with examples and troubleshooting.
+See [docs/WORKTREE_ISOLATION.md](/docs/WORKTREE_ISOLATION.md) for a comprehensive guide with examples and troubleshooting.
 
 ### Documentation Integration
 The Dungeon Master orchestration agent automatically invokes Quill (documentation specialist) in Phase 5 (Completion) when a planning session was conducted. Quill runs as step 5b — after reservations are logged (5a) but before the Resolution Gate (5c) and completion summary (5d). Quill receives the plan file, list of changed files, and feature summary, then updates documentation to reflect the implementation. If the Resolution Gate triggers post-gate Bitsmith work, Quill is re-invoked after the follow-up Phase 4 review. This ensures documentation stays synchronized with code without manual effort.

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -189,6 +189,26 @@ Follow this sequence:
 
 ### Phase 0: Session Isolation
 
+**Re-entry guard:** Before capturing session variables or doing any other Phase 0 work, evaluate whether the current user message is a continuation of an established session.
+
+**Bypass condition:** If the current user message begins with a slash-command invocation (`/feature`, `/bug`, `/ask`, `/ops`, or any other slash command that injects an `INTENT:` line), treat it as an implicit new-task signal and skip the guard entirely — proceed with full Phase 0 setup as a fresh session. Slash commands always start a new session boundary.
+
+**Continuation check (free-form messages only):** If the current user message is free-form text (no slash-command prefix), check whether `WORKTREE_PATH` is present in conversation memory from earlier in this session. If it is, run `git worktree list --porcelain` and confirm that the path appears in the output. When both conditions hold, the session is a continuation:
+- Skip the rest of Phase 0 entirely (including session-variable capture — the existing variables are still authoritative).
+- If `WORKTREE_BRANCH` was dropped from conversation memory but `WORKTREE_PATH` is present, recover `WORKTREE_BRANCH` from the `branch` field in the porcelain output for that worktree.
+- If `REPO_SLUG` was dropped, recover it via `basename $(git rev-parse --show-toplevel)`.
+- Log to the user: `"Continuing existing session: worktree {WORKTREE_PATH} on branch {WORKTREE_BRANCH}. Phase 0 skipped."`
+- Proceed to Phase 1 with the (possibly recovered) context.
+
+If `WORKTREE_PATH` is missing from conversation memory, OR `git worktree list --porcelain` does not show the path, proceed with full Phase 0 setup as a fresh session.
+
+**Session reset triggers:** A session is considered ended (so the re-entry guard does not fire on the next free-form message) only when one of the following has occurred:
+- The `/merged` command completed successfully (which already removes the worktree and clears `WORKTREE_PATH` / `WORKTREE_BRANCH`). Note that `/open-pr` does **not** end the session — the worktree remains until `/merged` or manual cleanup, but a subsequent slash-command invocation will still bypass the guard per the Bypass condition above.
+- The user explicitly indicates a new unrelated task in a free-form message (e.g., "Let's switch to a different feature", "New task: ...", or any clear topic change). When ambiguous, ask the user before resetting — do not silently treat a follow-up as a new session.
+- Any slash-command invocation (`/feature`, `/bug`, `/ask`, `/ops`) per the Bypass condition above.
+
+Adding scope to an in-flight feature, fixing a follow-up bug introduced by the in-flight implementation, or asking advisory questions about the work in progress — when raised as free-form follow-up messages — all count as continuations of the same session.
+
 At the very start of every session, before any other work, capture three session-scoped variables in conversation memory:
 - `SESSION_TS` — current local time formatted as `YYYYMMDD-HHmmss` (e.g., `20260401-143022`)
 - `SESSION_SLUG` — the task description slugified: lowercase, alphanumeric and hyphens only, max 40 characters (e.g., "Add OAuth login" → `add-oauth-login`, "Rename env var" → `rename-env-var`)
@@ -196,11 +216,17 @@ At the very start of every session, before any other work, capture three session
 
 These are carried in conversation memory alongside `WORKTREE_PATH`, `WORKTREE_BRANCH`, and `REPO_SLUG` for the entire session and are used for consistent file naming throughout.
 
-Before any planning begins, create an isolated git worktree for this session so it does not conflict with other parallel DM sessions.
+**Worktree creation is deferred to Phase 1**, after intent classification. Phase 0 only captures session variables; the worktree (if any) is created by the Worktree Creation Subroutine, invoked from whichever Phase 1 routing branch the task is classified into. Advisory branches do not invoke the subroutine, so advisory sessions never create a worktree.
 
-**Skip condition:** When `INTENT: advisory` is explicitly set (typically via the `/ask` or `/ops` command), skip worktree creation (steps 1-5 below) and `~/.ai-tpk/plans/` directory setup. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured at the top of Phase 0 — they are lightweight conversational memory, not file writes. For all other intents (investigative, constructive, or heuristically classified), worktree creation is mandatory with no exceptions. Note: if the DM heuristically classifies a message as advisory (branch (d) in the Mutual Exclusivity Note), a worktree will already have been created because Phase 0 runs before Phase 1 classification. This is acceptable — the explicit `/ask` command is the primary mechanism for advisory sessions, and the worktree will simply go unused.
+### Phase 1: Planning
 
-**When creating a worktree:**
+1. Clarify the user goal in one sentence.
+
+**Worktree Creation Subroutine:**
+
+This subroutine is **invoked explicitly** by routing branches in this section that require a worktree. It is **not** a checkpoint — it does not run automatically. Each routing branch below states whether it invokes the subroutine. Branches that do not invoke it (the advisory branches) produce sessions with no worktree.
+
+**When invoked, perform the following steps in order:**
 
 1. **Derive branch name:** Slugify the task description using a conventional commit prefix → `{type}/{slugified-task}` (e.g., "Add OAuth login" → `feat/add-oauth-login`, "Fix null pointer in auth" → `fix/null-pointer-auth`, "Refactor cache layer" → `refactor/cache-layer`). Infer the prefix from the nature of the request: use `feat/` for new features, `fix/` for bug fixes, `refactor/` for refactoring, `chore/` for maintenance/config/tooling, `docs/` for documentation-only changes, `test/` for test-only changes. If the request is ambiguous, use `chore/session-{YYYYMMDD-HHmmss}` (local time). Max 60 characters, lowercase, alphanumeric and hyphens only.
 
@@ -220,16 +246,14 @@ Before any planning begins, create an isolated git worktree for this session so 
 
 5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 
-### Phase 1: Planning
-
-1. Clarify the user goal in one sentence.
+**After the subroutine completes, control returns to the routing branch that invoked it.**
 
 **Intent Override** (before classification):
 
 If the user's message begins with `INTENT: investigative`, `INTENT: constructive`, or `INTENT: advisory`, skip heuristic classification and route directly:
-- `INTENT: investigative` → fire the Investigative Gate immediately (skip the Mutual Exclusivity classification below)
-- `INTENT: constructive` → skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly)
-- `INTENT: advisory` → enter the Advisory Workflow (Phases A-B-C) immediately. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured. If `--save-report` is present on the `INTENT:` line (e.g., `INTENT: advisory --save-report`), capture it as an active workflow flag for this session before stripping.
+- `INTENT: investigative` → **invoke the Worktree Creation Subroutine first** (so `WORKTREE_PATH` is populated before Tracebloom delegation), then fire the Investigative Gate immediately (skip the Mutual Exclusivity classification below).
+- `INTENT: constructive` → **invoke the Worktree Creation Subroutine first**, then skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly).
+- `INTENT: advisory` → **do not invoke the Worktree Creation Subroutine** — advisory sessions never create a worktree. Enter the Advisory Workflow (Phases A-B-C) immediately. Session variables (`SESSION_TS`, `SESSION_SLUG`) are still captured. If `--save-report` is present on the `INTENT:` line (e.g., `INTENT: advisory --save-report`), capture it as an active workflow flag for this session before stripping.
 
 The `INTENT:` override is honored regardless of source — slash commands (`/bug`, `/feature`, `/ask`, `/ops`) are the typical injection mechanism, but any message starting with a valid `INTENT:` directive will be routed accordingly.
 
@@ -240,14 +264,17 @@ Strip the `INTENT:` line (including any flags on it, such as `--save-report`) fr
 When not triggered: proceed to the Mutual Exclusivity Note below.
 
 **Mutual exclusivity note:** When no explicit `INTENT:` override is present, classify the task as exactly one of the following branches — only one fires per task, they are not sequential filters:
-- **(a) Investigative** (the task is "why is X broken?" with unknown root cause) → Investigative Gate → Tracebloom
-- **(b) Ambiguous or underspecified** (the task needs clarification before planning) → Intake Gate → Askmaw
-- **(c) Ready for planning** (clear, bounded, constructive task) → proceed to Pathfinder (which will internally handle scope confirmation and options discovery in its Section 4)
-- **(d) Advisory** (the task is a question — "how does X work?", "is this a good approach?", "what are my options?") → Advisory Workflow (Phases A-B-C)
+- **(a) Investigative** (the task is "why is X broken?" with unknown root cause) → **invoke the Worktree Creation Subroutine** → Investigative Gate → Tracebloom
+- **(b) Ambiguous or underspecified** (the task needs clarification before planning) → **invoke the Worktree Creation Subroutine** → Intake Gate → Askmaw
+- **(c) Ready for planning** (clear, bounded, constructive task) → **invoke the Worktree Creation Subroutine** → proceed to Pathfinder (which will internally handle scope confirmation and options discovery in its Section 4)
+- **(d) Advisory** (the task is a question — "how does X work?", "is this a good approach?", "what are my options?") → **do not invoke the Worktree Creation Subroutine** → Advisory Workflow (Phases A-B-C)
 
 **Investigative Gate** (between step 1 and the Intake Gate):
 
 If the task was classified as investigative (see "When to call Tracebloom" routing rules):
+
+**Precondition:** The Worktree Creation Subroutine must have been invoked by the routing branch that selected the Investigative Gate (either `INTENT: investigative` per the Intent Override, or Mutual Exclusivity branch (a)). `WORKTREE_PATH` and `WORKTREE_BRANCH` must be populated in conversation memory before this gate runs, because the Tracebloom delegation template below requires them.
+
 1. Delegate to Tracebloom with the user's reported symptom and any error messages or context using the delegation template below
 2. When Tracebloom returns a Diagnostic Report, evaluate the "Recommended next action" field:
    - **"Route to Pathfinder for planning a fix"**: Proceed to step 2 (Planning), passing the Diagnostic Report to Pathfinder as context using the handoff template below
@@ -580,7 +607,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 This workflow fires when `INTENT: advisory` is detected (typically via the `/ask` or `/ops` command). It is a lightweight, read-only Q&A path that bypasses the entire constructive/investigative pipeline.
 
-**What is skipped:** Worktree creation (Phase 0 steps 1-5), Pathfinder, Bitsmith (unless `--save-report` is active), Ruinor, Quill, all review gates, completion steps (summary and worktree log). No plan file is written. No code is changed. No files are written — except when `--save-report` is active, in which case Bitsmith is invoked solely to write the report file after Phase C synthesis.
+**What is skipped:** Worktree creation (the Phase 1 Worktree Creation Subroutine is not invoked by the advisory branches), Pathfinder, Bitsmith (unless `--save-report` is active), Ruinor, Quill, all review gates, completion steps (summary and worktree log). No plan file is written. No code is changed. No files are written — except when `--save-report` is active, in which case Bitsmith is invoked solely to write the report file after Phase C synthesis.
 
 **What is NOT skipped:** Session variable capture (`SESSION_TS`, `SESSION_SLUG`) — these are lightweight conversational memory and are retained for logging and potential pipeline transitions.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -198,14 +198,14 @@ Follow this sequence:
 - If `WORKTREE_BRANCH` was dropped from conversation memory but `WORKTREE_PATH` is present, recover `WORKTREE_BRANCH` from the `branch` field in the porcelain output for that worktree.
 - If `REPO_SLUG` was dropped, recover it via `basename $(git rev-parse --show-toplevel)`.
 - Log to the user: `"Continuing existing session: worktree {WORKTREE_PATH} on branch {WORKTREE_BRANCH}. Phase 0 skipped."`
-- Proceed to Phase 1 with the (possibly recovered) context.
+- Proceed to Phase 1 with the (possibly recovered) context. If a Phase 1 workflow was already in progress (e.g., the Askmaw interview loop, a scope confirmation prompt, or the Resolution Gate's user-prompt path), resume it at the point the prior message left off — do not restart Phase 1 from step 1.
 
 If `WORKTREE_PATH` is missing from conversation memory, OR `git worktree list --porcelain` does not show the path, proceed with full Phase 0 setup as a fresh session.
 
 **Session reset triggers:** A session is considered ended (so the re-entry guard does not fire on the next free-form message) only when one of the following has occurred:
 - The `/merged` command completed successfully (which already removes the worktree and clears `WORKTREE_PATH` / `WORKTREE_BRANCH`). Note that `/open-pr` does **not** end the session — the worktree remains until `/merged` or manual cleanup, but a subsequent slash-command invocation will still bypass the guard per the Bypass condition above.
 - The user explicitly indicates a new unrelated task in a free-form message (e.g., "Let's switch to a different feature", "New task: ...", or any clear topic change). When ambiguous, ask the user before resetting — do not silently treat a follow-up as a new session.
-- Any slash-command invocation (`/feature`, `/bug`, `/ask`, `/ops`) per the Bypass condition above.
+- Any slash-command invocation that injects an `INTENT:` line (`/feature`, `/bug`, `/ask`, `/ops`) per the Bypass condition above.
 
 Adding scope to an in-flight feature, fixing a follow-up bug introduced by the in-flight implementation, or asking advisory questions about the work in progress — when raised as free-form follow-up messages — all count as continuations of the same session.
 
@@ -242,7 +242,7 @@ This subroutine is **invoked explicitly** by routing branches in this section th
 
 3. **Handle branch collisions:** If `git worktree add` fails because the branch already exists, retry with a numeric suffix (`feat/add-oauth-login-2`, then `-3`). After 3 failures, fall back to main working tree and warn the user.
 
-4. **Set session context:** The DM carries `WORKTREE_PATH`, `WORKTREE_BRANCH`, `SESSION_TS`, `SESSION_SLUG`, and `REPO_SLUG` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used. If a session is interrupted and context is lost, run `git worktree list` to recover `WORKTREE_PATH` and `WORKTREE_BRANCH`. Inspect `~/.ai-tpk/plans/{REPO_SLUG}/` to recover `SESSION_TS` and `SESSION_SLUG` from the plan filename. Recover `REPO_SLUG` via `basename $(git rev-parse --show-toplevel)`.
+4. **Set session context:** The DM carries `WORKTREE_PATH`, `WORKTREE_BRANCH`, `SESSION_TS`, `SESSION_SLUG`, and `REPO_SLUG` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used. If a session is interrupted and context is lost, run `git worktree list` to recover `WORKTREE_PATH` and `WORKTREE_BRANCH`. Inspect `~/.ai-tpk/plans/{REPO_SLUG}/` to recover `SESSION_TS` and `SESSION_SLUG` from the plan filename. Recover `REPO_SLUG` via `basename $(git rev-parse --show-toplevel)`. If a prior worktree's variables are present in conversation memory (e.g., from a session that ended with `/open-pr` rather than `/merged`), overwrite them with the new values — the DM never tracks multiple active worktrees simultaneously.
 
 5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 

--- a/claude/commands/bug.md
+++ b/claude/commands/bug.md
@@ -8,6 +8,6 @@ $ARGUMENTS
 
 **Routing note for DM:** This message was submitted via the `/bug` command. The `INTENT: investigative` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip heuristic classification and fire the Investigative Gate (Tracebloom) directly. Strip the `INTENT: investigative` line before passing the task description to downstream agents.
 
-All standard Phase 0 steps (worktree creation, session variables) still apply. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+Phase 0 (session-variable capture) and the Phase 1 Worktree Creation Subroutine both apply: Phase 0 captures session variables, and because `INTENT: investigative` is set, the Intent Override branch invokes the Worktree Creation Subroutine before firing the Investigative Gate. All other Phase 1 gates apply normally. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
 
 If the task description above is empty (user provided no arguments), ask the user to describe the bug before proceeding.

--- a/claude/commands/feature.md
+++ b/claude/commands/feature.md
@@ -8,6 +8,6 @@ $ARGUMENTS
 
 **Routing note for DM:** This message was submitted via the `/feature` command. The `INTENT: constructive` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly). Strip the `INTENT: constructive` line before passing the task description to downstream agents.
 
-All standard Phase 0 steps (worktree creation, session variables) still apply. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
+Phase 0 (session-variable capture) and the Phase 1 Worktree Creation Subroutine both apply: Phase 0 captures session variables, and because `INTENT: constructive` is set, the Intent Override branch invokes the Worktree Creation Subroutine before proceeding to the Intake Gate. All other Phase 1 gates (Intake, Explore-Options, etc.) apply normally. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.
 
 If the task description above is empty (user provided no arguments), ask the user to describe the feature before proceeding.

--- a/claude/references/dm-routing-examples.md
+++ b/claude/references/dm-routing-examples.md
@@ -26,7 +26,7 @@ Action:
 Example 2:
 User asks: "Rename this variable in one file."
 Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree (always required — no exceptions)
+- **Phase 1 Worktree Creation Subroutine:** DM invokes the subroutine, which delegates to Bitsmith to create the worktree (constructive intent inferred from the rename request)
 - Skip Pathfinder if clearly trivial (single-step, no ambiguity)
 - Delegate directly to Bitsmith
 - **Implementation Review:** For trivial changes, run Ruinor only (mandatory baseline still applies). Skip specialist reviewers.
@@ -87,7 +87,7 @@ Action:
 Example 6:
 User asks: "Add OAuth login" (while another DM session is already working on an unrelated issue)
 Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/feat-add-oauth-login` on branch `feat/add-oauth-login`
+- **Phase 1 Worktree Creation Subroutine:** DM invokes the subroutine, which delegates to Bitsmith to create the worktree at `.worktrees/feat-add-oauth-login` on branch `feat/add-oauth-login` (constructive intent)
 - All subsequent Pathfinder, Bitsmith, and Quill delegation prompts include:
   `WORKING_DIRECTORY: {REPO_ROOT}/.worktrees/feat-add-oauth-login`
   `WORKTREE_BRANCH: feat/add-oauth-login`
@@ -116,7 +116,7 @@ Action:
 Example 8:
 User asks: "Why is the background job queue dropping tasks silently?"
 Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree at `.worktrees/fix-job-queue-drops` on branch `fix/job-queue-drops`
+- **Phase 1 Worktree Creation Subroutine:** DM invokes the subroutine (because `/bug` sets `INTENT: investigative`), which delegates to Bitsmith to create the worktree at `.worktrees/fix-job-queue-drops` on branch `fix/job-queue-drops`. The Investigative Gate then fires per the Intent Override
 - **Phase 1, step 1:** DM clarifies goal: "Determine why enqueued background jobs are silently dropped."
 - **Investigative Gate triggers** (investigative question: "why is X happening?", no known cause, no plan; Intake and Explore-Options gates do not fire)
 - Invoke Tracebloom with symptom: "background job queue dropping tasks silently"
@@ -132,7 +132,7 @@ Action:
 Example 9:
 User asks: "Add webhook support for payment events"
 Action:
-- **Phase 0:** DM delegates to Bitsmith to create worktree
+- **Phase 1 Worktree Creation Subroutine:** DM invokes the subroutine, which delegates to Bitsmith to create the worktree (constructive intent)
 - **Phase 1:** Task is clear and well-specified — no Tracebloom, no Askmaw
 - DM invokes Pathfinder (first invocation)
 - Pathfinder researches codebase, reaches Section 4 (Scope Confirmation), returns scope output to DM:
@@ -153,11 +153,11 @@ User asks (via /ask): "How does the session isolation work with worktrees?"
 Action:
 - **Intent override fires:** `INTENT: advisory`. Log: "Intent override: advisory. Heuristic classification skipped."
 - **Session variables captured:** `SESSION_TS` = `20260401-143022`, `SESSION_SLUG` = `session-isolation-worktrees`
-- **Phase 0 worktree creation skipped** — advisory sessions do not create worktrees or plans
+- **Phase 1 Worktree Creation Subroutine not invoked** — advisory branches do not invoke the subroutine, so no worktree or plan is created
 - **Phase A:** Question classified as "How does X work in this codebase?" → select Tracebloom
 - **Phase B:** Invoke Tracebloom with advisory research request: "How does the session isolation work with worktrees?"
-- Tracebloom returns findings: Phase 0 creates an isolated git worktree per session at `.worktrees/{branch-slug}`, all sub-agents receive WORKING_DIRECTORY context, worktree is cleaned up in Phase 5e
-- **Phase C:** DM synthesises Tracebloom's findings into a direct answer, attributing codebase references. Sources: `claude/agents/dungeonmaster.md` (Phase 0 section), `claude/references/worktree-protocol.md`
+- Tracebloom returns findings: the Phase 1 Worktree Creation Subroutine creates an isolated git worktree at `.worktrees/{branch-slug}` when invoked by a routing branch (advisory branches do not invoke it), Phase 0 captures session variables only, all sub-agents receive WORKING_DIRECTORY context, worktree is cleaned up in Phase 5e
+- **Phase C:** DM synthesises Tracebloom's findings into a direct answer, attributing codebase references. Sources: `claude/agents/dungeonmaster.md` (Phase 0 and Phase 1 Worktree Creation Subroutine), `claude/references/worktree-protocol.md`
 - Session complete — no review, no plan, no PR prompt
 
 Example 11:
@@ -165,7 +165,7 @@ User asks (via /ops): "What authentication patterns are used in this codebase?"
 Action:
 - **Intent override fires:** `INTENT: advisory --save-report`. Log: "Intent override: advisory. Heuristic classification skipped." Capture `--save-report` as active workflow flag. Strip `INTENT: advisory --save-report` from message.
 - **Session variables captured:** `SESSION_TS` = `20260413-110000`, `SESSION_SLUG` = `auth-patterns-codebase`
-- **Phase 0 worktree creation skipped** — advisory sessions do not create worktrees or plans
+- **Phase 1 Worktree Creation Subroutine not invoked** — advisory branches do not invoke the subroutine, so no worktree or plan is created
 - **Phase A:** Question classified as "How does X work in this codebase?" → select Tracebloom
 - **Phase B:** Invoke Tracebloom with advisory research request: "What authentication patterns are used in this codebase?"
 - Tracebloom returns findings on auth patterns used in the codebase

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -4,7 +4,7 @@
 
 The Dungeon Master orchestration agent now supports **parallel isolated sessions** via Git worktrees. This feature enables multiple simultaneous `claude --agent dungeonmaster` terminals to work on unrelated issues without git conflicts or interference.
 
-Each DungeonMaster session automatically creates a dedicated git worktree on an isolated branch, ensuring clean separation of concerns and enabling truly parallel development workflows.
+Each constructive or investigative DungeonMaster session automatically creates a dedicated git worktree on an isolated branch, ensuring clean separation of concerns and enabling truly parallel development workflows.
 
 ## Quick Start
 
@@ -18,10 +18,11 @@ claude --agent dungeonmaster
 ```
 
 The session automatically:
-1. Creates an isolated git worktree at `.worktrees/dm-add-oauth-login/`
-2. Creates a dedicated branch `dm/add-oauth-login`
-3. Executes all planning, implementation, and reviews within that worktree
-4. Logs the branch as ready at completion; run `/open-pr` to create a pull request or handle cleanup manually
+1. Captures session variables (Phase 0)
+2. Creates an isolated git worktree at `.worktrees/feat-add-oauth-login/` (Phase 1)
+3. Creates a dedicated branch `feat/add-oauth-login`
+4. Executes all planning, implementation, and reviews within that worktree
+5. Logs the branch as ready at completion; run `/open-pr` to create a pull request or handle cleanup manually
 
 In another terminal, start a second DungeonMaster session:
 
@@ -31,57 +32,63 @@ claude --agent dungeonmaster
 ```
 
 Both sessions operate independently:
-- Session 1 works on branch `dm/add-oauth-login` in `.worktrees/dm-add-oauth-login/`
-- Session 2 works on branch `dm/fix-db-perf-issue-42` in `.worktrees/dm-fix-db-perf-issue-42/`
+- Session 1 works on branch `feat/add-oauth-login` in `.worktrees/feat-add-oauth-login/`
+- Session 2 works on branch `fix/db-perf-issue-42` in `.worktrees/fix-db-perf-issue-42/`
 - No git conflicts, no interference, completely isolated development
 
 ## How It Works
 
-### Worktree Creation (Phase 0)
+### Phase 0: Session Variable Capture
 
-DM performs **Phase 0: Session Isolation** before any planning. Branch names follow the pattern `dm/{slugified-task}` (e.g., "Add OAuth login" → `dm/add-oauth-login`). See `claude/agents/dungeonmaster.md` for the full Phase 0 specification.
+DM performs **Phase 0: Session Isolation** before any other work. Phase 0 only captures three session-scoped variables in conversation memory — no worktree is created here:
 
-### Skip Conditions
+- `SESSION_TS` — current local time formatted as `YYYYMMDD-HHmmss`
+- `SESSION_SLUG` — the task description slugified (lowercase, alphanumeric and hyphens, max 40 characters)
+- `REPO_SLUG` — the repository directory name (used to namespace plan files)
 
-Phase 0 (worktree creation) is **skipped** if:
+Phase 0 also includes a **re-entry guard** that detects when a free-form follow-up message is continuing an existing session (e.g., adding scope to an in-flight feature). When a continuation is detected, Phase 0 is skipped entirely and the session proceeds directly to Phase 1 with the existing context. Slash-command invocations (`/feature`, `/bug`, `/ask`, `/ops`) always bypass the guard and start a fresh session boundary.
 
-- The `--no-worktree` flag is provided
-- The task is trivially single-file (identified early as not needing Pathfinder)
+### Phase 1: Worktree Creation Subroutine
 
-Examples:
+Worktree creation happens in **Phase 1**, not Phase 0. After intent classification, the routing branch invokes the **Worktree Creation Subroutine** when required. This subroutine:
 
-```bash
-# Explicitly skip worktree creation (operate in main working tree)
-claude --agent dungeonmaster --no-worktree
-# Prompt: "Fix typo in README.md"
+1. Derives a branch name using a conventional commit prefix: `{type}/{slugified-task}` — for example, "Add OAuth login" → `feat/add-oauth-login`, "Fix null pointer in auth" → `fix/null-pointer-auth`, "Refactor cache layer" → `refactor/cache-layer`. The prefix is inferred from the nature of the request (`feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `test/`).
+2. Delegates `git worktree add` to Bitsmith (the DM's Bash scope is read-only; write operations are always delegated).
+3. Sets `WORKTREE_PATH` and `WORKTREE_BRANCH` in conversation memory for the remainder of the session.
+4. Logs: "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 
-# Trivial task: worktree skipped automatically
-claude --agent dungeonmaster
-# Prompt: "Rename AuthContext to AuthProvider in one file"
-```
+See `claude/agents/dungeonmaster.md` for the full subroutine specification.
 
-**Late initialization:** If DungeonMaster initially skips worktree creation but later determines the task is non-trivial (e.g., decides to invoke Pathfinder), it creates the worktree at that point before proceeding.
+### When a Worktree is Created vs. Not Created
+
+The subroutine is invoked **only by routing branches that require implementation work**. Advisory sessions never invoke it:
+
+| Session type | Worktree created? |
+|---|---|
+| Constructive (`/feature`, free-form feature request) | Yes — subroutine invoked in Phase 1 |
+| Investigative (`/bug`, free-form "why is X broken?") | Yes — subroutine invoked in Phase 1 |
+| Advisory (`/ask`, `/ops`, free-form questions) | No — advisory branches do not invoke the subroutine |
+
+Advisory sessions (`INTENT: advisory`) bypass the constructive/investigative pipeline entirely. They capture session variables in Phase 0 but never proceed to a routing branch that invokes the subroutine. No worktree, no plan file, no code changes.
 
 ### Worktree Structure
 
-After Phase 0 completes, your repository structure looks like:
+After the subroutine completes, your repository structure looks like:
 
 ```
 .
-├── .git/                    # Main repo git directory (shared across worktrees)
-├── .worktrees/              # Worktrees directory (gitignored)
-│   ├── dm-add-oauth-login/  # Session 1 worktree
-│   │   ├── .git            # Pointer to main .git (shared objects)
-│   │   ├── plans/           # Local plans (gitignored)
+├── .git/                        # Main repo git directory (shared across worktrees)
+├── .worktrees/                  # Worktrees directory (gitignored)
+│   ├── feat-add-oauth-login/    # Session 1 worktree
+│   │   ├── .git                 # Pointer to main .git (shared objects)
 │   │   ├── src/
 │   │   └── ...
-│   └── dm-fix-db-perf/      # Session 2 worktree
+│   └── fix-db-perf-issue-42/    # Session 2 worktree
 │       ├── .git
-│       ├── plans/
 │       └── ...
 ├── src/
-├── plans/                   # Main repo plans (gitignored)
-└── .gitignore               # Contains .worktrees/ and plans/
+├── ~/.ai-tpk/plans/{repo-slug}/ # Plans (user-scoped, outside repo)
+└── .gitignore                   # Contains .worktrees/
 ```
 
 ## Managing Worktrees
@@ -97,11 +104,11 @@ git worktree list
 Output example:
 
 ```
-/path/to/repo                 abc1234 [main]
-/path/to/repo/.worktrees/dm-add-oauth-login
-                              def5678 [dm/add-oauth-login]
-/path/to/repo/.worktrees/dm-fix-db-perf
-                              ghi9012 [dm/fix-db-perf]
+/path/to/repo                     abc1234 [main]
+/path/to/repo/.worktrees/feat-add-oauth-login
+                                  def5678 [feat/add-oauth-login]
+/path/to/repo/.worktrees/fix-db-perf-issue-42
+                                  ghi9012 [fix/db-perf-issue-42]
 ```
 
 ### Cleanup
@@ -113,40 +120,27 @@ Use standard git worktree commands to remove stale worktrees and branches:
 ```bash
 git worktree remove .worktrees/{slug}
 git worktree prune
-git branch -d dm/{slug}
+git branch -d feat/{slug}
 ```
 
-## Suppressing Worktree Creation
-
-If you want to suppress worktree creation and work directly in the main working tree, use the `--no-worktree` flag:
-
-```bash
-claude --agent dungeonmaster --no-worktree
-# Prompt: "Add OAuth login"
-```
-
-With `--no-worktree`:
-- DungeonMaster operates in the main working tree
-- Plans are saved to `plans/` (main repo)
-- No `.worktrees/` directory is used
-- Useful for analysis-only sessions or read-only work
-- Backwards compatible with pre-worktree workflow
+Or use the `/merged` command after a PR is merged — it removes the worktree and local branch automatically.
 
 ## Worktree Awareness in Sub-Agents
 
-When a DungeonMaster session has an active worktree, all sub-agents (Pathfinder, Bitsmith, Quill) automatically receive worktree context:
+When a DungeonMaster session has an active worktree, all sub-agents (Pathfinder, Bitsmith, Quill, Tracebloom) automatically receive worktree context:
 
 ```
-WORKING_DIRECTORY: /absolute/path/to/.worktrees/dm-add-oauth-login
-WORKTREE_BRANCH: dm/add-oauth-login
+WORKING_DIRECTORY: /absolute/path/to/.worktrees/feat-add-oauth-login
+WORKTREE_BRANCH: feat/add-oauth-login
 All file operations and Bash commands must use this directory as the working root.
 ```
 
 Sub-agents respect this context:
 
-- **Pathfinder:** Writes plans to `{WORKING_DIRECTORY}/plans/` instead of the main repo's `plans/`
-- **Bitsmith:** Performs all code changes within the worktree, commits land on the worktree's branch
+- **Pathfinder:** Writes plans to `~/.ai-tpk/plans/{REPO_SLUG}/` (user-scoped, not worktree-relative)
+- **Bitsmith:** Performs all code changes within the worktree; commits land on the worktree's branch
 - **Quill:** Writes documentation updates relative to the worktree
+- **Tracebloom:** Reads files from the worktree when investigating
 
 ### Bitsmith's Path Mismatch Guard
 
@@ -157,15 +151,15 @@ Bitsmith includes a safeguard that prevents silent writes to the main working tr
 At session completion (Phase 5), DungeonMaster logs a status line and leaves the worktree and branch intact:
 
 ```
-Branch `dm/add-oauth-login` is ready at `.worktrees/dm-add-oauth-login`.
+Branch `feat/add-oauth-login` is ready at `.worktrees/feat-add-oauth-login`.
 Run `/open-pr` to create a pull request, or handle cleanup manually.
 ```
 
 No interactive prompt is shown. The worktree is never removed automatically. When you are ready to create a PR, run `/open-pr` in the same session or a new session. When you are done with the worktree, clean up manually:
 
 ```bash
-git worktree remove .worktrees/dm-add-oauth-login
-git branch -d dm/add-oauth-login
+git worktree remove .worktrees/feat-add-oauth-login
+git branch -d feat/add-oauth-login
 ```
 
 ## Example: Two Parallel Sessions
@@ -178,13 +172,14 @@ git branch -d dm/add-oauth-login
 $ claude --agent dungeonmaster
 > Add OAuth login to the authentication system
 ...
-[DungeonMaster creates .worktrees/dm-add-oauth-login/ on branch dm/add-oauth-login]
-[Pathfinder creates plan at .worktrees/dm-add-oauth-login/plans/oauth-plan.md]
+[Phase 0: session variables captured]
+[Phase 1: Worktree Creation Subroutine creates .worktrees/feat-add-oauth-login/ on branch feat/add-oauth-login]
+[Pathfinder creates plan at ~/.ai-tpk/plans/{repo-slug}/20260401-143022-add-oauth-login.md]
 [Bitsmith implements OAuth in the worktree]
 [Ruinor and Riskmancer review in the worktree context]
 [Quill updates documentation in the worktree]
 ...
-Branch `dm/add-oauth-login` is ready at `.worktrees/dm-add-oauth-login`. Run `/open-pr` to create a pull request, or handle cleanup manually.
+Branch `feat/add-oauth-login` is ready at `.worktrees/feat-add-oauth-login`. Run `/open-pr` to create a pull request, or handle cleanup manually.
 ```
 
 ### Session 2: Database Performance
@@ -195,41 +190,43 @@ Branch `dm/add-oauth-login` is ready at `.worktrees/dm-add-oauth-login`. Run `/o
 $ claude --agent dungeonmaster
 > Fix slow database queries on issue #42
 ...
-[DungeonMaster creates .worktrees/dm-fix-db-perf-issue-42/ on branch dm/fix-db-perf-issue-42]
-[Pathfinder creates plan at .worktrees/dm-fix-db-perf-issue-42/plans/db-optimization.md]
+[Phase 0: session variables captured]
+[Phase 1: Worktree Creation Subroutine creates .worktrees/fix-db-perf-issue-42/ on branch fix/db-perf-issue-42]
+[Pathfinder creates plan at ~/.ai-tpk/plans/{repo-slug}/20260401-144500-fix-db-perf-issue-42.md]
 [Bitsmith implements query fixes in the worktree]
 [Ruinor and Windwarden review in the worktree context]
 ...
-Branch `dm/fix-db-perf-issue-42` is ready at `.worktrees/dm-fix-db-perf-issue-42`. Run `/open-pr` to create a pull request, or handle cleanup manually.
+Branch `fix/db-perf-issue-42` is ready at `.worktrees/fix-db-perf-issue-42`. Run `/open-pr` to create a pull request, or handle cleanup manually.
 ```
 
 **Result:**
-- Session 1: Branch `dm/add-oauth-login` preserved at `.worktrees/dm-add-oauth-login`; run `/open-pr` when ready
-- Session 2: Branch `dm/fix-db-perf-issue-42` preserved at `.worktrees/dm-fix-db-perf-issue-42`; run `/open-pr` when ready
+- Session 1: Branch `feat/add-oauth-login` preserved at `.worktrees/feat-add-oauth-login`; run `/open-pr` when ready
+- Session 2: Branch `fix/db-perf-issue-42` preserved at `.worktrees/fix-db-perf-issue-42`; run `/open-pr` when ready
 - Main branch untouched until you merge or create a PR
 - Zero git conflicts between sessions
+
+## Advisory Sessions: No Worktree
+
+Advisory sessions (triggered via `/ask`, `/ops`, or any free-form question classified as advisory) never create a worktree:
+
+```bash
+$ claude --agent dungeonmaster
+> How does the session isolation work with worktrees?
+...
+[Phase 0: session variables captured]
+[Advisory branch: Worktree Creation Subroutine not invoked]
+[DM answers directly via Phases A-B-C — no plan, no code, no worktree]
+```
+
+The advisory workflow bypasses the entire constructive/investigative pipeline. No `.worktrees/` entry is created, no branch is created, and no plan file is written.
 
 ## Workflow Flags Summary
 
 | Flag | Effect | Use Case |
 |------|--------|----------|
-| `--no-worktree` | Suppress worktree creation; operate in main working tree | Read-only analysis, single-file trivial changes, explicit backwards compatibility |
-| `--explore-options` | Trigger options exploration before execution planning | Architectural decisions, technology selection, multiple viable paths |
+| `--explore-options` | Scope-exploration mode: invoke Pathfinder to surface scope and implementation options, then stop before plan generation until the user confirms | Architectural decisions, technology selection, multiple viable paths |
 
-You can combine flags:
-
-```bash
-claude --agent dungeonmaster --no-worktree --explore-options
-```
-
-## Backwards Compatibility
-
-This feature is **fully backwards compatible**:
-
-- Sessions without `--no-worktree` automatically get worktree isolation
-- Sessions with `--no-worktree` behave exactly like pre-worktree DM sessions
-- Existing workflows are unaffected
-- The `.worktrees/` directory is already gitignored
+Note: the `--explore-options` flag is a constructive-pipeline flag. It has no effect when the session is classified as advisory (`INTENT: advisory`).
 
 ## Troubleshooting
 
@@ -238,27 +235,27 @@ This feature is **fully backwards compatible**:
 If you see this error during worktree creation:
 
 ```
-fatal: 'dm/add-oauth-login' already exists.
+fatal: 'feat/add-oauth-login' already exists.
 ```
 
 **Solution:** The branch already exists from a previous session. Either:
 
-1. Delete the stale branch: `git branch -D dm/add-oauth-login`
-2. Use `--no-worktree` to operate in the main tree for this session
-3. Start a new session with a different task description
+1. Delete the stale branch: `git branch -D feat/add-oauth-login`
+2. Start a new session with a different task description
+3. Use `/clean-the-desk` to remove merged branches and their worktrees in bulk
 
-DungeonMaster retries with a numeric suffix (e.g., `dm/add-oauth-login-2`) after 3 attempts before falling back to the main working tree.
+DungeonMaster retries with a numeric suffix (e.g., `feat/add-oauth-login-2`) after 3 attempts before falling back to the main working tree.
 
 ### Stale or Crashed Worktrees
 
-If a session crashes before Phase 5, use the Cleanup commands above to remove the orphaned worktree and branch.
+If a session crashes before Phase 5, use the cleanup commands above to remove the orphaned worktree and branch.
 
 ### Worktree on Wrong Branch
 
 If you manually switch branches within a worktree, git may confuse the worktree state. To fix:
 
 ```bash
-git worktree remove .worktrees/dm-corrupted-task
+git worktree remove .worktrees/feat-corrupted-task
 git worktree prune
 ```
 
@@ -281,7 +278,7 @@ Git worktrees provide a lightweight solution:
 - Worktrees share git object storage (efficient)
 - Cleanup is simple: `git worktree remove`
 
-This enables truly parallel development workflows where multiple issues can be worked on simultaneously without manual coordination.
+Deferring worktree creation to Phase 1 (rather than Phase 0) means advisory sessions never incur the cost of worktree creation, and re-entry guard continuations don't redundantly create a second worktree for an already-established session.
 
 ## Best Practices
 
@@ -294,16 +291,13 @@ This enables truly parallel development workflows where multiple issues can be w
 3. **Clean up worktrees after completion**
    - Stale worktrees consume disk space
    - `git worktree remove` is quick and safe
+   - `/merged` automates cleanup after a PR is merged
 
 4. **Run `/open-pr`** to create a pull request when your branch is ready
    - The worktree stays active for feedback iteration after the PR is created
    - Delete the worktree when the PR is merged
 
 5. **Merge manually** when you are confident the work needs no review — then remove the worktree and branch (see Cleanup section above).
-
-6. **Use `--no-worktree`** only for trivial changes
-   - Most tasks benefit from worktree isolation
-   - Only skip when explicitly needed (read-only work)
 
 ## Related Documentation
 


### PR DESCRIPTION
Phase 0 previously created a git worktree unconditionally at session start, before intent was known. This caused advisory sessions to silently create dangling worktrees, and scope extensions after Phase 5e completion to spawn duplicate branches instead of reusing the active one.

Fix 1 adds a re-entry guard to Phase 0: free-form follow-up messages within an established session skip Phase 0 and reuse the existing worktree; slash-command invocations always start a fresh session boundary.

Fix 2 moves worktree creation into a Phase 1 callable subroutine invoked explicitly by the 5 routing branches that need a worktree (investigative, constructive, ambiguous). Advisory branches never invoke it. Updates feature.md, bug.md, dm-routing-examples.md, docs/WORKTREE_ISOLATION.md, and README.md for consistency.