### PR TITLE
feat(scripts): extract branch slug derivation into slugify.sh

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -264,7 +264,22 @@ This subroutine is **invoked explicitly** by routing branches in this section th
 
 **When invoked, perform the following steps in order:**
 
-1. **Derive branch name:** Slugify the task description using a conventional commit prefix → `{type}/{slugified-task}` (e.g., "Add OAuth login" → `feat/add-oauth-login`, "Fix null pointer in auth" → `fix/null-pointer-auth`, "Refactor cache layer" → `refactor/cache-layer`). Infer the prefix from the nature of the request: use `feat/` for new features, `fix/` for bug fixes, `refactor/` for refactoring, `chore/` for maintenance/config/tooling, `docs/` for documentation-only changes, `test/` for test-only changes. If the request is ambiguous, use `chore/session-{YYYYMMDD-HHmmss}` (local time). Max 60 characters, lowercase, alphanumeric and hyphens only.
+1. **Derive branch name:**
+
+   **Part (a) — DM judgment (prefix inference):** Infer the conventional-commit type prefix from the nature of the request: use `feat/` for new features, `fix/` for bug fixes, `refactor/` for refactoring, `chore/` for maintenance/config/tooling, `docs/` for documentation-only changes, `test/` for test-only changes. The following are prefix-inference illustrations only — they show how to map request intent to a prefix type, not the exact slug the script will emit:
+   - "Add OAuth login" → infer `feat` → script produces `feat/add-oauth-login`
+   - "Resolve null pointer in auth" → infer `fix` → script produces `fix/resolve-null-pointer-in-auth`
+   - "Simplify cache layer" → infer `refactor` → script produces `refactor/simplify-cache-layer`
+
+   If the request is ambiguous, use `chore/session-{YYYYMMDD-HHmmss}` (local time) as `{branch-name}` and skip the slugify call below.
+
+   **Part (b) — mechanical transform (script call):** Call `bash ~/.claude/scripts/slugify.sh "<description>" "<prefix>"` and capture stdout as `{branch-name}`. The script handles lowercasing, character normalization, hyphen collapsing, and the 60-character cap on the full composed branch name.
+
+   On a non-zero exit, handle by exit code:
+   - Exit 2 (programmer error — empty arg passed): do NOT silently fall back. Abort with a clear error message to the user explaining the argument was empty.
+   - Exit 3 or 4 (data error — pathological prefix or empty slug): fall back to `chore/session-{YYYYMMDD-HHmmss}` and warn the user.
+
+   The `{branch-slug}` used in `WORKTREE_PATH` (step 2) is the portion of `{branch-name}` after the final `/`, with any remaining `/` replaced by `-` to keep the path segment flat (e.g., `{branch-name}` = `feat/add-oauth-login` → `{branch-slug}` = `add-oauth-login`, so `WORKTREE_PATH` = `{REPO_ROOT}/.worktrees/add-oauth-login`).
 
 2. **Delegate worktree creation to Bitsmith** (DM's Bash is read-only scoped; `mkdir` and `git worktree add` are write operations):
    ```

--- a/claude/scripts/slugify.sh
+++ b/claude/scripts/slugify.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Compose a git branch name `{prefix}/{slug}` from a free-form description and
+# a conventional-commit prefix; cap at 60 chars total.
+#
+# Usage: slugify.sh <description> <prefix>
+#
+# Exits:
+#   0  — success; branch name written to stdout
+#   2  — missing or empty argument (programmer error — DM passed empty arg)
+#   3  — prefix consumes entire 60-char branch cap (no room for slug character)
+#   4  — description normalised to empty slug (no [a-z0-9] characters)
+#
+# Note: SESSION_SLUG derivation in dungeonmaster.md uses similar rules but a
+# 40-char cap; that is intentionally separate from this script.
+
+DESC="${1:-}"
+PREFIX="${2:-}"
+
+if [[ -z "$DESC" ]]; then
+  printf '%s\n' "slugify.sh: missing or empty description argument (expected as \$1)" >&2
+  exit 2
+fi
+
+if [[ -z "$PREFIX" ]]; then
+  printf '%s\n' "slugify.sh: missing or empty prefix argument (expected as \$2)" >&2
+  exit 2
+fi
+
+if [[ ! "$PREFIX" =~ ^[a-z][a-z0-9]*$ ]]; then
+  printf '%s\n' "slugify.sh: prefix must match ^[a-z][a-z0-9]*$ (got: ${PREFIX})" >&2
+  exit 2
+fi
+
+# Transform the description into a slug:
+# 1. Lowercase
+# 2. Replace any character not in [a-z0-9-] with -
+# 3. Collapse runs of - into a single -
+# 4. Strip leading and trailing -
+SLUG=$(printf '%s' "$DESC" | tr '[:upper:]' '[:lower:]')
+SLUG=$(printf '%s' "$SLUG" | sed -E 's/[^a-z0-9-]+/-/g')
+SLUG=$(printf '%s' "$SLUG" | sed -E 's/-+/-/g')
+SLUG=$(printf '%s' "$SLUG" | sed -E 's/^-+//; s/-+$//')
+
+if [[ -z "$SLUG" ]]; then
+  printf '%s\n' "slugify.sh: description normalised to empty slug (input contained no [a-z0-9] characters)" >&2
+  exit 4
+fi
+
+# Compose branch name
+BRANCH="${PREFIX}/${SLUG}"
+
+# Apply 60-character cap: truncate the slug portion (not the prefix)
+if [[ ${#BRANCH} -gt 60 ]]; then
+  MAX_SLUG_LEN=$((60 - ${#PREFIX} - 1))
+  if [[ $MAX_SLUG_LEN -le 0 ]]; then
+    printf '%s\n' "slugify.sh: prefix too long for 60-char branch cap (prefix=${PREFIX})" >&2
+    exit 3
+  fi
+  SLUG="${SLUG:0:$MAX_SLUG_LEN}"
+  # Strip trailing - introduced by truncation
+  SLUG=$(printf '%s' "$SLUG" | sed -E 's/-+$//')
+  BRANCH="${PREFIX}/${SLUG}"
+fi
+
+printf '%s\n' "$BRANCH"


### PR DESCRIPTION
Offloads the mechanical branch-name slug transformation from DM natural-language prose into a dedicated shell script at claude/scripts/slugify.sh. Each constructive session previously required the LLM to re-derive the slug logic from prose description; the script makes that transformation deterministic and free of model tokens. The DM agent spec is updated to reference the script instead of describing the algorithm inline.