### PR TITLE
feat(scripts): extract token-aggregation into token-summary.sh

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -644,7 +644,7 @@ This is a read-only Bash usage authorized by DM's read-only scope (see "What the
     Format the completion summary using the appropriate template from `claude/references/completion-templates.md`: Template A (Constructive) for constructive sessions, Template B (Investigative) for investigative sessions.
 
     To obtain the values for the template:
-    - **Token usage:** read the session's enriched chronicle file — glob `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-*.jsonl` and select the file most recently modified during this session. Sum `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` across all entries using `jq`. Report as: "{input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read" (divide raw counts by 1000, round to 1 decimal). If the chronicle file is not found, unreadable, or contains no token data, report "unavailable".
+    - **Token usage:** run `~/.claude/scripts/token-summary.sh {REPO_SLUG}` and use its output verbatim. The script reads a pre-computed cache written by the Stop hook, or falls back to computing from the most recent chronicle file. If no data is available, it emits `unavailable` — report that value as-is.
     - **Reservations logged:** populate from Phase 5a and 5c. Values:
       - "no" — no ACCEPT-WITH-RESERVATIONS verdicts were issued
       - "yes — {file path} — resolved" — reservations were logged and resolved (via auto-fix or user-requested "Fix now")

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -194,10 +194,4 @@ Populate the fields as follows:
 - **Branch deleted:** `<branch>`, or "skipped (detached HEAD)" if Step 8 was skipped, or "skipped (see warning)" if Step 8 failed.
 - **Current branch:** main (up to date)
 - **Plan files cleaned:** the list of deleted file names from Step 10a, or "none" if Step 10a found no files, or "skipped (no SESSION_TS)" if Step 10a was skipped entirely.
-- **Token usage:** Derive the current repo slug as in Step 10a. Then run (single Bash call):
-
-  ```
-  ls -t ~/.ai-tpk/logs/<repo-slug>/talekeeper-*.jsonl 2>/dev/null | head -n1 | xargs -I{} jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' {}
-  ```
-
-  The pipeline (a) lists chronicle files for the repo by modification time, (b) selects the most recent, (c) feeds it to `jq -rs` which slurps all newline-delimited JSON records into a single array, filters to records that have an `input_tokens` key (token record fields are flat top-level keys — not nested under a `usage` object), reduces the four token fields, and formats the totals. If no chronicle file is found or `jq` exits non-zero, the pipeline produces empty output — report "unavailable".
+- **Token usage:** Run `~/.claude/scripts/token-summary.sh <repo-slug>` (where `<repo-slug>` is the value derived in Step 10a). Use its output verbatim. If it outputs `unavailable`, report that value as-is.

--- a/claude/hooks/talekeeper-enrich.sh
+++ b/claude/hooks/talekeeper-enrich.sh
@@ -120,4 +120,14 @@ if [ -s "$OUTPUT_FILE" ]; then
   truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' > "$RAW_LOG"
 fi
 
+# Pre-compute token summary for fast-path reads by token-summary.sh
+# Reads from the just-written chronicle, not the (now-cleared) raw log.
+# Any failure here is silently swallowed — hook must always exit 0.
+if [ -s "$OUTPUT_FILE" ] && command -v jq &>/dev/null; then
+  TOKEN_SUMMARY=$(jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' "$OUTPUT_FILE" 2>/dev/null || true)
+  if [ -n "$TOKEN_SUMMARY" ]; then
+    printf '%s\n' "$TOKEN_SUMMARY" > "$LOG_DIR/latest-token-summary.txt" 2>/dev/null || true
+  fi
+fi
+
 exit 0

--- a/claude/scripts/token-summary.sh
+++ b/claude/scripts/token-summary.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# token-summary.sh — emit formatted session token totals for a repo
+# Usage: token-summary.sh <repo-slug>
+# Output: "<N>k in / <N>k out / <N>k cache-write / <N>k cache-read"  or "unavailable"
+# Always exits 0.
+
+set -euo pipefail
+
+REPO_SLUG="${1:-}"
+if [[ -z "$REPO_SLUG" ]]; then
+  printf 'unavailable\n'
+  exit 0
+fi
+
+LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
+CACHE_FILE="$LOG_DIR/latest-token-summary.txt"
+
+# Fast path: read pre-computed cache written by talekeeper-enrich.sh Stop hook
+if [[ -s "$CACHE_FILE" ]]; then
+  RESULT=$(cat "$CACHE_FILE" 2>/dev/null || true)
+  if [[ -n "$RESULT" ]]; then
+    printf '%s\n' "$RESULT"
+    exit 0
+  fi
+  # Cache read failed or produced empty output — fall through to jq fallback
+fi
+
+# Fallback: compute from most-recent chronicle file
+if ! command -v jq &>/dev/null; then
+  printf 'unavailable\n'
+  exit 0
+fi
+
+LATEST=$(ls -t "$LOG_DIR"/talekeeper-*.jsonl 2>/dev/null | grep -v '/talekeeper-raw\.jsonl$' | head -n1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf 'unavailable\n'
+  exit 0
+fi
+
+RESULT=$(jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' "$LATEST" 2>/dev/null || true)
+
+if [[ -z "$RESULT" ]]; then
+  printf 'unavailable\n'
+  exit 0
+fi
+
+printf '%s\n' "$RESULT"
+exit 0


### PR DESCRIPTION
The same jq pipeline for summing session token fields was embedded as prose in both dungeonmaster.md Phase 5d and merged.md Step 11, causing the LLM to re-read and re-execute it on every session. This PR introduces claude/scripts/token-summary.sh with a fast-path/fallback design: the Stop hook (talekeeper-enrich.sh) pre-computes the formatted string and caches it to latest-token-summary.txt; the script reads that file instantly or falls back to a jq reduction over the most-recent enriched chronicle. Both call sites are updated to a single-line invocation. Saves ~600 tokens per completion report.