### PR TITLE
feat(scripts): extract tier-2 discovery logic into five POSIX shell scripts

### DIFF
--- a/claude/commands/address-pr-comments.md
+++ b/claude/commands/address-pr-comments.md
@@ -21,120 +21,78 @@ chain commands with `&&`, `;`, or `|`.
 Generate `<session-ts>` in the format `YYYYMMDD-HHMMSS` using the current date and time. Store
 it for use in the summary file path.
 
-## Step 2 -- Verify GitHub authentication
+## Step 2 -- Discover unresolved review threads
 
-Run: `gh auth status`
+Run `~/.claude/scripts/pr-comments-fetch.sh <pr-number>` as a single Bash call.
 
-If the command exits with a non-zero status, abort immediately: "GitHub authentication is
-required. Run `gh auth login` and try again."
+**Exit code handling:**
 
-## Step 3 -- Derive owner and repo
+- Exit code **2** means the script rejected its arguments — this is an internal bug in the
+  command prose. Abort immediately: "Internal error: pr-comments-fetch.sh rejected its
+  arguments. This is a bug; please report." Do not retry.
+- Exit code **1** means the script encountered an error (e.g. PR not found, auth failure,
+  network issue). The script will have printed an explanatory message to stderr. Surface that
+  message to the user and abort.
+- Exit code **0** means success. Parse the script's stdout as JSON and continue.
 
-Run: `git remote get-url origin`
+**JSON shape emitted on success:**
 
-Parse the output to extract `<owner>` and `<repo>`. Handle both URL formats:
-
-- SSH: `git@github.com:owner/repo.git` — split on `:`, take the right side, split on `/`
-- HTTPS: `https://github.com/owner/repo.git` — split on `/`, take the last two segments
-
-Strip trailing `.git` if present. Store as `<owner>` and `<repo>` for use in all API calls.
-
-## Step 4 -- Fetch PR metadata and unresolved review threads
-
-Fetch the PR metadata and all unresolved review threads in a single paginated GraphQL query.
-
-**Important:** The cursor variable must be named `$endCursor` exactly. This is the variable
-name that `gh api graphql --paginate` recognises for automatic pagination. Any other name
-causes pagination to silently return only the first page.
-
-Run the following query:
-
-```
-gh api graphql --paginate -f query='
-query($owner: String!, $repo: String!, $prNumber: Int!, $endCursor: String) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $prNumber) {
-      title
-      state
-      reviewThreads(first: 100, after: $endCursor) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          endCursor
+```json
+{
+  "pr_number": 42,
+  "title": "...",
+  "state": "OPEN",
+  "owner": "...",
+  "repo": "...",
+  "threads": [
+    {
+      "thread_id": "...",
+      "is_resolved": false,
+      "is_outdated": false,
+      "path": "src/foo.ts",
+      "line": 17,
+      "start_line": null,
+      "first_comment_full_database_id": 1234567890123456,
+      "comments": [
+        {
+          "comment_full_database_id": 1234567890123456,
+          "author": "reviewer-login",
+          "body": "...",
+          "created_at": "2026-01-01T00:00:00Z",
+          "diff_hunk": "...",
+          "url": "https://github.com/..."
         }
-        nodes {
-          id
-          isResolved
-          isOutdated
-          path
-          line
-          startLine
-          diffSide
-          comments(first: 100) {
-            nodes {
-              fullDatabaseId
-              author {
-                login
-              }
-              body
-              createdAt
-              path
-              line
-              diffHunk
-              url
-            }
-          }
-        }
-      }
+      ]
     }
-  }
+  ]
 }
-' -f owner=<owner> -f repo=<repo> -F prNumber=<pr-number>
 ```
 
-Note: inner thread comments are fetched up to 100 per thread, which is sufficient for all practical review threads. Pagination within threads is not implemented.
+The `thread_id` field is the GraphQL node id of the thread (used for resume matching). The
+`first_comment_full_database_id` is the integer database id of the first (root) comment in
+the thread — this is the value to pass to the reply script. The `comment_full_database_id`
+field inside each comment object is the per-comment integer id. No field is named bare `id`.
 
-Check the result:
+**Sub-steps — execute in this exact order:**
 
-- If the `pullRequest` field is `null` (PR not found), abort: "PR #`<pr-number>` not found in
-  `<owner>/<repo>`."
-- If the PR `state` is `MERGED` or `CLOSED`, warn: "PR #`<pr-number>` is `<state>`. Comments
-  can still be addressed but replies may have limited visibility." Ask: "Proceed anyway? (yes/no)"
-  If the user says anything other than `yes`, abort.
-- Print: "PR #`<pr-number>`: `<title>`"
+1. **State warning first.** Read `.state` from the JSON. If it is `MERGED` or `CLOSED`, warn
+   the user: "PR #`<pr-number>` is `<state>`. Comments can still be addressed but replies may
+   have limited visibility." Ask: "Proceed anyway? (yes/no)". If the user says anything other
+   than `yes`, abort.
 
-Filter the `reviewThreads.nodes` array: keep only entries where `isResolved` is `false`.
+2. **Print PR title.** Print "PR #`<pr-number>`: `<title>`".
 
-For each unresolved thread, extract and store:
+3. **Zero-thread short-circuit.** If `.threads | length == 0`, print "No unresolved review
+   comments found on PR #`<pr-number>`." and stop. (This runs after the state warning so that
+   a CLOSED PR with zero unresolved threads still receives the state warning before
+   terminating.)
 
-- `thread-id`: the GraphQL `id` of the thread (for internal tracking and resume matching)
-- `file-path`: the `path` field from the thread
-- `line`: the `line` field (may be null)
-- `start-line`: the `startLine` field (may be null; if non-null, the comment spans
-  `startLine` to `line`)
-- `is-outdated`: the `isOutdated` field (true when the thread references a diff range that
-  has since changed)
-- `comments`: the ordered list of comments in the thread. For each comment:
-  - `comment-full-database-id`: the `fullDatabaseId` value. This is a BigInt string (e.g.,
-    `"1234567890123456"`). Use it as-is when interpolating into URL paths -- no type
-    conversion is needed; URL path segments are character strings and GitHub's server
-    parses them numerically.
-  - `author`: `author.login`
-  - `body`: the comment body text
-  - `created-at`: the `createdAt` timestamp
-  - `diff-hunk`: the `diffHunk` context
-  - `url`: the GitHub URL of the comment
-- **Reply target:** Use `comments.nodes[0].fullDatabaseId` -- the `fullDatabaseId` of the
-  **first** (top-level/root) comment in the thread. The GitHub REST API requires the
-  original top-level review comment ID. Replies to replies are not supported; the last
-  comment's ID must not be used.
+4. **"Found N unresolved..." print.** Print "Found `<count>` unresolved review thread(s) on
+   PR #`<pr-number>`."
 
-If zero unresolved threads remain after filtering, print: "No unresolved review comments found
-on PR #`<pr-number>`." and stop.
+Store `<owner>`, `<repo>`, and `<title>` from the JSON for use in subsequent steps.
 
-Print: "Found `<count>` unresolved review thread(s) on PR #`<pr-number>`."
-
-## Step 5 -- Check for an existing session (resume)
+## Step 3 -- Check for an existing session (resume)
 
 Define the summary directory as `~/.ai-tpk/pr-review-comments/`.
 
@@ -151,46 +109,47 @@ If one or more matching files exist:
 - Identify the most recent by filename (filenames are timestamped, so lexicographic order
   gives chronological order).
 - Read the file and parse it for already-processed thread IDs. Each processed thread entry
-  in the summary contains a `**Thread ID:**` line with the GraphQL `id`.
+  in the summary contains a `**Thread ID:**` line with the `thread_id` value.
 - Ask: "Found an existing session for PR #`<pr-number>` (`<filename>`). Resume from where
   it left off? (yes/no)"
-  - If `yes`: filter the unresolved threads list to exclude any thread whose `id` appears
-    in the existing summary. Update `<session-ts>` to match the existing file's timestamp
-    (extracted from the filename prefix) so new entries append to the same file. Print:
-    "Resuming -- `<remaining-count>` thread(s) remaining."
+  - If `yes`: filter the threads list (from Step 2 JSON) to exclude any thread whose
+    `thread_id` appears in the existing summary. Update `<session-ts>` to match the existing
+    file's timestamp (extracted from the filename prefix) so new entries append to the same
+    file. Print: "Resuming -- `<remaining-count>` thread(s) remaining."
   - If `no`: proceed with all threads. Keep the newly generated `<session-ts>`.
 
 If no matching files exist, proceed normally.
 
-## Step 6 -- Reason over each thread and propose a response
+## Step 4 -- Reason over each thread and propose a response
 
-For each unresolved thread (in the order fetched), perform the following sequence:
+For each unresolved thread (in the order returned by the fetch script), perform the following
+sequence:
 
-**6a. Present thread context.**
+**4a. Present thread context.**
 
 Display a clearly formatted block:
 
 ```
 --- Thread <N> of <total> ---
-File: <file-path>:<line>
-(use <file-path>:<start-line>-<line> when start-line is non-null)
-Status: outdated   (if is-outdated is true)
-Status: current    (if is-outdated is false)
+File: <path>:<line>
+(use <path>:<start_line>-<line> when start_line is non-null)
+Status: outdated   (if is_outdated is true)
+Status: current    (if is_outdated is false)
 
 Diff context:
-<diffHunk from comments.nodes[0]>
+<diff_hunk from comments[0]>
 
-Review comment by @<author> (<created-at>):
-<body of comments.nodes[0]>
+Review comment by @<author> (<created_at>):
+<body of comments[0]>
 
 (For each subsequent comment in the thread, if any:)
-Reply by @<author> (<created-at>):
+Reply by @<author> (<created_at>):
 <body>
 ```
 
-**6b. Read the current file.**
+**4b. Read the current file.**
 
-Read the file at `<file-path>` in the working tree, focusing on the lines around `<line>`.
+Read the file at `<path>` in the working tree, focusing on the lines around `<line>`.
 This reveals whether the reviewer's concern has already been addressed by subsequent commits.
 
 If the file does not exist in the working tree (deleted or renamed since the review), display:
@@ -198,7 +157,7 @@ If the file does not exist in the working tree (deleted or renamed since the rev
 code that no longer exists, making ALREADY-ADDRESSED the likely appropriate category with an
 explanation that the file was removed.
 
-**6c. Reason about the comment.**
+**4c. Reason about the comment.**
 
 Consider:
 
@@ -210,7 +169,7 @@ Consider:
   misunderstanding?
 - What is the appropriate response category?
 
-**6d. Categorize the response** as one of:
+**4d. Categorize the response** as one of:
 
 - **FIX** -- The reviewer is right and the code should be changed. The reply acknowledges
   the issue and states what will be (or has been) fixed.
@@ -223,7 +182,7 @@ Consider:
 - **ACKNOWLEDGE** -- The comment is informational or a question that deserves a simple
   acknowledgment or answer.
 
-**6e. Draft the reply text.**
+**4e. Draft the reply text.**
 
 The reply should be:
 
@@ -232,7 +191,7 @@ The reply should be:
 - Concise (2-5 sentences typically)
 - Actionable where appropriate
 
-**6f. Present the proposal.**
+**4f. Present the proposal.**
 
 ```
 Proposed response (category: <CATEGORY>):
@@ -242,64 +201,71 @@ Proposed response (category: <CATEGORY>):
 Actions: [approve] [edit] [skip] [quit]
 ```
 
-**6g. Handle the user's decision.**
+**4g. Handle the user's decision.**
 
-- **approve**: Accept the draft as-is. Proceed to Step 7.
-- **edit**: The user provides revised text. Use the user's text instead. Proceed to Step 7.
+- **approve**: Accept the draft as-is. Proceed to Step 5.
+- **edit**: The user provides revised text. Use the user's text instead. Proceed to Step 5.
 - **skip**: Do not post a reply. Record in the summary as "skipped". Move to the next thread.
 - **quit**: Stop processing. Record this thread as "quit -- not processed" in the summary.
   Do not process remaining threads. Print: "Session paused. Run `/address-pr-comments
   <pr-number>` to resume later."
 
-After each decision (including skip and quit), proceed to Step 8 to write the summary entry
+After each decision (including skip and quit), proceed to Step 6 to write the summary entry
 before moving on.
 
-## Step 7 -- Post the approved reply
+## Step 5 -- Post the approved reply
 
-For approved or edited replies, post the reply using the REST API. Because reply text is
+For approved or edited replies, post the reply using the reply script. Because reply text is
 free-form and may contain single quotes, double quotes, backticks, dollar signs, newlines,
-and other shell-special characters, do not pass the body inline. Instead:
+and other shell-special characters, the script reads the body from a file to bypass all shell
+quoting issues.
 
-**7a.** Write the reply text to a temporary file:
+**5a.** Write the reply text to a temporary file:
 
 Run a write operation to create `/tmp/pr-reply-body.txt` containing the reply body.
 
-**7b.** Post using the `-F` flag with `@file` syntax, which reads the field value from the
-file and bypasses all shell quoting issues. (`-F/--field` supports `@filename` file-read
-syntax; lowercase `-f/--raw-field` does not -- it would send the literal string
-`@/tmp/pr-reply-body.txt` as the comment body.)
-
-Run:
+**5b.** Invoke the reply script as a single Bash call:
 
 ```
-gh api --method POST /repos/<owner>/<repo>/pulls/<pr-number>/comments/<first-comment-full-database-id>/replies -F body=@/tmp/pr-reply-body.txt
+~/.claude/scripts/pr-comments-reply.sh <pr-number> <first-comment-full-database-id> /tmp/pr-reply-body.txt
 ```
 
-Where:
+Where `<first-comment-full-database-id>` is the `first_comment_full_database_id` value for
+this thread from the Step 2 JSON.
 
-- `<pr-number>` is the PR number (the `pulls/{pull_number}` segment is required in the path)
-- `<first-comment-full-database-id>` is the `fullDatabaseId` string of
-  `comments.nodes[0]` for this thread (identified in Step 4) -- used as-is, no conversion
+**5c.** Branch on the script's exit code and JSON output:
 
-**7c.** Remove the temporary file regardless of success or failure:
+- **Exit code 2** — This is an arg-validation bug in the prose. Abort immediately: "Internal
+  error: pr-comments-reply.sh rejected its arguments. This is a bug; please report." Do not
+  retry.
+- **Exit code 0 or 1** — Parse the script's stdout as JSON and branch on `.ok`:
+  - **`.ok == true`**: extract `.html_url` and print "Reply posted: `<html_url>`". Record in
+    the summary as "posted" with the URL.
+  - **`.ok == false` and `.error_kind == "review_flow_comment"`**: print "Cannot reply via
+    REST: this comment was submitted as part of a formal review and GitHub's /replies endpoint
+    does not support it. Skipping this thread." Record in the summary as "failed (review-flow
+    comment -- REST replies endpoint returned 404)". **Do not retry** -- the next attempt will
+    produce the same 404. Move to the next thread.
+  - **`.ok == false` and any other `error_kind`** (`auth`, `body_file_missing`,
+    `owner_repo_parse`, `api`, `unknown`): print `.error` and ask "Retry? (yes/no)". On
+    `yes`, re-run sub-steps 5a--5c once. If the second attempt also returns `.ok == false`,
+    record as "failed" in the summary and move to the next thread. On `no`, record as
+    "failed" and move on.
+
+**5d.** Remove the temporary file regardless of success or failure:
 
 Run: `rm /tmp/pr-reply-body.txt`
 
-**If the API call succeeds:**
+### Known limitation
 
-- Extract the `html_url` from the JSON response.
-- Print: "Reply posted: `<html_url>`"
-- Record in the summary: status = "posted", include `<html_url>`.
+GitHub's `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`
+endpoint returns **404** for comments that were submitted as part of a formal review flow
+("Start a Review" in the GitHub UI). It works only for standalone diff comments. The script
+detects this case and emits `error_kind: "review_flow_comment"`, which the prose above treats
+as a non-retryable failure. When this occurs, record the thread as failed with the documented
+summary text and move on -- retrying will produce the same result.
 
-**If the API call fails:**
-
-- Print: "Failed to post reply: `<error>`"
-- Ask: "Retry? (yes/no)"
-- If `yes`: retry the API call once (Steps 7a--7c again). If it fails again, record as
-  "failed" in the summary and move to the next thread.
-- If `no`: record as "failed" in the summary and move to the next thread.
-
-## Step 8 -- Write or update the session summary
+## Step 6 -- Write or update the session summary
 
 After each thread is processed (posted, skipped, failed, or quit), write its entry to the
 summary file at `~/.ai-tpk/pr-review-comments/<session-ts>-pr-<pr-number>.md`. Write
@@ -317,9 +283,9 @@ incrementally after each thread so progress is preserved if the session is inter
 
 ---
 
-## Thread 1: <file-path>:<line>
+## Thread 1: <path>:<line>
 
-**Thread ID:** <thread-id>
+**Thread ID:** <thread_id>
 **Status:** <outdated | current>
 **Reviewer:** @<author>
 **Comment:**
@@ -344,7 +310,7 @@ after the last existing entry.
 **When resuming an existing session:** read the existing file first, then append new thread
 entries after the last existing `---` separator.
 
-## Step 9 -- Print the final session summary
+## Step 7 -- Print the final session summary
 
 After all threads are processed (or the user quit), print:
 

--- a/claude/commands/clean-the-desk.md
+++ b/claude/commands/clean-the-desk.md
@@ -11,77 +11,61 @@ be delegated to Bitsmith per the DM delegation policy. Those steps are marked be
 **Known limitation:** `--limit 1000` captures at most the 1000 most-recently merged PRs.
 Branches from PRs merged long ago may not appear in the list and will not be cleaned up.
 
-## Step 1 — Verify GitHub authentication
+## Step 1 — Discover stale branches
 
-Run: `gh auth status`
+Run `~/.claude/scripts/clean-the-desk-discover.sh` as a single Bash call.
 
-If the command exits with a non-zero status or prints an error, abort immediately and tell the
-user: "GitHub authentication is required. Run `gh auth login` and try again."
+Exit-code contract:
+- **Exit 0** — discovery succeeded; parse stdout as JSON.
+- **Non-zero exit** — abort immediately; the script has already printed an error message to stderr.
 
-## Step 2 — Fetch remote-tracking refs
+On success, stdout is a single-line JSON object with the following shape:
 
-Run: `git fetch origin`
+```json
+{
+  "branches_to_delete": ["feat/old-branch", "fix/another"],
+  "worktrees_to_remove": [
+    {"branch": "feat/old-branch", "path": "/abs/path/to/worktree"}
+  ],
+  "skipped_reasons": {
+    "main": "protected",
+    "feat/current": "current branch",
+    "feat/closed-pr": "upstream gone (PR not in merged-list — possibly closed-without-merge)"
+  }
+}
+```
 
-This updates remote-tracking refs without modifying the working tree.
+- `.branches_to_delete` — local branches whose PR is confirmed merged and that are safe to delete.
+- `.worktrees_to_remove` — worktrees that must be removed before the associated branch can be deleted. Every entry here has a matching entry in `.branches_to_delete`.
+- `.skipped_reasons` — merged-list or gone-upstream branches that were excluded from cleanup, with the reason for each. Present this to the user in Step 2 if non-empty.
 
-## Step 3 — Collect merged PR branch names
+If both `.branches_to_delete` and `.worktrees_to_remove` are empty, print "Nothing to clean up."
+and stop.
 
-Run: `gh pr list --state merged --json headRefName --limit 1000`
+## Step 2 — Display summary and ask for confirmation
 
-Parse the JSON response. Extract the `headRefName` value from each object into a list of merged
-branch names. These are already short names (e.g., `feat/my-feature`) — no stripping needed.
-
-## Step 4 — Collect local branch names
-
-Run: `git branch --format='%(refname:short)'`
-
-This produces one short branch name per line.
-
-## Step 5 — Collect worktree path-to-branch mapping
-
-Run: `git worktree list --porcelain`
-
-Parse the output to build a map from worktree path to branch name. Each worktree entry begins
-with a `worktree` line (the path) followed later by a `branch` line. Strip the `refs/heads/`
-prefix from the branch value. This map is used in Step 7 to find worktrees associated with
-stale branches.
-
-## Step 6 — Identify stale branches
-
-A branch is stale if it meets ALL of the following:
-- It exists in the local branch list (Step 4)
-- Its name appears in the merged PR branch list (Step 3)
-- Its name is NOT `main` or `master`
-
-## Step 7 — Find associated worktrees
-
-Using the porcelain output from Step 5, map each stale branch to its worktree path (if any).
-A worktree entry has a `worktree` line (the path) followed later by a `branch` line. Collect
-every worktree path whose branch matches a stale branch.
-
-## Step 8 — Display summary and ask for confirmation
-
-Print a clear summary:
-- List each worktree path that will be removed (if any)
-- List each branch that will be deleted (if any)
-- If both lists are empty, tell the user "Nothing to clean up." and stop.
+Print a clear summary derived from the JSON:
+- List each worktree path that will be removed (from `.worktrees_to_remove[*].path`), if any.
+- List each branch that will be deleted (from `.branches_to_delete`), if any.
+- If `.skipped_reasons` is non-empty, surface it so the user understands why some branches were
+  not included — for example: "Skipped: main (protected), feat/current (current branch)."
 
 Ask the user: "Proceed with deletion? (yes/no)"
 
 If the user answers anything other than `yes`, abort without making any changes.
 
-## Step 9 — Remove worktrees [write operation — delegate to Bitsmith]
+## Step 3 — Remove worktrees [write operation — delegate to Bitsmith]
 
-For each worktree path identified in Step 7, delegate to Bitsmith to run:
+For each entry in `.worktrees_to_remove`, delegate to Bitsmith to run:
 `git worktree remove --force {path}`
 
 (Per DM delegation policy, write operations must not be executed directly by the DM.)
 
 Report each removal as it completes.
 
-## Step 10 — Delete stale branches [write operation — delegate to Bitsmith]
+## Step 4 — Delete stale branches [write operation — delegate to Bitsmith]
 
-For each stale branch, delegate to Bitsmith to run:
+For each branch in `.branches_to_delete`, delegate to Bitsmith to run:
 `git branch -D {branch}`
 
 (Per DM delegation policy, write operations must not be executed directly by the DM.)
@@ -89,7 +73,7 @@ For each stale branch, delegate to Bitsmith to run:
 If the command fails (e.g., because the branch is still checked out somewhere), treat it as a
 skip — do not treat it as a fatal error. Note the branch as skipped.
 
-## Step 11 — Report final summary
+## Step 5 — Report final summary
 
 Print a final summary with three sections:
 - **Worktrees removed:** list of paths (or "none")

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -19,105 +19,80 @@ worktree session).
 **If both are set:**
 Print: `"Using session context: <WORKTREE_PATH> (<WORKTREE_BRANCH>)"`
 Set `<worktree-path>` to `WORKTREE_PATH` and `<branch>` to `WORKTREE_BRANCH`. Proceed through
-Steps 1 and 2 (to identify `<main-path>` and verify the worktree exists), then skip directly
-to Step 6.
+Step 1 (to identify `<main-path>` and verify the worktree exists), then skip directly
+to Step 2.
 
 **If not both set:**
 Proceed to Step 1 (full discovery flow).
 
-## Step 1 — Enumerate all worktrees
+## Step 1 — Discover candidates
 
-Run: `git worktree list --porcelain`
+Run `~/.claude/scripts/merged-discover.sh` as a single Bash call. The script:
+- Runs `git fetch --prune` and records success/failure.
+- Captures `git worktree list --porcelain` and parses it in pure bash.
+- Identifies the main worktree path (the first block in the porcelain output — **not**
+  `git rev-parse --show-toplevel`, which returns the wrong value from inside a worktree).
+- Builds the list of non-prunable worktrees whose paths start with `<main-path>/`.
+- Detects gone-upstream branches using `git for-each-ref` plumbing internally (not
+  `git branch -vv` — that format is undocumented and unstable).
+- Computes `candidates`: the subset of worktree branches whose upstream is gone.
+- Emits a single-line JSON object to stdout:
 
-Parse the porcelain output. The output consists of blocks separated by blank lines. Each
-block starts with a `worktree <path>` line, followed by a `HEAD <sha>` line, and then
-either a `branch refs/heads/<name>` line or the word `detached`. Some blocks may also
-contain a `prunable` line.
+```json
+{
+  "main_path": "<absolute-path>",
+  "fetch_ok": true,
+  "worktrees": [
+    { "path": "<absolute-path>", "branch": "<branch-name>" }
+  ],
+  "gone_branches": ["<branch-name>"],
+  "candidates": ["<branch-name>"]
+}
+```
 
-## Step 2 — Identify the main worktree
+Extract `<main-path>` from `.main_path`.
 
-The **first block** in the porcelain output is always the main worktree, regardless of
-which directory the command is invoked from. Extract its path as `<main-path>`.
+**If arriving from Step 0 (session-context path):** Verify that `WORKTREE_PATH` appears
+in the discovery output's `worktrees[*].path` list. If it does not, tell the user:
+"Session context worktree not found in `git worktree list` output. Aborting." and stop.
+If it does, proceed to Step 2.
 
-Do **not** use `git rev-parse --show-toplevel` for this purpose — it returns the worktree
-path when run from inside a worktree, which would produce incorrect results.
+**If `.fetch_ok` is `false`:** Warn the user that remote-gone detection is unavailable.
+Then proceed with the branching rules below using whatever `candidates` the script produced
+(which may be empty if the fetch failed).
 
-**If arriving from Step 0 (session-context path):** Verify that `<worktree-path>` appears
-as a worktree path in the porcelain output. If it does not, tell the user: "Session context
-worktree not found in `git worktree list` output. Aborting." and stop. If it does, proceed
-to Step 6.
+**Branching on candidates and worktrees:**
 
-## Step 3 — Build the candidate list
+- **If `.candidates | length == 1`:** Auto-select that branch. Find its worktree path by
+  looking up the matching entry in `.worktrees[*]` where `.branch == candidates[0]`.
+  Print: `"Identified merged branch via remote deletion: <branch> at <path>. Proceeding with cleanup."`
+  Store as `<worktree-path>` and `<branch>`. Proceed to Step 2.
 
-From the remaining blocks (all blocks after the first), build a list of cleanup candidates
-by applying these filters in order:
+- **If `.candidates | length == 0` and `.worktrees | length == 0`:**
+  Print: "No worktrees found to clean up." Stop here — do not continue to later steps.
 
-1. **Skip prunable entries.** If a block contains a `prunable` line, exclude it entirely.
-   These are stale entries, often belonging to a different repository.
+- **If `.candidates | length == 0` and `.worktrees | length >= 1`:**
+  Present the full `.worktrees` array as a numbered list (path and branch for each).
+  Ask the user: "Multiple worktrees found. Which one was merged? Enter the number, or 'none' to abort."
+  If the user answers `none` or provides an invalid selection, abort without making any changes.
+  Store the selected candidate's path as `<worktree-path>` and branch as `<branch>`.
 
-2. **Skip cross-repo worktrees.** If the worktree path does not start with `<main-path>/`,
-   exclude it. This ensures only worktrees belonging to this repository are candidates.
+- **If `.candidates | length > 1`:**
+  Present those candidates as a numbered list (branch name for each; look up the path
+  from `.worktrees`).
+  Ask the user: "Multiple worktrees found. Which one was merged? Enter the number, or 'none' to abort."
+  If the user answers `none` or provides an invalid selection, abort without making any changes.
+  Store the selected candidate's path as `<worktree-path>` and branch as `<branch>`.
 
-3. **Parse branch name.** If the block has a `branch refs/heads/<name>` line, strip the
-   `refs/heads/` prefix and store `<name>` as the branch. If the block has `detached`
-   instead of a `branch` line, store the branch as `(detached HEAD)`.
-
-Each candidate entry contains a path and a branch name (or `(detached HEAD)`).
-
-## Step 4 — Check for remote-gone signal
-
-Run: `git fetch --prune`
-
-This is a non-destructive network operation that updates remote tracking refs and prunes
-refs for branches deleted on the remote. It modifies local tracking refs but not local
-branches or the working tree. No Bitsmith delegation is required.
-
-If `git fetch --prune` fails (e.g., network error, authentication failure), warn the user
-that remote-gone detection is unavailable and fall through to Step 5 (the manual picker).
-
-Run: `git branch -vv`
-
-Parse the output for lines whose tracking-ref information contains `: gone]` — for example,
-a line like `  fix/my-branch  abc1234 [origin/fix/my-branch: gone] commit message` indicates
-that `origin/fix/my-branch` was deleted on the remote.
-
-Cross-reference the gone branches with the candidate list from Step 3. A candidate matches
-if its branch name equals the local branch name shown in a gone line. Candidates with
-`(detached HEAD)` as their branch cannot match and are ignored in this cross-reference.
-
-**If exactly one candidate has a `[gone]` upstream:**
-Auto-select it. Print: `"Identified merged branch via remote deletion: <branch> at <path>. Proceeding with cleanup."`
-Store the candidate's path as `<worktree-path>` and branch as `<branch>`, then proceed to Step 6.
-
-**If zero or multiple candidates have `[gone]` upstream:**
-Fall through to Step 5 (the manual picker).
-
-## Step 5 — Branch on candidate count
-
-**If zero candidates:**
-Tell the user: "No worktrees found to clean up." Stop here — do not continue to later steps.
-
-**If exactly one candidate:**
-Print the candidate's path and branch name.
-Store the candidate's path as `<worktree-path>` and branch as `<branch>`.
-
-**If multiple candidates:**
-Print a numbered list of all candidates (path and branch for each). Ask the user:
-"Multiple worktrees found. Which one was merged? Enter the number, or 'none' to abort."
-
-If the user answers `none` or provides an invalid selection, abort without making any changes.
-
-Store the selected candidate's path as `<worktree-path>` and branch as `<branch>`.
-
-## Step 6 — Change to the main repo directory
+## Step 2 — Change to the main repo directory
 
 Before any destructive operations, change the working directory to `<main-path>` (from
-Step 2). This is critical: if the current shell is inside `<worktree-path>`, removing that
+Step 1). This is critical: if the current shell is inside `<worktree-path>`, removing that
 worktree will destroy the cwd and cause all subsequent commands to fail.
 
-All remaining steps (7 through 10) must execute with `<main-path>` as the working directory.
+All remaining steps (3 through 6) must execute with `<main-path>` as the working directory.
 
-## Step 7 — Remove the worktree [write operation — delegate to Bitsmith]
+## Step 3 — Remove the worktree [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git worktree remove --force <worktree-path>`
 
@@ -128,7 +103,7 @@ in the worktree are expendable.
 
 If the command fails, report the error to the user and abort. Do not continue to later steps.
 
-## Step 8 — Delete the local branch [write operation — delegate to Bitsmith]
+## Step 4 — Delete the local branch [write operation — delegate to Bitsmith]
 
 **If `<branch>` is `(detached HEAD)`:** Skip this step entirely. There is no branch to delete.
 Print: "Skipping branch deletion — worktree was in detached HEAD state."
@@ -138,9 +113,9 @@ Print: "Skipping branch deletion — worktree was in detached HEAD state."
 (Per DM delegation policy, write operations must not be executed directly by the DM.)
 
 If the command fails (e.g., the branch was already deleted or does not exist locally), report
-the failure as a warning but do not abort — continue to Step 9.
+the failure as a warning but do not abort — continue to Step 5.
 
-## Step 9 — Checkout main [write operation — delegate to Bitsmith]
+## Step 5 — Checkout main [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git checkout main`
 
@@ -148,7 +123,7 @@ Delegate to Bitsmith to run (from `<main-path>`): `git checkout main`
 
 If this fails, report the error and abort.
 
-## Step 10 — Pull latest from origin [write operation — delegate to Bitsmith]
+## Step 6 — Pull latest from origin [write operation — delegate to Bitsmith]
 
 Delegate to Bitsmith to run (from `<main-path>`): `git pull origin main`
 
@@ -157,13 +132,13 @@ Delegate to Bitsmith to run (from `<main-path>`): `git pull origin main`
 If this fails, report the error but do not treat it as fatal — the local checkout is already
 on `main`.
 
-## Step 10a — Auto-clean session plan files
+## Step 6a — Auto-clean session plan files
 
 Check whether `SESSION_TS` is present in your conversation memory.
 
 **If SESSION_TS is not available** (e.g., `/merged` was run in a new session without
 worktree context): Skip this step silently. Do not list, prompt about, or delete any
-plan files. Do not run `git rev-parse`, `ls`, or any other command. Proceed to Step 11.
+plan files. Do not run `git rev-parse`, `ls`, or any other command. Proceed to Step 7.
 
 **If SESSION_TS is available:**
 
@@ -174,24 +149,30 @@ List files matching the session timestamp in the plan directory:
 `ls -1 ~/.ai-tpk/plans/<repo-slug>/{SESSION_TS}-* 2>/dev/null`
 
 If no files match (command produces no output or the directory does not exist), skip
-this step silently and proceed to Step 11.
+this step silently and proceed to Step 7.
 
 If matching files exist, delegate to Bitsmith to delete each file using `rm` (one call
 per file, not chained). Do not prompt the user. Do not mention or touch any files that
 do not match `{SESSION_TS}-*`.
 
-Store the list of deleted file names for use in Step 11's summary.
+Store the list of deleted file names for use in Step 7's summary.
 
 (Per DM delegation policy, file deletions must be delegated to Bitsmith.)
 
-## Step 11 — Report final summary
+## Step 7 — Report final summary
 
 Format the summary using Template D (Post-Merge Cleanup) from `claude/references/completion-templates.md`.
 
 Populate the fields as follows:
 - **PR** and **Merge method:** Include these lines only when `MERGED_PR_NUMBER` is present in session context (i.e., `/merged` was chained from `/merge-pr`). Omit both lines when `/merged` is run standalone.
 - **Worktree removed:** `<worktree-path>`, or "N/A" if no worktree was found.
-- **Branch deleted:** `<branch>`, or "skipped (detached HEAD)" if Step 8 was skipped, or "skipped (see warning)" if Step 8 failed.
+- **Branch deleted:** `<branch>`, or "skipped (detached HEAD)" if Step 4 was skipped, or "skipped (see warning)" if Step 4 failed.
 - **Current branch:** main (up to date)
-- **Plan files cleaned:** the list of deleted file names from Step 10a, or "none" if Step 10a found no files, or "skipped (no SESSION_TS)" if Step 10a was skipped entirely.
-- **Token usage:** Run `~/.claude/scripts/token-summary.sh <repo-slug>` (where `<repo-slug>` is the value derived in Step 10a). Use its output verbatim. If it outputs `unavailable`, report that value as-is.
+- **Plan files cleaned:** the list of deleted file names from Step 6a, or "none" if Step 6a found no files, or "skipped (no SESSION_TS)" if Step 6a was skipped entirely.
+- **Token usage:** Derive the current repo slug as in Step 6a. Then run (single Bash call):
+
+  ```
+  ls -t ~/.ai-tpk/logs/<repo-slug>/talekeeper-*.jsonl 2>/dev/null | head -n1 | xargs -I{} jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' {}
+  ```
+
+  The pipeline (a) lists chronicle files for the repo by modification time, (b) selects the most recent, (c) feeds it to `jq -rs` which slurps all newline-delimited JSON records into a single array, filters to records that have an `input_tokens` key (token record fields are flat top-level keys — not nested under a `usage` object), reduces the four token fields, and formats the totals. If no chronicle file is found or `jq` exits non-zero, the pipeline produces empty output — report "unavailable".

--- a/claude/scripts/clean-the-desk-discover.sh
+++ b/claude/scripts/clean-the-desk-discover.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+# This script's internals are exempt from `claude/references/bash-style.md` — that file governs
+# agent-level Bash tool calls only. Internal use of `&&`, `;`, `|`, and `$(...)` is permitted.
+
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+
+# Verify GitHub authentication.
+if ! gh auth status >/dev/null 2>&1; then
+  printf 'GitHub authentication is required. Run `gh auth login` and try again.\n' >&2
+  exit 1
+fi
+
+# Fetch remote-tracking refs so merged-PR data is current.
+git fetch origin
+
+# Collect merged PR branch names (one per line) into an array.
+merged_branches=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && merged_branches+=("$line")
+done < <(gh pr list --state merged --json headRefName --limit 1000 | jq -r '.[].headRefName')
+
+# Collect local branch names into an array.
+local_branches=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && local_branches+=("$line")
+done < <(git branch --format='%(refname:short)')
+
+# Detect current branch (may be empty in detached-HEAD state).
+current_branch="$(git branch --show-current)"
+
+# Parse `git worktree list --porcelain` into a path-by-branch lookup map.
+# Associative array: worktree_path_for_branch[branch]=path
+# Skip prunable entries and the first (main) worktree block.
+declare -A worktree_path_for_branch
+worktree_raw="$(git worktree list --porcelain)"
+wt_path=""
+wt_branch=""
+wt_prunable=false
+block_count=0
+
+while IFS= read -r wt_line; do
+  if [[ "$wt_line" == worktree\ * ]]; then
+    # Flush the previous block before starting a new one.
+    if [[ $block_count -gt 1 && -n "$wt_path" && "$wt_prunable" == false ]]; then
+      if [[ -n "$wt_branch" && "$wt_branch" != "(detached HEAD)" ]]; then
+        worktree_path_for_branch["$wt_branch"]="$wt_path"
+      fi
+    fi
+    wt_path="${wt_line#worktree }"
+    wt_branch=""
+    wt_prunable=false
+    (( block_count++ )) || true
+  elif [[ "$wt_line" == branch\ * ]]; then
+    raw_branch="${wt_line#branch }"
+    wt_branch="${raw_branch#refs/heads/}"
+  elif [[ "$wt_line" == "detached" ]]; then
+    wt_branch="(detached HEAD)"
+  elif [[ "$wt_line" == "prunable"* ]]; then
+    wt_prunable=true
+  fi
+done <<< "$worktree_raw"
+
+# Flush the final block.
+if [[ $block_count -gt 1 && -n "$wt_path" && "$wt_prunable" == false ]]; then
+  if [[ -n "$wt_branch" && "$wt_branch" != "(detached HEAD)" ]]; then
+    worktree_path_for_branch["$wt_branch"]="$wt_path"
+  fi
+fi
+
+# Build a set of local branches for O(1) lookup.
+declare -A local_branch_set
+for b in "${local_branches[@]+"${local_branches[@]}"}"; do
+  local_branch_set["$b"]=1
+done
+
+# Build a set of protected branches.
+declare -A protected_set
+protected_set["main"]=1
+protected_set["master"]=1
+protected_set["HEAD"]=1
+[[ -n "$current_branch" ]] && protected_set["$current_branch"]=1
+
+# Compute candidates: in merged_branches AND in local_branches AND NOT protected.
+candidates=()
+declare -A candidate_set
+for mb in "${merged_branches[@]+"${merged_branches[@]}"}"; do
+  if [[ -n "${local_branch_set[$mb]+_}" && -z "${protected_set[$mb]+_}" ]]; then
+    candidates+=("$mb")
+    candidate_set["$mb"]=1
+  fi
+done
+
+# For each candidate, record it for deletion and check whether a worktree exists.
+branches_to_delete=("${candidates[@]+"${candidates[@]}"}")
+# worktrees_to_remove stored as parallel arrays for branch and path.
+wtr_branches=()
+wtr_paths=()
+for c in "${candidates[@]+"${candidates[@]}"}"; do
+  if [[ -n "${worktree_path_for_branch[$c]+_}" ]]; then
+    wtr_branches+=("$c")
+    wtr_paths+=("${worktree_path_for_branch[$c]}")
+  fi
+done
+
+# Build skipped_reasons for merged branches that exist locally but were excluded.
+# Priority order: protected → current branch.
+declare -A skipped_reasons
+for mb in "${merged_branches[@]+"${merged_branches[@]}"}"; do
+  # Only surface branches that exist locally.
+  [[ -z "${local_branch_set[$mb]+_}" ]] && continue
+  # Skip if already a candidate.
+  [[ -n "${candidate_set[$mb]+_}" ]] && continue
+  # Determine reason.
+  if [[ "$mb" == "main" || "$mb" == "master" || "$mb" == "HEAD" ]]; then
+    skipped_reasons["$mb"]="protected"
+  elif [[ -n "$current_branch" && "$mb" == "$current_branch" ]]; then
+    skipped_reasons["$mb"]="current branch"
+  fi
+done
+
+# Cross-check: surface local branches with [gone] upstream that are NOT already candidates.
+# These are branches whose PR was likely closed without merge. Priority: after protected/current.
+while IFS= read -r ref_line; do
+  ref_branch="${ref_line%% *}"
+  ref_track="${ref_line##* }"
+  [[ "$ref_track" != "[gone]" ]] && continue
+  # Already a candidate — skip.
+  [[ -n "${candidate_set[$ref_branch]+_}" ]] && continue
+  # Only add if not already recorded with a higher-priority reason.
+  if [[ -z "${skipped_reasons[$ref_branch]+_}" ]]; then
+    skipped_reasons["$ref_branch"]="upstream gone (PR not in merged-list — possibly closed-without-merge)"
+  fi
+done < <(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/)
+
+# Serialize branches_to_delete as a JSON array.
+branches_json="$(
+  if [[ ${#branches_to_delete[@]} -eq 0 ]]; then
+    printf '[]'
+  else
+    for b in "${branches_to_delete[@]}"; do
+      jq -Rn --arg v "$b" '$v'
+    done | jq -s .
+  fi
+)"
+
+# Serialize worktrees_to_remove as a JSON array of {branch, path} objects.
+worktrees_json="$(
+  if [[ ${#wtr_branches[@]} -eq 0 ]]; then
+    printf '[]'
+  else
+    for i in "${!wtr_branches[@]}"; do
+      jq -n --arg branch "${wtr_branches[$i]}" --arg path "${wtr_paths[$i]}" \
+        '{"branch": $branch, "path": $path}'
+    done | jq -s .
+  fi
+)"
+
+# Serialize skipped_reasons as a JSON object.
+skipped_json="$(
+  if [[ ${#skipped_reasons[@]} -eq 0 ]]; then
+    printf '{}'
+  else
+    for sk_br in "${!skipped_reasons[@]}"; do
+      jq -n --arg k "$sk_br" --arg v "${skipped_reasons[$sk_br]}" '{($k): $v}'
+    done | jq -s 'add // {}'
+  fi
+)"
+
+# Emit final JSON to stdout.
+jq -n \
+  --argjson branches_to_delete "$branches_json" \
+  --argjson worktrees_to_remove "$worktrees_json" \
+  --argjson skipped_reasons "$skipped_json" \
+  '{
+    "branches_to_delete": $branches_to_delete,
+    "worktrees_to_remove": $worktrees_to_remove,
+    "skipped_reasons": $skipped_reasons
+  }'

--- a/claude/scripts/detect-stack.sh
+++ b/claude/scripts/detect-stack.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script's internals are exempt from `claude/references/bash-style.md` — that file governs
+# agent-level Bash tool calls only. Internal use of `&&`, `;`, `|`, and `$(...)` is permitted.
+
+# NO repo-preflight guard — this script accepts an optional <repo-root> arg and operates on
+# arbitrary directories, not necessarily git repos.
+
+# Accept optional positional arg <repo-root>; default to current directory.
+repo_root="${1:-$(pwd)}"
+
+# Verify the target directory exists and is readable.
+if [[ ! -d "$repo_root" || ! -r "$repo_root" ]]; then
+  printf 'Error: directory not found or not readable: %s\n' "$repo_root" >&2
+  exit 1
+fi
+
+stack=""
+lint_cmd=""
+format_check_cmd=""
+format_warning=""
+
+# Detection rules — first match wins.
+
+# Rule 1: Node/npm
+if [[ -f "$repo_root/package.json" ]]; then
+  stack="node"
+  lint_cmd="npm run lint"
+  format_check_cmd="npm run format:check"
+  format_warning=""
+
+# Rule 2: Makefile with lint target
+elif [[ -f "$repo_root/Makefile" ]] && grep -qE '^lint[[:space:]]*:' "$repo_root/Makefile"; then
+  stack="make"
+  lint_cmd="make lint"
+  # Determine format check command by inspecting targets in priority order.
+  if grep -qE '^fmt-check[[:space:]]*:' "$repo_root/Makefile"; then
+    format_check_cmd="make fmt-check"
+    format_warning=""
+  elif grep -qE '^format-check[[:space:]]*:' "$repo_root/Makefile"; then
+    format_check_cmd="make format-check"
+    format_warning=""
+  elif grep -qE '^check-format[[:space:]]*:' "$repo_root/Makefile"; then
+    format_check_cmd="make check-format"
+    format_warning=""
+  elif grep -qE '^fmt[[:space:]]*:' "$repo_root/Makefile"; then
+    format_check_cmd=""
+    format_warning="Makefile \`fmt\` target detected but it modifies files — skipping format check. Add a \`fmt-check\` target to enable it."
+  else
+    format_check_cmd=""
+    format_warning="No format check target found in Makefile."
+  fi
+
+# Rule 3: Python (modern)
+elif [[ -f "$repo_root/pyproject.toml" ]]; then
+  stack="python"
+  lint_cmd="ruff check ."
+  format_check_cmd="ruff format --check ."
+  format_warning=""
+
+# Rule 4: Python (legacy)
+elif [[ -f "$repo_root/setup.py" || -f "$repo_root/setup.cfg" ]]; then
+  stack="python-legacy"
+  lint_cmd="flake8 ."
+  format_check_cmd="black --check ."
+  format_warning=""
+
+# Rule 5: Go
+elif [[ -f "$repo_root/go.mod" ]]; then
+  stack="go"
+  lint_cmd="golangci-lint run"
+  format_check_cmd="gofmt -l ."
+  format_warning=""
+
+# Rule 6: Rust
+elif [[ -f "$repo_root/Cargo.toml" ]]; then
+  stack="rust"
+  lint_cmd="cargo clippy"
+  format_check_cmd="cargo fmt --check"
+  format_warning=""
+
+# Rule 7: No match
+else
+  stack="unknown"
+  lint_cmd=""
+  format_check_cmd=""
+  format_warning="No recognized lint/format toolchain was found. Skipping validation."
+fi
+
+# Emit single-line JSON. All four fields are always present.
+jq -n \
+  --arg stack "$stack" \
+  --arg lint_cmd "$lint_cmd" \
+  --arg format_check_cmd "$format_check_cmd" \
+  --arg format_warning "$format_warning" \
+  '{"stack": $stack, "lint_cmd": $lint_cmd, "format_check_cmd": $format_check_cmd, "format_warning": $format_warning}'

--- a/claude/scripts/merged-discover.sh
+++ b/claude/scripts/merged-discover.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# This script's internals are exempt from `claude/references/bash-style.md` — that file
+# governs agent-level Bash tool calls only. Internal use of `&&`, `;`, `|`, and `$(...)`
+# is permitted.
+
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# git fetch --prune
+# Run non-destructively; record success/failure but continue regardless.
+# ---------------------------------------------------------------------------
+fetch_ok=true
+if ! git fetch --prune >/dev/null 2>&1; then
+  fetch_ok=false
+fi
+
+# ---------------------------------------------------------------------------
+# Capture worktree list in porcelain format.
+# ---------------------------------------------------------------------------
+worktree_output="$(git worktree list --porcelain)"
+
+# ---------------------------------------------------------------------------
+# Parse porcelain output block by block.
+# Each block is separated by a blank line. Fields of interest:
+#   worktree <path>
+#   branch refs/heads/<name>   (or absent when detached)
+#   detached                   (present instead of branch line when HEAD is detached)
+#   prunable                   (present when the worktree is stale/prunable)
+# ---------------------------------------------------------------------------
+main_path=""
+worktrees_json="[]"   # JSON array built incrementally via jq
+block_path=""
+block_branch=""
+block_prunable=false
+block_detached=false
+first_block=true
+
+flush_block() {
+  # Called when a blank line (or EOF) is encountered after a non-empty block.
+  [[ -z "$block_path" ]] && return
+
+  if [[ "$block_detached" == "true" ]]; then
+    block_branch="(detached HEAD)"
+  fi
+
+  if [[ "$first_block" == "true" ]]; then
+    main_path="$block_path"
+    first_block=false
+  else
+    # Add to worktrees array only if: not prunable AND path starts with <main_path>/
+    if [[ "$block_prunable" == "false" && "$block_path" == "$main_path/"* ]]; then
+      worktrees_json="$(printf '%s' "$worktrees_json" | jq \
+        --arg p "$block_path" \
+        --arg b "$block_branch" \
+        '. + [{"path": $p, "branch": $b}]')"
+    fi
+  fi
+
+  # Reset block state
+  block_path=""
+  block_branch=""
+  block_prunable=false
+  block_detached=false
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "$line" ]]; then
+    flush_block
+  elif [[ "$line" == worktree\ * ]]; then
+    block_path="${line#worktree }"
+  elif [[ "$line" == branch\ refs/heads/* ]]; then
+    block_branch="${line#branch refs/heads/}"
+  elif [[ "$line" == "detached" ]]; then
+    block_detached=true
+  elif [[ "$line" == "prunable"* ]]; then
+    block_prunable=true
+  fi
+done <<< "$worktree_output"
+
+# Flush the last block (no trailing blank line at EOF).
+flush_block
+
+# ---------------------------------------------------------------------------
+# Detect gone-upstream branches using documented plumbing — NOT `git branch -vv`.
+# `git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/`
+# produces `[gone]` in the second column for branches whose upstream is deleted.
+# ---------------------------------------------------------------------------
+gone_branches_json="[]"
+
+while IFS= read -r ref_line; do
+  branch_name="${ref_line%% *}"
+  track_info="${ref_line#* }"
+  if [[ "$track_info" == "[gone]" ]]; then
+    gone_branches_json="$(printf '%s' "$gone_branches_json" | jq --arg b "$branch_name" '. + [$b]')"
+  fi
+done < <(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/)
+
+# ---------------------------------------------------------------------------
+# Compute candidates: worktrees whose branch name is in gone_branches,
+# excluding detached-HEAD entries.
+# ---------------------------------------------------------------------------
+candidates_json="$(jq -n \
+  --argjson worktrees "$worktrees_json" \
+  --argjson gone "$gone_branches_json" \
+  '[$worktrees[] | select(.branch != "(detached HEAD)" and (.branch as $b | $gone | index($b) != null)) | .branch]')"
+
+# ---------------------------------------------------------------------------
+# Emit final JSON to stdout.
+# ---------------------------------------------------------------------------
+jq -n \
+  --arg main_path "$main_path" \
+  --argjson fetch_ok "$fetch_ok" \
+  --argjson worktrees "$worktrees_json" \
+  --argjson gone_branches "$gone_branches_json" \
+  --argjson candidates "$candidates_json" \
+  '{
+    main_path: $main_path,
+    fetch_ok: $fetch_ok,
+    worktrees: $worktrees,
+    gone_branches: $gone_branches,
+    candidates: $candidates
+  }'

--- a/claude/scripts/pr-comments-fetch.sh
+++ b/claude/scripts/pr-comments-fetch.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+# This script's internals are exempt from `claude/references/bash-style.md` — that file
+# governs agent-level Bash tool calls only. Internal use of `&&`, `;`, `|`, and `$(...)` is
+# permitted.
+
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+
+# Arg validation: require a positive integer PR number.
+pr_number="${1:-}"
+if [[ -z "$pr_number" ]] || ! [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'Usage: pr-comments-fetch.sh <pr-number>\n' >&2
+  exit 2
+fi
+
+# Verify GitHub authentication.
+if ! gh auth status >/dev/null 2>&1; then
+  printf 'GitHub authentication is required. Run `gh auth login` and try again.\n' >&2
+  exit 1
+fi
+
+# Derive owner and repo from the git remote URL.
+origin_url="$(git remote get-url origin)"
+if [[ "$origin_url" =~ ^git@github\.com:([^/]+)/(.+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]%.git}"
+elif [[ "$origin_url" =~ ^https://github\.com/([^/]+)/([^/]+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]%.git}"
+else
+  printf 'Could not parse owner/repo from origin URL\n' >&2
+  exit 1
+fi
+
+# Fetch all pages of unresolved review threads via GraphQL and merge them.
+# NOTE (F-001): `gh api graphql --paginate` emits one separate JSON document per page
+# concatenated to stdout — NOT a single merged document. `jq -s` (slurp) is required to
+# collect all pages into an array before merging the per-page nodes arrays.
+#
+# The GraphQL query string and the jq merge filter are stored in variables so that
+# single-quote characters do not conflict with the surrounding $(...) command substitution.
+
+graphql_query='
+query($owner: String!, $repo: String!, $prNumber: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      title
+      state
+      reviewThreads(first: 100, after: $endCursor) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          comments(first: 100) {
+            nodes {
+              fullDatabaseId
+              author {
+                login
+              }
+              body
+              createdAt
+              diffHunk
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+jq_merge_filter='
+  if length == 0 then null
+  else
+    (.[0].data.repository.pullRequest) as $pr
+    | if $pr == null then null
+      else
+        {
+          title: $pr.title,
+          state: $pr.state,
+          threads: [ .[] | .data.repository.pullRequest.reviewThreads.nodes[] ]
+        }
+      end
+  end
+'
+
+result="$(gh api graphql --paginate \
+  -f query="$graphql_query" \
+  -f owner="$owner" \
+  -f repo="$repo" \
+  -F prNumber="$pr_number" \
+  | jq -s "$jq_merge_filter")"
+
+# Check that the PR was found.
+if [[ "$result" == "null" ]] || [[ -z "$result" ]]; then
+  printf 'PR #%s not found in %s/%s\n' "$pr_number" "$owner" "$repo" >&2
+  exit 1
+fi
+
+# Transform into final output shape: filter to unresolved threads only and rename fields.
+# F-002: no bare "id" in output — use thread_id, comment_full_database_id,
+#         first_comment_full_database_id.
+jq -n \
+  --argjson data "$result" \
+  --argjson pr_number "$pr_number" \
+  --arg owner "$owner" \
+  --arg repo "$repo" \
+  '
+    $data
+    | .threads |= map(select(.isResolved == false))
+    | {
+        pr_number: $pr_number,
+        title: .title,
+        state: .state,
+        owner: $owner,
+        repo: $repo,
+        threads: [
+          .threads[] | {
+            thread_id: .id,
+            is_resolved: .isResolved,
+            is_outdated: .isOutdated,
+            path: .path,
+            line: .line,
+            start_line: .startLine,
+            first_comment_full_database_id: .comments.nodes[0].fullDatabaseId,
+            comments: [
+              .comments.nodes[] | {
+                comment_full_database_id: .fullDatabaseId,
+                author: .author.login,
+                body: .body,
+                created_at: .createdAt,
+                diff_hunk: .diffHunk,
+                url: .url
+              }
+            ]
+          }
+        ]
+      }
+  '

--- a/claude/scripts/pr-comments-reply.sh
+++ b/claude/scripts/pr-comments-reply.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This script's internals are exempt from `claude/references/bash-style.md` — that file
+# governs agent-level Bash tool calls only. Internal use of `&&`, `;`, `|`, and `$(...)` is
+# permitted.
+
+# Known limitation (FV-2): GitHub's POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/
+# {comment_id}/replies endpoint returns 404 for comments submitted as part of a formal review
+# flow ("Start a Review"). It works only for standalone diff comments. When the script detects
+# a 404 response, it emits error_kind=review_flow_comment so the caller can show a clear
+# non-retryable error.
+
+set -euo pipefail
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+
+# Error contract (F-004):
+#   - Exit 2 ONLY for arg-validation (no JSON emitted — the only case where stdout is empty).
+#   - ALL other failures: emit {"ok": false, "error": "...", "error_kind": "<kind>"} to stdout
+#     and exit 1. The caller branches on .ok uniformly.
+#   - error_kind enum: auth, body_file_missing, owner_repo_parse, review_flow_comment, api,
+#     unknown.
+
+# Arg validation: require all three positional args.
+pr_number="${1:-}"
+comment_full_database_id="${2:-}"
+body_file_path="${3:-}"
+
+if [[ -z "$pr_number" ]] || [[ -z "$comment_full_database_id" ]] || [[ -z "$body_file_path" ]]; then
+  printf 'Usage: pr-comments-reply.sh <pr-number> <comment-full-database-id> <body-file-path>\n' >&2
+  exit 2
+fi
+
+# Verify GitHub authentication. On failure: emit JSON to stdout + exit 1.
+if ! gh auth status >/dev/null 2>&1; then
+  jq -n '{ok: false, error: "GitHub authentication is required. Run `gh auth login` and try again.", error_kind: "auth"}'
+  exit 1
+fi
+
+# Verify body file exists and is readable. On failure: emit JSON to stdout + exit 1.
+if [[ ! -r "$body_file_path" ]]; then
+  jq -n --arg path "$body_file_path" '{ok: false, error: ("body file not found: " + $path), error_kind: "body_file_missing"}'
+  exit 1
+fi
+
+# Derive owner and repo from the git remote URL.
+origin_url="$(git remote get-url origin)"
+if [[ "$origin_url" =~ ^git@github\.com:([^/]+)/(.+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]%.git}"
+elif [[ "$origin_url" =~ ^https://github\.com/([^/]+)/([^/]+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]%.git}"
+else
+  jq -n '{ok: false, error: "Could not parse owner/repo from origin URL", error_kind: "owner_repo_parse"}'
+  exit 1
+fi
+
+# Post the reply via the GitHub REST API. Capture stdout, stderr, and exit code separately.
+tmp_stdout="$(mktemp)"
+tmp_stderr="$(mktemp)"
+
+gh_exit=0
+gh api --method POST \
+  "/repos/${owner}/${repo}/pulls/${pr_number}/comments/${comment_full_database_id}/replies" \
+  -F body="@${body_file_path}" \
+  >"$tmp_stdout" 2>"$tmp_stderr" || gh_exit=$?
+
+api_stdout="$(cat "$tmp_stdout")"
+api_stderr="$(cat "$tmp_stderr")"
+rm -f "$tmp_stdout" "$tmp_stderr"
+
+if [[ "$gh_exit" -ne 0 ]]; then
+  # Detect the 404 review-flow case (FV-2).
+  if printf '%s' "$api_stderr" | grep -q 'HTTP 404'; then
+    jq -n '{
+      ok: false,
+      error: "Review-flow comment (404): cannot reply via REST replies endpoint. This comment was submitted as part of a formal review and the /replies endpoint does not support it. Use a standalone comment on the PR instead.",
+      error_kind: "review_flow_comment"
+    }'
+    exit 1
+  fi
+
+  # Any other API failure.
+  jq -n --arg err "$api_stderr" '{ok: false, error: $err, error_kind: "api"}'
+  exit 1
+fi
+
+# Success: extract html_url from the response and emit ok=true.
+html_url="$(printf '%s' "$api_stdout" | jq -r '.html_url // empty')"
+if [[ -z "$html_url" ]]; then
+  jq -n --arg raw "$api_stdout" '{ok: false, error: ("Unexpected response from GitHub API: " + $raw), error_kind: "unknown"}'
+  exit 1
+fi
+
+jq -n --arg url "$html_url" '{ok: true, html_url: $url}'

--- a/claude/skills/validate-before-pr/SKILL.md
+++ b/claude/skills/validate-before-pr/SKILL.md
@@ -19,49 +19,56 @@ This skill is **mandatory** for:
 
 **Do not** open a PR through any means without running this skill first.
 
-## Stack Detection
-
-Before running the checks below, detect which toolchain the repository uses. Check in this order and use the **first match**:
-
-1. **`package.json` exists** (Node/npm): Use `npm run lint` and `npm run format:check` (Steps 1-2 below as written).
-2. **`Makefile` exists with `lint` target**: Use `make lint` for lint. For format check: look for a `make fmt-check`, `make format-check`, or `make check-format` target (exits non-zero on violations without modifying files). If the Makefile only has a `fmt` target that modifies files, skip the format check for this project and warn the user: "Makefile `fmt` target detected but it modifies files — skipping format check. Add a `fmt-check` target to enable it." (substitute lint command in Step 1).
-3. **`pyproject.toml` exists**: Use `ruff check .` for lint and `ruff format --check .` for format (substitute in Steps 1-2).
-4. **`setup.py` or `setup.cfg` exists** (legacy Python): Use `flake8 .` for lint and `black --check .` for format (substitute in Steps 1-2).
-5. **`go.mod` exists** (Go): Use `golangci-lint run` for lint and `gofmt -l .` for format check (substitute in Steps 1-2; format check passes if `gofmt -l .` produces no output).
-6. **`Cargo.toml` exists** (Rust): Use `cargo clippy` for lint and `cargo fmt --check` for format check (substitute in Steps 1-2).
-7. **No match**: Warn the user that no recognized lint/format toolchain was found. Skip validation and proceed to `open-pull-request` with a note that pre-PR checks were not run.
-
-The npm commands in Steps 1-2 below are the default. When stack detection selects a different toolchain, substitute the corresponding commands but follow the same pass/fail logic.
-
 ## Steps
 
 Each check must be run as a **separate, standalone Bash call**. Do not chain commands with `&&` or `;` — this is required by the bash-style rule.
 
-### Step 1 — Run lint (npm default: `npm run lint`)
+### Step 0 — Detect stack
 
-Run the following as a standalone Bash call:
+Run the following as a standalone Bash call (no args — uses the current directory):
 
 ```
-npm run lint
+~/.claude/scripts/detect-stack.sh
+```
+
+The script emits a single-line JSON object to stdout:
+
+```json
+{"stack": "...", "lint_cmd": "...", "format_check_cmd": "...", "format_warning": "..."}
+```
+
+Branch on `.stack`:
+
+- If `.stack == "unknown"`: print the value of `.format_warning` (which will be "No recognized lint/format toolchain was found. Skipping validation."), then jump directly to Step 3. Note in the handoff that pre-PR checks were not run.
+- Otherwise: store `.lint_cmd` as `<lint_cmd>` and `.format_check_cmd` as `<format_check_cmd>` for use in Steps 1–2. If `.format_warning` is non-empty, print it now (this surfaces the Makefile `fmt`-only warning to the user). Proceed to Step 1.
+
+### Step 1 — Run lint
+
+Run the following as a standalone Bash call, using the `<lint_cmd>` value captured in Step 0:
+
+```
+<lint_cmd>
 ```
 
 - If lint **passes** (exit code 0): proceed to Step 2.
 - If lint **fails** (non-zero exit): stop immediately. Do not proceed to format check or PR creation. Report the full lint output to the user and request that the errors be fixed before retrying.
 
-### Step 2 — Run format check (npm default: `npm run format:check`)
+### Step 2 — Run format check
 
-Run the following as a standalone Bash call:
+If `<format_check_cmd>` is empty (e.g., a Makefile repo with only a `fmt` target that modifies files), skip this step with the note: "No format check is configured for this stack." Proceed directly to Step 3.
+
+Otherwise, run the following as a standalone Bash call, using the `<format_check_cmd>` value captured in Step 0:
 
 ```
-npm run format:check
+<format_check_cmd>
 ```
 
 - If format check **passes** (exit code 0): proceed to Step 3.
-- If format check **fails** (non-zero exit): stop immediately. Do not open the PR. Report the full output to the user. Suggest running `npm run format` to auto-fix formatting issues, then re-running `npm run format:check` to confirm.
+- If format check **fails** (non-zero exit): stop immediately. Do not open the PR. Report the full output to the user and request that the formatting issues be fixed before retrying.
 
 ### Step 3 — Proceed to open-pull-request
 
-Only after **both** Step 1 and Step 2 pass may you proceed to the `open-pull-request` skill to create the pull request.
+Only after **both** Step 1 and Step 2 pass (or after Step 0 short-circuits to here on `stack == "unknown"`, or after Step 2 is skipped due to empty `<format_check_cmd>`) may you proceed to the `open-pull-request` skill to create the pull request.
 
 ## Fail-Fast Behavior
 


### PR DESCRIPTION
Adds five POSIX shell scripts to claude/scripts/ that replace prose-directed shell work in the /merged, /clean-the-desk, /address-pr-comments commands and the validate-before-pr skill. Each script emits structured JSON output, making mechanical discovery steps deterministic and eliminating repeated inline shell logic from command/skill prose. This reduces LLM token consumption on each invocation of the affected commands.