### PR TITLE
docs: replace duplicate agent-spec content with cross-references

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -224,7 +224,8 @@ When the data is insufficient, she says so plainly and records a candidate for f
 
 ### Everwise Scout: Subagent Transcript Drill-Down
 
-Everwise now includes Scout, a selective transcript analysis capability. When chronicle analysis identifies specific anomalies—REJECT verdicts, repeated REVISE loops (3+), rapid re-invocations (<60 seconds), unresolved escalations, or anomalous agent routing—Everwise can dynamically discover and read raw Claude Code subagent JSONL transcripts to understand what actually happened beyond the chronicle's metadata. Scout uses a two-pass reading algorithm with a 20-line cap per transcript and a 3-transcript budget per session, keeping context consumption bounded while providing ground-truth behavioral evidence. This capability works in full graceful degradation mode when `~/.claude/` data is unavailable.
+**Scout (Selective Transcript Analysis)**
+Everwise includes Scout, a selective transcript-analysis capability. When chronicle analysis identifies anomalies, Scout reads raw Claude Code subagent JSONL transcripts to understand what actually happened beyond chronicle metadata. For the authoritative trigger criteria, two-pass reading algorithm, per-transcript line cap, per-session transcript budget, security policies, and graceful-degradation behavior, see [`claude/agents/everwise.md`](/claude/agents/everwise.md) — "Step 2b: Flag Entries for Transcript Drill-Down" and "Step 2c: Read Flagged Transcripts".
 
 ---
 
@@ -259,9 +260,7 @@ This ensures documentation stays synchronized with code without manual effort, a
 
 ## Session Logging
 
-Orchestration sessions are automatically chronicled by a two-stage shell pipeline. During each session, `talekeeper-capture.sh` runs as a SubagentStop command hook and appends raw sub-agent events to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-raw.jsonl`. At session end, `talekeeper-enrich.sh` runs as an async Stop hook and processes the raw log into a structured enriched JSONL chronicle (`~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-{session_id}.jsonl`). The enriched chronicle includes all agent metadata plus an `agent_transcript_path` field for SubagentStop events, enabling downstream tools like Everwise Scout to locate and analyze raw transcripts. Both scripts filter out internal hook-agent noise. Logs are gitignored and stay local to your machine.
-
-When you want a human-readable summary of past sessions, invoke the Talekeeper narrator agent manually. It reads the enriched chronicle files, delivers a concise chat digest, and appends structured narrative sections with Mermaid diagrams to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrative.md`.
+Orchestration sessions are automatically chronicled by a two-stage shell pipeline that runs as Claude Code hooks. Logs are written to `~/.ai-tpk/logs/{REPO_SLUG}/`, are gitignored, and stay local to your machine. For the authoritative hook pipeline behavior and enriched chronicle schema, see [docs/CONFIGURATION.md — SubagentStop Hook and Stop Hook](/docs/CONFIGURATION.md). When you want a human-readable summary of past sessions, invoke the Talekeeper narrator agent manually — see [`claude/agents/talekeeper.md`](/claude/agents/talekeeper.md) for its session discovery, tracking, and narration protocol.
 
 ## Terminal Tab Rename
 
@@ -271,16 +270,4 @@ Terminal tab titles are automatically managed via a SessionStart hook for resume
 
 Agent definitions can reference shared behavioral vocabulary defined in `claude/references/`. This eliminates duplication across multiple agents:
 
-- **`claude/references/github-auth-probe.md`** — Canonical procedure for verifying GitHub account access before pushing or committing. Both `commit-message-guide` and `open-pull-request` skills reference this to ensure consistent GitHub authentication checks.
-- **`claude/references/implementation-standards.md`** — Shared behavioral norms (Minimal Diff, YAGNI, Test-First) for implementation, planning, and review agents. Bitsmith, Pathfinder, Ruinor, and Knotcutter all cite this as the canonical source; each may elaborate in its own definition file.
-- **`claude/references/review-gates.md`** — Shared two-gate review framework (Plan Review Gate and Implementation Review Gate) for all reviewer agents (Ruinor, Riskmancer, Windwarden, Knotcutter, Truthhammer). Defines universal operational constraints (read-only operation, in-memory returns) and plan-file-scoping rules. Each reviewer agent defines its own domain-specific criteria for each gate inline in its definition file.
-- **`claude/references/verdict-taxonomy.md`** — Shared verdict labels (REJECT, REVISE, ACCEPT-WITH-RESERVATIONS, ACCEPT) and severity scales. Agents load this reference when issuing verdicts to ensure consistent evaluation vocabulary.
-- **`claude/references/worktree-protocol.md`** — Shared rules for how agents interpret and apply the `WORKING_DIRECTORY:` context block. Agents load this reference when operating in isolated worktrees to ensure consistent path handling.
-- **`claude/references/dm-routing-examples.md`** — 11 worked routing examples for the Dungeon Master, covering multi-step plans, trivial changes, user flags, explore-options, worktrees, intake, investigation, scope confirmation, advisory queries, and ops reports. The DM loads this reference at runtime rather than embedding the examples inline in its system prompt.
-- **`claude/references/completion-templates.md`** — Four rigid per-command completion report templates (A: Constructive, B: Investigative, C: Operational PR, D: Post-Merge) and a shared Common Fields block. The DM output contract and `/open-pr`, `/merged`, `/merge-pr` commands all reference this file to ensure consistent, parseable completion output across sessions.
-
-- **`claude/references/bash-style.md`** — Required Bash command style guide for all agents with Bash tool access. Defines enforced rules: no compound commands, no process substitution, no `--no-verify` on git commands, and no command substitution in git commit commands.
-
-- **`claude/references/quill-documentation-style.md`** — Documentation style guide used by Quill when authoring and updating documentation.
-
-When modifying these reference files, changes apply automatically to all agents that load them, eliminating the need to update redundant constraints across multiple agent definitions.
+For the authoritative catalog of shared reference files and what each one does, see [docs/CONFIGURATION.md — References](/docs/CONFIGURATION.md). Each agent definition file in [`claude/agents/`](/claude/agents/) cites the specific references it loads.

--- a/docs/WORKFLOW_ENTRY_POINTS.md
+++ b/docs/WORKFLOW_ENTRY_POINTS.md
@@ -20,12 +20,8 @@ The Dungeon Master now supports two distinct entry points for development tasks,
 
 **Flow:**
 1. Dungeon Master routes to **Tracebloom** for investigation
-2. Tracebloom produces a **Diagnostic Report** (symptom, investigation summary, root cause, evidence, recommended next action)
-3. DM evaluates the report's recommendation and routes accordingly:
-   - **"Route to Pathfinder"** → Proceed to planning with the report as context
-   - **"Fix is trivial"** → Skip planning, route directly to Bitsmith
-   - **"Inconclusive"** → Present findings to user, ask how to proceed
-   - **"No bug found"** → Session ends unless user disagrees
+2. Tracebloom produces a **Diagnostic Report**. For the authoritative report schema and the five required fields, see [`claude/agents/tracebloom.md`](/claude/agents/tracebloom.md#diagnostic-report).
+3. DM evaluates the report's recommendation and routes accordingly: For the authoritative routing logic for each of the four "Recommended next action" values, see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-1-planning) "Investigative Gate".
 
 **Key property:** Read-only investigation. Tracebloom never writes, edits, or runs write-bearing commands. The Diagnostic Report is structured to feed directly into Pathfinder's planning.
 

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -49,24 +49,15 @@ Both sessions operate independently:
 
 ### Phase 0: Session Variable Capture
 
-DM performs **Phase 0: Session Isolation** before any other work. Phase 0 only captures three session-scoped variables in conversation memory — no worktree is created here:
+DM performs **Phase 0: Session Isolation** before any other work. Phase 0 only captures session-scoped variables in conversation memory — no worktree is created here.
 
-- `SESSION_TS` — current local time formatted as `YYYYMMDD-HHmmss`
-- `SESSION_SLUG` — the task description slugified (lowercase, alphanumeric and hyphens, max 40 characters)
-- `REPO_SLUG` — the repository directory name (used to namespace plan files)
-
-Phase 0 also includes a **re-entry guard** that detects when a free-form follow-up message is continuing an existing session (e.g., adding scope to an in-flight feature). When a continuation is detected, Phase 0 is skipped entirely and the session proceeds directly to Phase 1 with the existing context. Slash-command invocations (`/feature`, `/bug`, `/ask`, `/ops`) always bypass the guard and start a fresh session boundary.
+For the authoritative Phase 0 specification — including the exact variable definitions, the re-entry guard logic, slash-command bypass behavior, and session reset triggers — see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-0-session-isolation).
 
 ### Phase 1: Worktree Creation Subroutine
 
-Worktree creation happens in **Phase 1**, not Phase 0. After intent classification, the routing branch invokes the **Worktree Creation Subroutine** when required. This subroutine:
+Worktree creation happens in **Phase 1**, not Phase 0. After intent classification, the routing branch invokes the **Worktree Creation Subroutine** when required.
 
-1. Derives a branch name using a conventional commit prefix: `{type}/{slugified-task}` — for example, "Add OAuth login" → `feat/add-oauth-login`, "Fix null pointer in auth" → `fix/null-pointer-auth`, "Refactor cache layer" → `refactor/cache-layer`. The prefix is inferred from the nature of the request (`feat/`, `fix/`, `refactor/`, `chore/`, `docs/`, `test/`).
-2. Delegates `git worktree add` to Bitsmith (the DM's Bash scope is read-only; write operations are always delegated).
-3. Sets `WORKTREE_PATH` and `WORKTREE_BRANCH` in conversation memory for the remainder of the session.
-4. Logs: "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
-
-See `claude/agents/dungeonmaster.md` for the full subroutine specification.
+For the authoritative subroutine specification — including branch-name derivation rules with conventional commit prefixes, the exact Bash command sequence delegated to Bitsmith, branch-collision retry logic (numeric suffix retries, fallback after 3 failures), and session-context propagation — see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-1-planning).
 
 ### When a Worktree is Created vs. Not Created
 
@@ -153,7 +144,7 @@ Sub-agents respect this context:
 
 ### Bitsmith's Path Mismatch Guard
 
-Bitsmith includes a safeguard that prevents silent writes to the main working tree when a session worktree is active. This **Path Mismatch Guard** fires as a per-operation invariant before every Write, Edit, or file-modifying Bash command. If you (or Bitsmith) accidentally reference a file path outside the active worktree, Bitsmith halts and surfaces the conflict to the Dungeon Master for confirmation rather than proceeding silently. This ensures changes land on the correct branch in the correct worktree, preventing accidental main-tree modifications during isolated sessions.
+Bitsmith includes a safeguard that prevents silent writes to the main working tree when a session worktree is active. For the authoritative Path Mismatch Guard specification, see [`claude/agents/bitsmith.md`](/claude/agents/bitsmith.md#path-mismatch-guard). This ensures changes land on the correct branch in the correct worktree, preventing accidental main-tree modifications during isolated sessions.
 
 ## Phase 5 Completion Log
 
@@ -170,6 +161,8 @@ No interactive prompt is shown. The worktree is never removed automatically. Whe
 git worktree remove .worktrees/feat-add-oauth-login
 git branch -d feat/add-oauth-login
 ```
+
+For the authoritative Phase 5e specification, see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-5-completion).
 
 ## Example: Two Parallel Sessions
 
@@ -228,6 +221,8 @@ $ claude --agent dungeonmaster
 ```
 
 The advisory workflow bypasses the entire constructive/investigative pipeline. No `.worktrees/` entry is created, no branch is created, and no plan file is written.
+
+For the authoritative bypass rule, see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-1-planning) — the advisory branch of the Mutual Exclusivity note.
 
 ## Workflow Flags Summary
 

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -117,14 +117,7 @@ flowchart TD
 - ALL plan reviews
 - ALL implementation reviews
 
-**Provides:**
-- Quality and correctness review
-- Basic security checks (obvious injection, exposed secrets, basic OWASP)
-- Basic performance checks (N+1 queries, obvious inefficiencies, missing indexes)
-- Basic complexity checks (obvious over-engineering, YAGNI violations)
-- **Specialist triage** - flags when deeper expertise is needed
-
-**Configuration:** `mandatory: true`, `invoke_when: "all plan and implementation reviews"`
+For the authoritative provides list and configuration, see [`claude/agents/ruinor.md`](/claude/agents/ruinor.md).
 
 #### Riskmancer - Security Specialist
 
@@ -133,16 +126,7 @@ flowchart TD
 - User explicitly requests with `--review-security` flag, OR
 - Plan/code contains security keywords (heuristic fallback)
 
-**Provides:**
-- OWASP Top 10 deep analysis
-- Advanced authentication/authorization review
-- Cryptography and key management audit
-- Payment processing and PII handling review
-- Advanced injection pattern detection
-
-**Configuration:** `mandatory: false`, `invoke_when: "security-sensitive features or when Ruinor flags security concerns"`
-
-**Trigger keywords:** auth, authentication, authorization, session, jwt, token, password, crypto, encrypt, decrypt, secret, credential, payment, pii, personal data, api key, oauth, saml, security
+For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/riskmancer.md`](/claude/agents/riskmancer.md).
 
 #### Windwarden - Performance Specialist
 
@@ -151,16 +135,7 @@ flowchart TD
 - User explicitly requests with `--review-performance` flag, OR
 - Plan/code contains performance keywords (heuristic fallback)
 
-**Provides:**
-- Algorithmic complexity analysis
-- Database query optimization review
-- Scalability pattern validation
-- Caching strategy assessment
-- Resource usage optimization
-
-**Configuration:** `mandatory: false`, `invoke_when: "performance-critical features or when Ruinor flags performance concerns"`
-
-**Trigger keywords:** database, query, performance, scale, scalability, optimization, cache, index, pagination, algorithm, batch, real-time, throughput, latency, memory, cpu
+For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/windwarden.md`](/claude/agents/windwarden.md).
 
 #### Knotcutter - Complexity Specialist
 
@@ -169,16 +144,7 @@ flowchart TD
 - User explicitly requests with `--review-complexity` flag, OR
 - Plan/code contains complexity keywords (heuristic fallback)
 
-**Provides:**
-- Architectural over-engineering detection
-- Premature abstraction identification
-- Radical simplification proposals
-- YAGNI enforcement (deep analysis)
-- Complexity reduction strategies
-
-**Configuration:** `mandatory: false`, `invoke_when: "major refactors, new abstractions, or when Ruinor flags complexity concerns"`
-
-**Trigger keywords:** refactor, architecture, abstraction, framework, pattern, generalize, reusable, complexity, simplify, redesign, restructure
+For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/knotcutter.md`](/claude/agents/knotcutter.md).
 
 #### Truthhammer - Factual Validation Specialist
 
@@ -187,16 +153,7 @@ flowchart TD
 - User explicitly requests with `--verify-facts` flag, OR
 - Plan/code contains factual-validation keywords (heuristic fallback)
 
-**Provides:**
-- Config property verification for external services
-- API signature validation for libraries and SDKs
-- Version compatibility verification
-- CLI flag and environment variable validation
-- Cross-reference verification against official documentation
-
-**Configuration:** `mandatory: false`, `invoke_when: "plans or code reference specific external system behavior, or when Ruinor flags factual verification concerns"`
-
-**Trigger keywords:** changelog, breaking change, deprecated, upgrade path, migration guide, compatibility matrix, release notes
+For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/truthhammer.md`](/claude/agents/truthhammer.md).
 
 ## Triggering Mechanisms
 
@@ -252,18 +209,7 @@ Recommend performance specialist review.
 
 If no user flags present AND Ruinor doesn't recommend specialists, the orchestrator checks plan/code content for specialist keywords.
 
-**Security keywords:**
-- auth, authentication, authorization, session
-- jwt, token, password, crypto, encrypt, secret
-- credential, payment, pii, oauth, api key
-
-**Performance keywords:**
-- database, query, scale, cache, index
-- pagination, algorithm, batch, throughput
-
-**Complexity keywords:**
-- refactor, architecture, abstraction, framework
-- pattern, redesign, restructure
+The full keyword lists are defined per-agent in the agent files: [`claude/agents/riskmancer.md`](/claude/agents/riskmancer.md) (security), [`claude/agents/windwarden.md`](/claude/agents/windwarden.md) (performance), [`claude/agents/knotcutter.md`](/claude/agents/knotcutter.md) (complexity), and [`claude/agents/truthhammer.md`](/claude/agents/truthhammer.md) (factual validation). Truthhammer's list is intentionally narrow — see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) "Keyword Detection (Heuristic Fallback)" section for the rationale.
 
 **Limitations:**
 - Less precise than Ruinor recommendations
@@ -396,6 +342,8 @@ The new workflow is fully compatible with existing:
 Existing workflows continue to work; they just run more efficiently now.
 
 ## Key Principles
+
+> **Note:** These principles are recorded here as ADR-level design decisions. The authoritative runtime sources for these rules are [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) (orchestration rules, intermediate review gates, REJECT remediation) and [`claude/agents/ruinor.md`](/claude/agents/ruinor.md) (review verdicts and adversarial mode). When the runtime behavior diverges from this list, the agent files are authoritative.
 
 - **Plans are artifacts** - Saved to `~/.ai-tpk/plans/{repo-slug}/` for visibility and persistence
 - **Reviews are ephemeral** - Verdicts returned in-memory, not saved to files


### PR DESCRIPTION
Eight duplication sites between docs/ and claude/agents/ were creating silent drift risk: when an agent's operational spec changed in claude/agents/*.md, the paraphrased copies in docs/ would quietly fall out of sync. This PR removes those copies from docs/AGENTS.md, docs/WORKFLOW_ENTRY_POINTS.md, docs/WORKTREE_ISOLATION.md, and docs/adrs/REVIEW_WORKFLOW.md, replacing them with concise cross-references to the authoritative definitions. The single source of truth for all agent operational specs is now exclusively claude/agents/*.md.