### PR TITLE
docs: fix stale references, paths, and incorrect facts in docs

### DIFF
--- a/.claude/skills/agent-creator/SKILL.md
+++ b/.claude/skills/agent-creator/SKILL.md
@@ -359,10 +359,10 @@ tools: "Read, Write, Grep, Glob, Bash, Agent"
 - Agent tool for delegating research
 - Explicitly states "You never implement. You plan."
 - Structured interview workflow
-- Saves plans to specific location (`plans/*.md`)
+- Saves plans to specific location (`~/.ai-tpk/plans/{repo-slug}/*.md`)
 
 **Real example from Pathfinder:**
-> "Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/*.md`. You never implement code. You plan."
+> "Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `~/.ai-tpk/plans/{repo-slug}/*.md`. You never implement code. You plan."
 >
 > "When users request 'do X' or 'build X,' interpret this as 'create a work plan for X.'"
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -120,7 +120,7 @@ Quill has a single professional rival: documentation written by someone who clea
 
 <img src="avatars/pathfinder.png" alt="Pathfinder Avatar" width="300">
 
-**Core Mission:** Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `plans/*.md`.
+**Core Mission:** Interview users to gather requirements, research codebases via agents, and produce actionable work plans saved to `~/.ai-tpk/plans/{repo-slug}/`.
 
 **Configuration File:** `/claude/agents/pathfinder.md`
 
@@ -272,5 +272,9 @@ Agent definitions can reference shared behavioral vocabulary defined in `claude/
 - **`claude/references/worktree-protocol.md`** — Shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. Agents load this reference when operating in isolated worktrees to ensure consistent path handling.
 - **`claude/references/dm-routing-examples.md`** — 11 worked routing examples for the Dungeon Master, covering multi-step plans, trivial changes, user flags, explore-options, worktrees, intake, investigation, scope confirmation, advisory queries, and ops reports. The DM loads this reference at runtime rather than embedding the examples inline in its system prompt.
 - **`claude/references/completion-templates.md`** — Four rigid per-command completion report templates (A: Constructive, B: Investigative, C: Operational PR, D: Post-Merge) and a shared Common Fields block. The DM output contract and `/open-pr`, `/merged`, `/merge-pr` commands all reference this file to ensure consistent, parseable completion output across sessions.
+
+- **`claude/references/bash-style.md`** — Required Bash command style guide for all agents with Bash tool access. Defines enforced rules: no compound commands, no process substitution, no `--no-verify` on git commands, and no command substitution in git commit commands.
+
+- **`claude/references/quill-documentation-style.md`** — Documentation style guide used by Quill when authoring and updating documentation.
 
 When modifying these reference files, changes apply automatically to all agents that load them, eliminating the need to update redundant constraints across multiple agent definitions.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -231,6 +231,14 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`completion-templates.md`** — Four rigid per-command completion report templates and a shared Common Fields block. Defines what the DM must emit at the end of each pipeline: Template A (Constructive, `/feature`), Template B (Investigative, `/bug`), Template C (Operational PR, `/open-pr`), and Template D (Post-Merge, `/merged` and `/merge-pr`). The DM output contract references this file; templates are verbatim formats with no formatting discretion left to the model.
 
+- **`dm-routing-examples.md`** — Worked routing examples for the Dungeon Master, covering multi-step plans, trivial changes, user flags, explore-options, worktrees, intake, investigation, scope confirmation, advisory queries, and ops reports.
+
+- **`github-auth-probe.md`** — Canonical procedure for verifying GitHub account access before pushing or committing. Referenced by the `commit-message-guide` and `open-pull-request` skills.
+
+- **`review-gates.md`** — Shared two-gate review framework (Plan Review Gate and Implementation Review Gate) for all reviewer agents. Defines universal operational constraints and plan-file-scoping rules.
+
+- **`quill-documentation-style.md`** — Documentation style guide used by Quill when authoring and updating documentation.
+
 When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
 
 ## MCP Servers
@@ -269,8 +277,8 @@ myclaude
 
 The wizard will present a multi-step flow:
 
-1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana, CloudWatch, and/or GCP Observability)
-2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch; GCP project ID for GCP Observability)
+1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana, CloudWatch, GCP Observability, and/or Kubernetes)
+2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch; GCP project ID for GCP Observability; kube context for Kubernetes)
 3. **Launch** — Claude opens with `--agent dungeonmaster` and the correct environment variables set
 
 **Persistence:** Your last-used selections are saved to `~/.config/myclaude/config.json` and pre-fill the wizard on your next run. You can accept them with Enter or change them.
@@ -324,6 +332,12 @@ When "GCP Observability" is selected, the launcher runs `gcloud projects list` t
 
 **Note:** `GOOGLE_CLOUD_PROJECT` is used by the auth library for project ID resolution only — it does not auto-populate tool call parameters. Specify `resourceNames`, `parent`, `name`, or `projectId` explicitly in each tool call. The wrapper prints the active project to stderr as a context hint for Claude.
 
+### Kubernetes Configuration
+
+**Prerequisite:** `kubectx` must be installed and on `PATH`; the launcher exits with an error if it is missing.
+
+When "Kubernetes" is selected, the launcher runs `kubectx` to list available contexts and prompts you to select one. The selected context name is stored in `~/.claude/.current-kube-context` and exported as `K8S_CONTEXT` for the Kubernetes MCP server. If the chosen context differs from the previously saved one, the launcher invokes `kubectx <context>` to switch the active context.
+
 ### Environment Variables Set by myclaude
 
 When you select Grafana with Viewer role, the launcher sets:
@@ -349,6 +363,11 @@ When you select GCP Observability:
 GOOGLE_CLOUD_PROJECT={project_id}
 ```
 
+When you select Kubernetes:
+```
+K8S_CONTEXT={context_name}
+```
+
 These variables are passed to `claude --agent dungeonmaster`, and they flow through to all MCP server subprocesses.
 
 ## Skills (`claude/skills/`)
@@ -362,6 +381,8 @@ Skills are reusable capabilities that enhance Claude's functionality. Three mand
 Additional skills (non-mandatory):
 
 - **`write-reliable-tests`** — Guides authorship and review of deterministic, isolated, and idempotent automated tests across unit, integration, and e2e levels; applied automatically whenever test code is being written or evaluated
+- **`file-organization`** — Guide for file and module organization decisions
+- **`skill-creator`** — Creates and improves skills in this repository
 
 ## Slash Commands
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -20,7 +20,7 @@ Run the installation script:
 ./install.sh
 ```
 
-The installer copies the whitelisted paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `references/`) from `claude/` into `~/.claude/` and, when present, into `~/.cursor/`. Anything else in the repo or on disk under those destinations is left untouched except where those paths are replaced (after a timestamped backup).
+The installer copies the whitelisted paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `hooks/`, `references/`) from `claude/` into `~/.claude/` and, when present, into `~/.cursor/`. Anything else in the repo or on disk under those destinations is left untouched except where those paths are replaced (after a timestamped backup).
 
 The `.claude/` directory is never synced by the installer — it remains project-local.
 


### PR DESCRIPTION
Documentation audit identified 7 stale or incorrect items across 4 files. Fixes include: missing hooks/ in installer description, Kubernetes MCP added to wizard docs with accurate kubectx-based implementation details, 4 missing references and 2 missing skills added to CONFIGURATION.md, 2 missing references and a stale plan file path fixed in AGENTS.md, and stale plan paths corrected in the agent-creator skill.