### PR TITLE
feat(dungeonmaster): add documentation-primary routing for doc-only plans

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -467,8 +467,25 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 ### Phase 3: Execution
 
+**Phase 3 routing decision:** Determine the Phase 3 execution agent by reading the plan file frontmatter. The plan file path is the value `{PLAN_FILE_PATH}` returned by Pathfinder in Phase 1 step 4 (do not reconstruct the path from session variables; use the value Pathfinder gave you). Run the following read-only Bash command, substituting the actual plan file path:
+
+`head -n 5 {PLAN_FILE_PATH} | grep -c '^documentation-primary: true$' || true`
+
+The trailing `|| true` ensures `grep -c`'s exit code 1 (no matches) does not propagate as a shell failure — the relevant signal is the printed count, not the exit code.
+
+- If the command outputs `1`: the plan is documentation-primary; the Phase 3 execution agent is **Quill**. Log: `"Phase 3 routing: Quill (documentation-primary plan detected)."`
+- If the command outputs a value other than `0` or `1`: the frontmatter is malformed (possible duplicate tag); default to **Bitsmith** and log: `"Phase 3 routing: defaulted to Bitsmith (frontmatter check inconclusive: output was <N>, expected 0 or 1)."`
+- If the command outputs `0`: the plan is not documentation-primary; the Phase 3 execution agent is **Bitsmith**. Log: `"Phase 3 routing: Bitsmith."`
+- If the file does not exist or the command fails for any reason: default to **Bitsmith** and log: `"Phase 3 routing: defaulted to Bitsmith (frontmatter check inconclusive: <reason>)."`
+
+This routing decision is **re-derivable on demand** by re-running the same read-only Bash command against `{PLAN_FILE_PATH}`. No in-memory `PHASE_3_AGENT` variable is required or permitted — the plan file frontmatter is the canonical, durable source of truth. If conversation context is interrupted (stalled-loop termination, Phase 4 fix loop re-entry, or any other re-entry into Phase 3 or Phase 5b), re-run the routing check against the plan file rather than relying on memory.
+
+**Backward compatibility:** Existing plan files written before this routing logic was introduced have no frontmatter; the `grep -c` command outputs `0` and routing falls through to Bitsmith — the absence of the tag is the negative signal, so backward compatibility is automatic and no migration of existing plans is required.
+
+This is a read-only Bash usage authorized by DM's read-only scope (see "What the Dungeon Master may do directly" in this file).
+
 1. Convert the approved plan into execution tasks.
-2. Delegate each execution task to Bitsmith or another specialist. Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active. Bitsmith must operate entirely within this directory.
+2. Delegate each execution task to the Phase 3 execution agent determined by the routing decision above (Bitsmith for standard plans, Quill for documentation-primary plans). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active. The chosen agent must operate entirely within this directory. When the routing decision selected Quill, Quill executes the plan steps as the primary writer (Invocation Mode A — see quill.md). The Phase 4 Ruinor review still applies to Quill's output exactly as it would for Bitsmith's output. If a Mode A plan step exceeds Quill's documentation scope (e.g., requires running tests or invoking other agents), Quill returns a structured escalation per its escalation protocol; treat the escalation as you would a Bitsmith structured failure report.
 3. After each delegated task:
     - compare results against the plan
     - decide whether to continue, retry, or adjust
@@ -488,7 +505,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 5. Track implementation artifacts (changed files, new code).
 
-**Note on intermediate review gates:** After every 2 consecutive Bitsmith invocations without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed Bitsmith completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree. The counter resets to zero after each intermediate or Phase 4 Ruinor review, regardless of verdict.
+**Note on intermediate review gates:** After every 2 consecutive execution-agent invocations (whether Bitsmith or Quill) without an intervening Ruinor review, run an intermediate Ruinor review before continuing. Do not accumulate more than 2 unreviewed execution-agent completions in sequence. Phase 4's final Ruinor review remains mandatory even when intermediate reviews have passed during Phase 3. When passing file paths to Ruinor for intermediate reviews, DM must use worktree-absolute paths (e.g., `{WORKING_DIRECTORY}/src/foo.ts`), since Bitsmith operates in the worktree. The counter resets to zero after each intermediate or Phase 4 Ruinor review, regardless of verdict. Note: in documentation-primary plans, Quill typically completes the entire plan in a single invocation (Mode A), so this counter rarely accumulates for Quill; the generalization is a correctness measure, not an expected operational pattern.
 
 ### Phase 4: Implementation Review (Quality Gate)
 
@@ -542,18 +559,20 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     **Verification gate:** If step 5a was triggered (i.e., any reviewer issued ACCEPT-WITH-RESERVATIONS during this session), then before proceeding to step 5b, confirm that `open-questions.md` was actually written by checking the Bitsmith delegation result for success. If the delegation result does not confirm success, re-delegate to Bitsmith before proceeding. If step 5a was not triggered (no ACCEPT-WITH-RESERVATIONS verdicts), skip this gate and proceed directly to step 5b.
 
     **5b — Documentation update:**
-    If Pathfinder was invoked during this session, invoke Quill with the following three context items:
-    - (a) plan file path (e.g., `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{SESSION_SLUG}.md`)
-    - (b) list of files changed during implementation, collected via `git diff --name-only` against the pre-execution commit
-    - (c) one-sentence feature summary
+    **Note:** On post-Resolution-Gate re-invocations triggered from step 5c, skip this re-check and go directly to Branch 3 (see step 5c). The following frontmatter re-check applies only to the initial Phase 5b entry during normal session flow. **Determine the Phase 5b branch** by re-running the same read-only frontmatter check used in Phase 3 (`head -n 5 {PLAN_FILE_PATH} | grep -c '^documentation-primary: true$' || true`). The plan file frontmatter is the canonical source — do not rely on an in-memory variable that may have been lost across context interruption. Then:
+
+    - **Branch 1 — Skip Quill (no planning session):** If Pathfinder was NOT invoked during this session, skip Quill entirely (unchanged from prior behaviour).
+    - **Branch 2 — Skip Quill (already ran in Phase 3):** If Pathfinder was invoked AND the frontmatter check outputs `1` (documentation-primary plan, Phase 3 was Quill), skip the Phase 5b Quill invocation. Quill already produced the documentation as the primary writer in Phase 3; a meta-update would be redundant. Log: `"Phase 5b: Quill skipped — already invoked as Phase 3 primary writer for documentation-primary plan."`
+    - **Branch 3 — Invoke Quill (standard meta-update):** If Pathfinder was invoked AND the frontmatter check outputs `0` (or the check was inconclusive — same fallback as Phase 3), invoke Quill with the following three context items. An output other than `0` or `1` is treated the same as `0` — route to Branch 3 with a logged warning about malformed frontmatter.
+      - (a) plan file path (e.g., `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{SESSION_SLUG}.md`)
+      - (b) list of files changed during implementation, collected via `git diff --name-only` against the pre-execution commit
+      - (c) one-sentence feature summary
 
     Include the `WORKING_DIRECTORY` context block if a session worktree is active. Quill must write documentation relative to this directory.
 
-    If Pathfinder was NOT invoked during this session, skip Quill entirely.
+    **Pre-Quill gate:** (Applies only when Branch 3 fires, i.e., when Phase 5b is actually invoking Quill.) Before invoking Quill, cross-reference all steps in the approved plan against the list of completed Bitsmith delegations. If any plan step has not been executed and reviewed by Ruinor, defer Quill and complete those steps first. Do not invoke Quill based on self-assertion alone.
 
-    **Pre-Quill gate:** Before invoking Quill, cross-reference all steps in the approved plan against the list of completed Bitsmith delegations. If any plan step has not been executed and reviewed by Ruinor, defer Quill and complete those steps first. Do not invoke Quill based on self-assertion alone.
-
-    Quill must only be invoked after Phase 4 implementation review is fully complete and all reviewers have issued ACCEPT or ACCEPT-WITH-RESERVATIONS. If any Bitsmith implementation work is needed after Quill completes — including work triggered by the Resolution Gate (step 5c) — that work must re-enter Phase 4 (Implementation Review) and Quill must be re-invoked afterward. Do not treat post-documentation Bitsmith invocations as pre-reviewed work, and do not skip the Quill re-invocation even if Quill already ran earlier in this session.
+    Quill must only be invoked after Phase 4 implementation review is fully complete and all reviewers have issued ACCEPT or ACCEPT-WITH-RESERVATIONS. If any Bitsmith implementation work is needed after Quill completes — including work triggered by the Resolution Gate (step 5c) — that work must re-enter Phase 4 (Implementation Review) and Quill must be re-invoked afterward. Do not treat post-documentation Bitsmith invocations as pre-reviewed work, and do not skip the Quill re-invocation even if Quill already ran earlier in this session. When Phase 3 routed to Quill (Branch 2 path in Phase 5b), the Phase 4 review of Quill's Phase 3 output satisfies this requirement for the Phase 3 invocation; the Phase 5b skip in Branch 2 does not bypass any review.
 
     **5c — Resolution Gate:**
     This step fires only when step 5a logged ACCEPT-WITH-RESERVATIONS items. If no reservations were logged, skip to step 5d.
@@ -565,7 +584,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     **Auto-fix path** (fires when ALL reservations are MINOR severity):
     - Delegate the fixes to Bitsmith
     - After Bitsmith completes, re-enter Phase 4 (Implementation Review) for the changed files
-    - After Phase 4 completes, re-invoke Quill (step 5b) to update documentation for the new changes — do not skip Quill even if it already ran earlier in this session
+    - After Phase 4 completes, re-invoke Quill (step 5b) to update documentation for the new changes — do not skip Quill even if it already ran earlier in this session. Even when Phase 3 originally routed to Quill (Branch 2 in Phase 5b), post-gate fixes by Bitsmith may have introduced changes that need a Quill meta-update; treat the post-gate Quill re-invocation as Branch 3 (standard meta-update) regardless of the original Phase 3 routing — skip the frontmatter re-check and go directly to Branch 3.
     - Return to step 5a to log any new reservations from the post-gate Phase 4 review (these are logged only — they do not re-trigger this gate per the loop protection rule above)
     - Proceed to step 5d
 
@@ -579,7 +598,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
     1. **Fix now** — delegate fixes to Bitsmith, re-enter Phase 4, re-invoke Quill (step 5b), then proceed to step 5d
     2. **Proceed** — proceed to step 5d as-is; reservations remain logged in the open-questions file from step 5a
 
-    When "Fix now" is selected: after Bitsmith completes and Phase 4 re-review passes, re-invoke Quill (step 5b) before proceeding to step 5d. Do not skip Quill even if it already ran earlier in this session. Log any new post-gate reservations in 5a (logged only, no re-trigger).
+    When "Fix now" is selected: after Bitsmith completes and Phase 4 re-review passes, re-invoke Quill (step 5b) before proceeding to step 5d. Do not skip Quill even if it already ran earlier in this session. Log any new post-gate reservations in 5a (logged only, no re-trigger). Treat this re-invocation as Branch 3 (standard meta-update) regardless of the original Phase 3 routing, since post-gate fixes are always handled by Bitsmith — skip the frontmatter re-check and go directly to Branch 3.
 
     Examples of reservations requiring user decision:
     - Adding a new validation layer the plan did not anticipate (MAJOR — out of original scope)
@@ -594,7 +613,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
       - "no" — no ACCEPT-WITH-RESERVATIONS verdicts were issued
       - "yes — {file path} — resolved" — reservations were logged and resolved (via auto-fix or user-requested "Fix now")
       - "yes — {file path} — unresolved" — reservations were logged and the user chose "Proceed" in the Resolution Gate, or the gate did not fire due to loop protection
-    - **Documentation:** "updated by Quill" if Quill was invoked in 5b; "skipped (no planning session)" otherwise.
+    - **Documentation:** "updated by Quill (Phase 5b meta-update)" if Quill was invoked in 5b (Branch 3); "produced by Quill (Phase 3 primary writer, documentation-primary plan)" if Quill was invoked in Phase 3 and Phase 5b was skipped via Branch 2; "skipped (no planning session)" if Pathfinder was not invoked (Branch 1).
 
     If notable coordination issues, repeated escalations, or review loops occurred during this session, suggest: "Consider invoking Everwise to analyze these patterns across sessions."
 

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -186,10 +186,25 @@ Once requirements are clear and research is complete:
 4. Avoid vagueness (not "step 1: implement")
 5. Get explicit user confirmation before finalizing (skip this step when `REVISION_MODE: true` is active — save the revised plan directly). Note: this confirmation covers the execution steps (the *how*); the Section 4 Scope Confirmation covered the objective and approach (the *what*). Both serve distinct purposes and both are intentional.
 6. For steps with behavioral acceptance criteria (i.e., "given X, the system should do Y"), add `**test-first:** true` to signal Bitsmith to write a failing test before implementing. Do not annotate steps whose acceptance criteria are purely structural (e.g., "file exists," "config is valid YAML," "directory is created"). See `claude/references/implementation-standards.md` for the full test-first protocol that Bitsmith follows when this annotation is present.
+7. **Documentation-primary detection.** After all Task Flow steps are drafted, classify each step by the file types its TODOs modify, applying the following two-clause rule:
+   - **Inclusion clause (what counts as documentation):** A file is documentation if its primary audience is end users or external developers. The canonical set is: `*.md` files under `docs/`, `examples/`, or `tutorials/`; top-level `README*` files; top-level `CHANGELOG*` files; top-level `CONTRIBUTING*` files; top-level `CODE_OF_CONDUCT*` files; top-level `LICENSE*` files; top-level `NOTICE*` files. A step is 'documentation-only' if every file it modifies is in this set.
+   - **Exclusion clause (operational `.md` files that are NOT documentation):** The following `.md` files are operational artifacts (agent prompts, reference material, skill bodies, GitHub templates), not user-facing documentation, and must NOT be classified as documentation: `claude/agents/*.md`, `claude/references/*.md`, `claude/skills/**/*.md`, `claude/commands/*.md`, `claude/hooks/**/*.md`, `.github/**/*.md` (including PR and issue templates). Steps that modify these files are non-documentation steps regardless of file extension.
+   - **Catch-all:** Any file not explicitly named in the inclusion clause is non-documentation by default. A step is 'non-documentation' if any TODO modifies a non-documentation file (code, configuration, scripts, tests, build files, lockfiles, operational `.md` files per the exclusion clause, or anything else not in the inclusion clause).
+   - **Decision:** If every step in the Task Flow is documentation-only, the plan is documentation-primary; emit the frontmatter tag (next bullet). If any step is non-documentation, the plan is not documentation-primary; do not emit the tag.
+   - When the plan is documentation-primary, prepend the following YAML frontmatter as the literal first content of the plan file — no blank lines, no comments before it — followed by a blank line, then the `# Feature: ...` heading:
+
+     ```
+     ---
+     documentation-primary: true
+     ---
+     ```
+
+     The `documentation-primary: true` line must appear by itself with no leading whitespace and no trailing characters — DM's frontmatter check uses a line-anchored grep (`^documentation-primary: true$`) and any deviation (extra spaces, capitalisation, merged lines) will silently cause the routing to fall back to Bitsmith. When the plan is not documentation-primary, do not emit any frontmatter at all (do not emit `documentation-primary: false` — absence is the negative signal).
+   - When the plan is documentation-primary, do NOT add `**test-first:** true` annotations to any step. Quill has no test framework and the annotation is meaningless in Mode A. The `test-first` annotation in step 6 of this section applies only to non-documentation-primary plans.
 
 ### 6. Pre-Submission Checklist
 
-Before saving the plan, run through all 8 questions below. If any question reveals a deficiency, correct the plan before proceeding to step 7.
+Before saving the plan, run through all 9 questions below. If any question reveals a deficiency, correct the plan before proceeding to step 7.
 
 1. **Per-agent specificity:** Are instructions for each affected file/agent distinct where they differ meaningfully?
 2. **File reference accuracy:** Have you verified section names and line numbers by reading the actual files?
@@ -199,6 +214,7 @@ Before saving the plan, run through all 8 questions below. If any question revea
 6. **Sequencing and dependencies:** Are steps ordered so each prerequisite is satisfied before it is needed?
 7. **Completeness:** Does the plan cover every part of the stated objective with no unexplained gaps?
 8. **Ambiguity test:** Could a careful executor reasonably make a wrong judgement call from any instruction? If yes, rewrite that instruction.
+9. **Documentation-primary classification:** Did you apply the all-or-nothing rule from Section 5 step 7? If every step is documentation-only, is the YAML frontmatter (`---\ndocumentation-primary: true\n---`) present at the top of the plan AND are no `**test-first:** true` annotations present? If any step is non-documentation, is the frontmatter absent? Confirm the inclusion/exclusion clauses were checked — operational `.md` files under `claude/agents/`, `claude/references/`, `claude/skills/`, `claude/commands/`, `claude/hooks/`, `.github/` are NOT documentation.
 
 ### 7. Save Plan
 
@@ -394,7 +410,7 @@ Before considering a plan complete, verify:
 4. ✅ **Explicit user confirmation** - User approved plan before finalizing (skipped in revision mode)
 5. ✅ **Verifiable acceptance criteria** - Every step has clear success measures
 6. ✅ **Open questions tracked** - Nothing ambiguous without documentation
-7. ✅ **Pre-submission checklist passed** - all 8 questions reviewed and any issues corrected before saving
+7. ✅ **Pre-submission checklist passed** - all 9 questions reviewed and any issues corrected before saving
 8. ✅ **Scope confirmed** — User approved scope summary (and selected option if multiple were found) before plan generation (skipped when Askmaw brief, Tracebloom report, or Confirmed Scope block is present — REVISION_MODE skips Sections 3 and 4 entirely — proceed directly to Section 5)
 
 ## Tool Usage

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -18,6 +18,25 @@ See `claude/references/quill-documentation-style.md` for the standing style guid
 
 The core rule: document intent, constraints, and decisions. Do not narrate readable code. When details are already clear in source, point to the code instead of restating it.
 
+## Invocation Modes
+
+Quill has two invocation modes that share the same operational workflow but differ in *when* and *why* Quill is invoked:
+
+- **Mode A — Phase 3 primary writer (documentation-primary plans):** When Pathfinder produces a plan whose Task Flow steps modify only documentation files, the plan begins with `---\ndocumentation-primary: true\n---` YAML frontmatter. DM detects this tag at the start of Phase 3 and routes Phase 3 execution to Quill instead of Bitsmith. In this mode, Quill *produces* the documentation as primary executor of the plan steps. Phase 4 Ruinor review still applies to Quill's output. Phase 5b is skipped for documentation-primary plans (no meta-update needed since Quill already ran as the primary writer). Pathfinder must not emit `**test-first:** true` annotations on documentation-primary plans, so Quill will not encounter that annotation in Mode A; if it does encounter one (a Pathfinder bug), Quill must escalate per the escalation protocol below rather than attempt to honour the annotation.
+
+- **Mode B — Phase 5b post-implementation meta-updater (standard plans):** When the plan is not documentation-primary, DM routes Phase 3 to Bitsmith as usual. After Phase 4 implementation review completes, DM invokes Quill in Phase 5b with the plan, the list of changed files, and a feature summary. In this mode, Quill *updates* documentation to reflect the implementation Bitsmith produced.
+
+The operational workflow (gap analysis, planning, content development, refinement, file generation) is identical in both modes. The difference is purely in invocation context: Mode A treats the plan steps as the work order; Mode B treats the implementation diff as the work order.
+
+**Mode A escalation protocol:** Quill's tool list is limited to documentation-relevant operations (`Read`, `Write`, `Edit`, `Grep`, `Glob`, plus read-only `Bash`) and does not include `Agent`. If a Mode A plan step requires capabilities outside this scope — for example, running tests, invoking other agents, modifying non-documentation files (code, configuration, scripts, lockfiles), executing shell commands beyond read-only inspection, or honouring a `**test-first:** true` annotation — Quill must NOT attempt the step. Instead, return a structured escalation to DM with the following fields:
+- `escalation_reason`: one-line summary (e.g., "Step 3 requires running test suite, outside Quill scope").
+- `failing_step`: the exact step heading from the plan.
+- `required_capability`: the capability needed (e.g., "Bash test execution", "Agent delegation", "edit src/ file").
+- `partial_progress`: list of plan steps Quill completed before the escalation, if any.
+- `recommendation`: suggested next agent (typically Bitsmith) and a one-line rationale.
+
+DM treats the escalation analogously to a Bitsmith structured failure report: route the failing step (and any subsequent steps) to Bitsmith, then resume the plan. This escalation path also applies if Pathfinder misclassifies a plan as documentation-primary when it should not have been.
+
 ## Worktree Awareness
 
 See `claude/references/worktree-protocol.md` for the shared activation rule.

--- a/claude/references/completion-templates.md
+++ b/claude/references/completion-templates.md
@@ -33,7 +33,7 @@ Used for constructive pipeline sessions (e.g., sessions driven by `/feature`).
 **Validation:** {outcome — e.g., "all plan steps completed and passed Ruinor review" | "N steps skipped — see Risks"}
 **Implementation review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"}
 **Reservations logged:** {no | yes — file path — resolved | yes — file path — unresolved}
-**Documentation:** {updated by Quill | skipped (no planning session)}
+**Documentation:** {updated by Quill (Phase 5b meta-update) | produced by Quill (Phase 3 primary writer, documentation-primary plan) | skipped (no planning session)}
 
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
@@ -63,7 +63,7 @@ Used for investigative pipeline sessions (e.g., sessions driven by `/bug`). Exte
 **Validation:** {outcome — e.g., "all plan steps completed and passed Ruinor review" | "N steps skipped — see Risks"}
 **Implementation review:** Ruinor {verdict} | Specialists: {list with verdicts, or "none invoked"}
 **Reservations logged:** {no | yes — file path — resolved | yes — file path — unresolved}
-**Documentation:** {updated by Quill | skipped (no planning session)}
+**Documentation:** {updated by Quill (Phase 5b meta-update) | produced by Quill (Phase 3 primary writer, documentation-primary plan) | skipped (no planning session)}
 
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -249,7 +249,13 @@ He wears the dark *koromo* of a Zen monk, bound at the waist with a rope cord. H
 
 ## Documentation Integration
 
-The Dungeon Master orchestration agent automatically invokes Quill (documentation specialist) in Phase 5 (Completion) when a planning session was conducted. Quill runs as step 5b — after reservations are logged (5a) but before the Resolution Gate (5c) and completion summary (5d). Quill receives the plan file, list of changed files, and feature summary, then updates documentation to reflect the implementation. If the Resolution Gate triggers post-gate Bitsmith work, Quill is re-invoked after the follow-up Phase 4 review. This ensures documentation stays synchronized with code without manual effort.
+Quill (documentation specialist) has two invocation modes within the DM pipeline:
+
+**Mode A — Phase 3 primary writer (documentation-primary plans):** When Pathfinder produces a plan whose every step modifies only documentation files (READMEs, changelogs, `docs/` content, and similar user-facing files — not operational agent or reference files), Pathfinder emits a `documentation-primary: true` YAML frontmatter tag in the plan file. DM reads this tag at the start of Phase 3 and routes execution to Quill instead of Bitsmith. Phase 4 Ruinor review still applies to Quill's output. Phase 5b is skipped — Quill already produced the documentation as primary writer.
+
+**Mode B — Phase 5b post-implementation meta-updater (standard plans):** For plans that include any non-documentation work, DM routes Phase 3 to Bitsmith as usual. After Phase 4 implementation review passes, DM invokes Quill in step 5b — after reservations are logged (5a) but before the Resolution Gate (5c) and completion summary (5d). Quill receives the plan file, list of changed files, and a feature summary, then updates documentation to reflect Bitsmith's implementation. If the Resolution Gate triggers post-gate Bitsmith fixes, Quill is re-invoked afterward as a standard meta-update (Mode B) regardless of the original Phase 3 routing.
+
+This ensures documentation stays synchronized with code without manual effort, and that documentation-only plans are handled directly by the documentation specialist rather than routed through Bitsmith.
 
 ## Session Logging
 


### PR DESCRIPTION
When a plan's every step modifies only user-facing documentation files, Pathfinder now emits a YAML frontmatter tag that routes Phase 3 execution to Quill instead of Bitsmith, and suppresses the redundant Phase 5b Quill meta-update. This eliminates the circular 'docs about docs' redundancy when using /feature for documentation-only work. Quill gains a formal dual-role definition (Mode A primary writer vs Mode B meta-updater) with an escalation protocol for plan steps that exceed its tool scope.