### PR TITLE
fix(ci): add explicit permissions block to restrict GITHUB_TOKEN scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Addresses GitHub CodeQL code scanning alert #2 (actions/missing-workflow-permissions). Adds permissions: contents: read at the root workflow level so the check job runs with the minimum required GITHUB_TOKEN scope. No CI steps require write access.