### PR TITLE
feat(hooks): write session-context sidecar to eliminate bash permission prompts

### DIFF
--- a/claude/commands/clean-ai-tpk-artifacts.md
+++ b/claude/commands/clean-ai-tpk-artifacts.md
@@ -18,9 +18,19 @@ Store the age as `<days>` and the flag as `<all-repos>` (true/false).
 
 ## Step 2 — Derive current repo slug
 
-Run: `git rev-parse --show-toplevel`
+Derive the repo slug using the session-context sidecar:
 
-Take the basename of the result. Store it as `<repo-slug>`.
+1. **Try sidecar first.** Use the `Read` tool on `~/.ai-tpk/session-context/current.json`.
+   If the file exists and contains a JSON object with a non-empty `repo_slug` field,
+   use that value as `<repo-slug>`. The `Read` tool does not trigger a permission
+   prompt — this is the preferred path. The sidecar is written by `session-start.sh`
+   on every session start, so under normal conditions this path is taken; the fallback
+   exists for users who have not yet re-run `install.sh` after this update.
+
+2. **Fallback.** If the `Read` tool reports the file is missing, OR if the file is
+   present but `repo_slug` is empty, missing, or unparseable, run:
+   `git rev-parse --show-toplevel` (a Bash call — this triggers the usual permission
+   prompt). Take the basename of the result. Store it as `<repo-slug>`.
 
 ## Step 3 — Determine search scope
 

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -167,8 +167,20 @@ plan files. Do not run `git rev-parse`, `ls`, or any other command. Proceed to S
 
 **If SESSION_TS is available:**
 
-Derive the current repo slug by running: `git rev-parse --show-toplevel`
-Take the basename of the result. Store it as `<repo-slug>`.
+Derive the current repo slug using the session-context sidecar:
+
+1. **Try sidecar first.** Use the `Read` tool on `~/.ai-tpk/session-context/current.json`.
+   If the file exists and contains a JSON object with a non-empty `repo_slug` field,
+   use that value as `<repo-slug>` and proceed directly to the `ls -1` step below.
+   The `Read` tool does not trigger a permission prompt — this is the preferred path.
+   The sidecar is written by `session-start.sh` on every session start, so under
+   normal conditions this path is taken; the fallback exists for users who have not
+   yet re-run `install.sh` after this update.
+
+2. **Fallback.** If the `Read` tool reports the file is missing, OR if the file is
+   present but `repo_slug` is empty, missing, or unparseable, fall back to:
+   `git rev-parse --show-toplevel` (a Bash call — this triggers the usual permission
+   prompt). Take the basename of the result and store it as `<repo-slug>`.
 
 List files matching the session timestamp in the plan directory:
 `ls -1 ~/.ai-tpk/plans/<repo-slug>/{SESSION_TS}-* 2>/dev/null`
@@ -194,4 +206,8 @@ Populate the fields as follows:
 - **Branch deleted:** `<branch>`, or "skipped (detached HEAD)" if Step 8 was skipped, or "skipped (see warning)" if Step 8 failed.
 - **Current branch:** main (up to date)
 - **Plan files cleaned:** the list of deleted file names from Step 10a, or "none" if Step 10a found no files, or "skipped (no SESSION_TS)" if Step 10a was skipped entirely.
-- **Token usage:** Run `~/.claude/scripts/token-summary.sh <repo-slug>` (where `<repo-slug>` is the value derived in Step 10a). Use its output verbatim. If it outputs `unavailable`, report that value as-is.
+- **Token usage:** Derive the current repo slug as follows: use the `Read` tool on
+  `~/.ai-tpk/session-context/current.json`; if the file is absent or `repo_slug` is
+  empty, fall back to `git rev-parse --show-toplevel` (Bash call) and take the basename.
+  Then run `~/.claude/scripts/token-summary.sh <repo-slug>`. Use its output verbatim.
+  If it outputs `unavailable`, report that value as-is.

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -20,6 +20,20 @@ fi
 CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
 CWD="${CWD:-$PWD}"
 
+# Write session-context sidecar for downstream consumers (talekeeper hooks,
+# LLM commands). Uses a fixed path so consumers can read it without knowing
+# the session ID. Last-writer-wins for concurrent sessions — that race is an
+# accepted limitation. Written here, before the --name override exit and the
+# title-restore branches, so the sidecar is present on every invocation that
+# has a usable CWD.
+REPO_SLUG="$(basename "$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")")"
+SIDECAR_DIR="$HOME/.ai-tpk/session-context"
+SIDECAR_FILE="$SIDECAR_DIR/current.json"
+mkdir -p "$SIDECAR_DIR" 2>/dev/null || true
+jq -nc --arg repo_slug "$REPO_SLUG" \
+  '{repo_slug: $repo_slug}' > "$SIDECAR_FILE" 2>/dev/null || true
+unset REPO_SLUG SIDECAR_DIR SIDECAR_FILE
+
 # Source shared tab-rename library
 # shellcheck source=lib-tab-rename.sh
 source "$(dirname "$0")/lib-tab-rename.sh"

--- a/claude/hooks/talekeeper-capture.sh
+++ b/claude/hooks/talekeeper-capture.sh
@@ -3,7 +3,23 @@
 # Invoked as a command hook -- no LLM, millisecond latency
 # Reads event JSON from stdin, appends timestamped entry to raw log
 
-REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+# Prefer the session-context sidecar written by session-start.sh; fall back
+# to the original git-based derivation when the sidecar is absent or unreadable.
+SIDECAR_FILE="$HOME/.ai-tpk/session-context/current.json"
+REPO_SLUG=""
+if [ -f "$SIDECAR_FILE" ] && command -v jq &>/dev/null; then
+  REPO_SLUG=$(jq -r '.repo_slug // ""' "$SIDECAR_FILE" 2>/dev/null)
+fi
+if [ -z "$REPO_SLUG" ]; then
+  REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+fi
+# Cross-check: verify the sidecar slug matches the current git context.
+# If they differ, the sidecar is stale (written by a different-repo session).
+_CURRENT_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+if [ "$REPO_SLUG" != "$_CURRENT_SLUG" ]; then
+  REPO_SLUG="$_CURRENT_SLUG"
+fi
+unset _CURRENT_SLUG SIDECAR_FILE
 LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
 LOG_FILE="$LOG_DIR/talekeeper-raw.jsonl"
 

--- a/claude/hooks/talekeeper-enrich.sh
+++ b/claude/hooks/talekeeper-enrich.sh
@@ -3,7 +3,26 @@
 # Runs as an async Stop hook command — has full filesystem access (unlike agent hooks)
 # Never blocks the session; exits 0 in all cases
 
-REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+# Prefer the session-context sidecar written by session-start.sh; fall back
+# to the original git-based derivation when the sidecar is absent or unreadable.
+# Note: this hook has a global jq guard at lines below, but we add a local
+# jq check here so the sidecar read does not crash if jq is absent before
+# that guard fires.
+SIDECAR_FILE="$HOME/.ai-tpk/session-context/current.json"
+REPO_SLUG=""
+if [ -f "$SIDECAR_FILE" ] && command -v jq &>/dev/null; then
+  REPO_SLUG=$(jq -r '.repo_slug // ""' "$SIDECAR_FILE" 2>/dev/null)
+fi
+if [ -z "$REPO_SLUG" ]; then
+  REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+fi
+# Cross-check: verify the sidecar slug matches the current git context.
+# If they differ, the sidecar is stale (written by a different-repo session).
+_CURRENT_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+if [ "$REPO_SLUG" != "$_CURRENT_SLUG" ]; then
+  REPO_SLUG="$_CURRENT_SLUG"
+fi
+unset _CURRENT_SLUG SIDECAR_FILE
 LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
 mkdir -p "$LOG_DIR"
 RAW_LOG="$LOG_DIR/talekeeper-raw.jsonl"

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -99,11 +99,17 @@ Auto-approved entries include the `[auto-approved]` marker; calls falling throug
 - Logged + normal dialog: `Write to /tmp/output.txt` (path not in allowed set — falls through to normal dialog)
 - Allowed: `echo -n hello`, `git log -n 5` (context-aware: `-n` only blocked in `git commit` context)
 
-#### SessionStart Hook - Terminal Tab Title Restore
+#### SessionStart Hook - Terminal Tab Title Restore and Session-Context Sidecar
 
 Runs at the start of every Claude Code session. For resumed sessions, restores the previously stored tab title. For fresh sessions (e.g., after `/new`), resets the tab to the repo or directory name so the previous session's stale title does not persist until the Stop hook generates a new one. Title generation from conversation content is handled by the Stop hook (`tab-rename-stop.sh`).
 
 **Purpose:** Ensures the tab title always reflects the current session on startup — either a stored title for resumed sessions or a neutral repo/directory default for fresh sessions. Script: `claude/hooks/session-start.sh`.
+
+**Session-context sidecar:** On every invocation, the hook derives the current `repo_slug` (basename of `git rev-parse --show-toplevel` from the session's `cwd`, or the `cwd` basename when not in a git repo) and writes it to `~/.ai-tpk/session-context/current.json` as `{"repo_slug": "<value>"}`. This sidecar is written before the `--name` override exit and all title-restore branches, so it is present regardless of whether tab-rename work is performed. The directory is created automatically on first use; no installer step is required.
+
+The sidecar eliminates the `git rev-parse --show-toplevel` Bash permission prompt that LLM commands previously had to issue on every session. Commands and hooks read it via the `Read` tool (no prompt) or via a shell `jq` call, with a fallback to the inline git derivation for installations that have not yet been updated.
+
+**Concurrent sessions:** The sidecar uses a fixed path (`current.json`, not keyed by session ID). The last session to start wins. This is an accepted limitation for users running simultaneous Claude Code sessions across different repositories.
 
 **Non-obvious behaviors:** `--name` override is detected via process ancestry (walks up to 3 levels); `-n` is intentionally excluded to avoid false positives. Fresh-session neutral title is derived from the git repo basename when inside a repo, or the directory basename otherwise — matching the context used by the Stop hook. The neutral default is not persisted to `~/.claude/session-titles/`, so the Stop hook's single-fire guard is not tripped and the AI-generated title replaces it after the first exchange.
 
@@ -125,6 +131,8 @@ Runs after every sub-agent completion to capture raw session event data.
 
 **Purpose:** Appends raw sub-agent completion events to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-raw.jsonl` for later enrichment. Script: `claude/hooks/talekeeper-capture.sh`.
 
+**REPO_SLUG resolution:** The hook reads `repo_slug` from `~/.ai-tpk/session-context/current.json` (written by the SessionStart hook) when the sidecar is present and `jq` is available. It then cross-checks the sidecar value against the git context of the hook's own process (`git rev-parse --show-toplevel`). If they differ — indicating the sidecar was written by a concurrent session on a different repository — the inline git derivation wins. If the sidecar is absent or unreadable, the hook falls back to the original inline derivation unconditionally.
+
 **Non-obvious behavior:** Filters out `hook-agent-*` events — Stop hook agents are not real sub-agents and must not pollute the log. Always exits 0; logging must never block the session.
 
 #### Stop Hook - Session Enrichment
@@ -136,6 +144,8 @@ Note: A second Stop hook (`tab-rename-stop.sh`) also fires asynchronously for te
 **Session enrichment (async):**
 
 Processes the raw sub-agent event log captured during the session into a structured enriched JSONL chronicle. Script: `claude/hooks/talekeeper-enrich.sh`.
+
+**REPO_SLUG resolution:** Uses the same sidecar-then-cross-check-then-fallback pattern as the SubagentStop hook. The sidecar is preferred; a staleness cross-check against the hook's own git context overrides it when they disagree; the inline git derivation is the unconditional fallback when the sidecar is absent.
 
 **Non-obvious behaviors:** Filters out `hook-agent-*` events and `talekeeper` self-captures. Reads each agent's transcript file (`agent_transcript_path`) and sums token usage across all assistant turns. Clears the raw log on success.
 

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -12,8 +12,9 @@ Agent-produced artifacts (plans, open-questions files, lessons) are stored in us
 
 - **Plans** → `~/.ai-tpk/plans/{repo-slug}/` — One subdirectory per repository, containing plan files and associated open-questions files
 - **Lessons** → `~/.ai-tpk/lessons/` — Flat structure for Everwise Scout analysis recommendations (cross-repo)
+- **Session context** → `~/.ai-tpk/session-context/current.json` — Sidecar written by the SessionStart hook on every session start, containing `{"repo_slug": "<value>"}`. Read by talekeeper hooks and LLM commands to avoid redundant `git rev-parse` calls and the permission prompts they trigger. The directory is created lazily on first use; no installer step is required.
 
-These directories are created automatically when you run `install.sh`.
+The `plans/` and `lessons/` directories are created automatically when you run `install.sh`. The `session-context/` directory is created on first session start.
 
 ## Quick Start
 
@@ -87,7 +88,8 @@ After the subroutine completes, your repository structure looks like:
 │       ├── .git
 │       └── ...
 ├── src/
-├── ~/.ai-tpk/plans/{repo-slug}/ # Plans (user-scoped, outside repo)
+├── ~/.ai-tpk/plans/{repo-slug}/          # Plans (user-scoped, outside repo)
+├── ~/.ai-tpk/session-context/current.json # Session-context sidecar (written each session start)
 └── .gitignore                   # Contains .worktrees/
 ```
 

--- a/tests/hooks/test-talekeeper-sidecar.sh
+++ b/tests/hooks/test-talekeeper-sidecar.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Dev-only test — not installed by install.sh. Run from repo root.
+#
+# Tests the sidecar-then-fallback REPO_SLUG resolver in:
+#   claude/hooks/talekeeper-capture.sh
+#   claude/hooks/talekeeper-enrich.sh
+#
+# Strategy: extract the REPO_SLUG-resolution block from each hook (all lines
+# before LOG_DIR=), source it in a subshell with HOME overridden to a temp
+# dir, then verify the resolved REPO_SLUG for four cases:
+#   Case 1: sidecar present and well-formed   → use sidecar value
+#   Case 2: sidecar absent                    → git-based fallback
+#   Case 3: sidecar malformed                 → git-based fallback, no stderr
+#   Case 4: sidecar stale (wrong repo_slug)   → cross-check corrects it
+#
+# Usage: bash tests/hooks/test-talekeeper-sidecar.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CAPTURE_HOOK="$REPO_ROOT/claude/hooks/talekeeper-capture.sh"
+ENRICH_HOOK="$REPO_ROOT/claude/hooks/talekeeper-enrich.sh"
+
+PASS=0
+FAIL=0
+
+_pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+_fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# Extract lines from a hook file up to (not including) the LOG_DIR= line.
+# Prints the extracted block to stdout.
+_extract_resolver_block() {
+  local hook_file="$1"
+  awk '/^LOG_DIR=/{exit} {print}' "$hook_file"
+}
+
+# Resolve REPO_SLUG from a hook by sourcing only the resolver block.
+#
+#   $1  — hook file path
+#   $2  — sidecar file path (absolute path we control in tests)
+#   $3  — "stderr" to capture stderr instead of stdout; omit for stdout
+#
+# HOME is overridden so that $HOME/.ai-tpk/session-context/current.json
+# resolves to the temp-controlled sidecar file.
+_resolve_slug() {
+  local hook_file="$1"
+  local sidecar_file="$2"
+  local capture_mode="${3:-stdout}"
+  # Derive the fake HOME: two levels up from the sidecar file
+  # sidecar_file = $TMPDIR_BASE/.ai-tpk/session-context/current.json
+  # fake HOME    = $TMPDIR_BASE
+  local fake_home
+  fake_home="$(dirname "$(dirname "$(dirname "$sidecar_file")")")"
+  local block
+  block="$(_extract_resolver_block "$hook_file")"
+
+  if [ "$capture_mode" = "stderr" ]; then
+    (
+      HOME="$fake_home"
+      unset REPO_SLUG 2>/dev/null || true
+      eval "$block"
+      echo "${REPO_SLUG:-}"
+    ) 2>&1 >/dev/null || true
+  else
+    (
+      HOME="$fake_home"
+      unset REPO_SLUG 2>/dev/null || true
+      eval "$block"
+      echo "${REPO_SLUG:-}"
+    ) 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+TMPDIR_BASE="$(mktemp -d)"
+SIDECAR_DIR="$TMPDIR_BASE/.ai-tpk/session-context"
+SIDECAR_FILE="$SIDECAR_DIR/current.json"
+mkdir -p "$SIDECAR_DIR"
+
+# Reference: what git derivation alone would produce.
+# Use the same idiom the hooks use (no -C flag) so this matches the subshell context.
+GIT_DERIVED_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+
+# ---------------------------------------------------------------------------
+# talekeeper-capture.sh
+# ---------------------------------------------------------------------------
+printf "\n=== talekeeper-capture.sh ===\n"
+
+# Case 1: sidecar present and well-formed → slug matches sidecar value.
+# Use GIT_DERIVED_SLUG as the sidecar value: this simulates the real scenario
+# where session-start.sh wrote the sidecar for this exact repo. The cross-check
+# will see slug == git context and leave it unchanged.
+printf '{"repo_slug":"%s"}\n' "$GIT_DERIVED_SLUG" > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$CAPTURE_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 1: sidecar present and well-formed → slug matches sidecar value"
+else
+  _fail "Case 1: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+
+# Case 2: sidecar absent → fallback to git derivation
+rm -f "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$CAPTURE_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 2: sidecar absent → slug matches git-derived value ('$GIT_DERIVED_SLUG')"
+else
+  _fail "Case 2: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+
+# Case 3: sidecar present but malformed JSON → fallback, no stderr noise
+printf 'not-json\n' > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$CAPTURE_HOOK" "$SIDECAR_FILE" "stdout")"
+STDERR_OUT="$(_resolve_slug "$CAPTURE_HOOK" "$SIDECAR_FILE" "stderr")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 3: malformed sidecar → slug falls back to git-derived value"
+else
+  _fail "Case 3: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+if [ -z "$STDERR_OUT" ]; then
+  _pass "Case 3: malformed sidecar → no stderr output"
+else
+  _fail "Case 3: unexpected stderr: '$STDERR_OUT'"
+fi
+
+# Case 4: sidecar present with stale/wrong repo_slug → cross-check corrects it
+printf '{"repo_slug":"wrong-other-repo"}\n' > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$CAPTURE_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 4: stale sidecar slug → cross-check corrects to git-derived value"
+else
+  _fail "Case 4: expected '$GIT_DERIVED_SLUG', got '$RESULT' (cross-check not yet implemented)"
+fi
+
+# ---------------------------------------------------------------------------
+# talekeeper-enrich.sh
+# ---------------------------------------------------------------------------
+printf "\n=== talekeeper-enrich.sh ===\n"
+
+# Case 1: sidecar present and well-formed → slug matches sidecar value.
+# Use GIT_DERIVED_SLUG as the sidecar value (simulates a freshly-written sidecar).
+printf '{"repo_slug":"%s"}\n' "$GIT_DERIVED_SLUG" > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$ENRICH_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 1: sidecar present and well-formed → slug matches sidecar value"
+else
+  _fail "Case 1: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+
+# Case 2: sidecar absent → fallback to git derivation
+rm -f "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$ENRICH_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 2: sidecar absent → slug matches git-derived value ('$GIT_DERIVED_SLUG')"
+else
+  _fail "Case 2: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+
+# Case 3: sidecar present but malformed JSON → fallback, no stderr noise
+printf 'not-json\n' > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$ENRICH_HOOK" "$SIDECAR_FILE" "stdout")"
+STDERR_OUT="$(_resolve_slug "$ENRICH_HOOK" "$SIDECAR_FILE" "stderr")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 3: malformed sidecar → slug falls back to git-derived value"
+else
+  _fail "Case 3: expected '$GIT_DERIVED_SLUG', got '$RESULT'"
+fi
+if [ -z "$STDERR_OUT" ]; then
+  _pass "Case 3: malformed sidecar → no stderr output"
+else
+  _fail "Case 3: unexpected stderr: '$STDERR_OUT'"
+fi
+
+# Case 4: sidecar present with stale/wrong repo_slug → cross-check corrects it
+printf '{"repo_slug":"wrong-other-repo"}\n' > "$SIDECAR_FILE"
+RESULT="$(_resolve_slug "$ENRICH_HOOK" "$SIDECAR_FILE")"
+if [ "$RESULT" = "$GIT_DERIVED_SLUG" ]; then
+  _pass "Case 4: stale sidecar slug → cross-check corrects to git-derived value"
+else
+  _fail "Case 4: expected '$GIT_DERIVED_SLUG', got '$RESULT' (cross-check not yet implemented)"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+rm -rf "$TMPDIR_BASE"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\n--- Results: %d passed, %d failed ---\n" "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Repeated Bash calls to `git rev-parse --show-toplevel` in LLM-driven commands trigger per-call permission prompts. `session-start.sh` now writes `~/.ai-tpk/session-context/current.json` with `repo_slug` once per session start. The `/merged` and `/clean-ai-tpk-artifacts` commands now use the `Read` tool against this sidecar (no prompt), with a graceful Bash fallback for users who haven't yet run `install.sh`. Talekeeper hooks prefer the sidecar with a staleness cross-check. Tests and docs included.