### PR TITLE
feat(agents): add project constitution with parallel-session and self-containment enforcement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,3 +41,7 @@ The workflow is:
 **Critical implication for all changes:** The installed artifacts carry **no back-references to this repository**. Once copied, they are standalone files at their destination. Any change you make must therefore be complete and self-contained within the artifact itself — do not add relative paths, symlinks, or runtime references that assume the repo still exists on disk.
 
 This self-containment constraint applies to everything `install.sh` installs — the contents of `claude/` and `src/mcp/wrappers/`. It does **not** apply to repo-scope artifacts in `.claude/`, which are only active when the repo is checked out. When reviewing or authoring any artifact in `claude/` or `src/mcp/wrappers/`, always ask: *"Will this work correctly after being copied to its destination with no repo present?"*
+
+## Project Constitution
+
+This repository has a Project Constitution defining repo-scoped invariants that govern all work here. See `.claude/constitution.md` for the full text, definitions, and enforcement details. All plans, implementations, and reviews are evaluated against these principles; Ruinor enforces them as a mandatory checklist.

--- a/.claude/constitution.md
+++ b/.claude/constitution.md
@@ -1,0 +1,30 @@
+# Project Constitution — ai-tpk
+
+This file defines repo-scoped invariants that govern all work in this repository. Violations of these principles must be caught at plan review (Ruinor) and rejected before execution proceeds. Because globally-installed agents (Pathfinder, Bitsmith, Ruinor) live at `~/.claude/agents/` and cannot load repo-scoped instructions from `~/.claude/`, the Dungeon Master bridges the gap by inlining this constitution into every Pathfinder, Bitsmith, and Ruinor delegation prompt at delegation time.
+
+## Definitions
+
+**Session artifact:** any file written during a session that captures session-specific runtime state, output, or context. Canonical positive example (anti-pattern): `~/.ai-tpk/session-context/current.json` from PR #187. Session artifacts MUST be session-namespaced (e.g., prefixed with `SESSION_TS` or a session-unique identifier) and MUST NOT use fixed/singleton paths shared across sessions.
+
+**Static artifact:** any file that is not a session artifact — including documentation (e.g., `.claude/constitution.md`, `.claude/CLAUDE.md`), agent definitions (e.g., `~/.claude/agents/*.md`), configuration files (e.g., `claude/settings.json`), and per-repo (not per-session) artifacts. Static artifacts MAY use fixed paths. The shared parent directory `~/.ai-tpk/plans/{REPO_SLUG}/` is itself static; the per-session files inside it are session artifacts and ARE session-namespaced (e.g., `{SESSION_TS}-{feature-slug}.md`).
+
+## Principle 1 — Parallel Session Isolation
+
+ai-tpk is designed to support multiple sessions running concurrently. Every design, plan, and implementation must respect this invariant.
+
+- Each session runs in its own isolated worktree — no two sessions share a working directory.
+- No agent, hook, or artifact may write to a fixed/singleton path shared across sessions. "Session artifact" means any file written during a session that captures session-specific runtime state, output, or context (e.g., `~/.ai-tpk/session-context/current.json` from PR #187 is the canonical anti-pattern). Static documentation, agent definitions, configuration files, and per-repo (not per-session) artifacts are NOT session artifacts and may use fixed paths.
+- All session artifacts (plan files, sidecar files, open-questions files) must be session-namespaced (e.g., prefixed with `SESSION_TS` or a session-unique identifier).
+- No agent definition may assume it is the only active session.
+
+## Principle 2 — Install-time Self-Containment
+
+All artifacts in `claude/` (agents, skills, commands, hooks, references, settings) must be fully self-contained after `install.sh` copies them to `~/.claude/`. No runtime back-references to the repository are permitted — no relative paths that assume the repo exists on disk, no symlinks to repo directories, no instructions to read files at `.claude/` paths that only exist in the repo working tree.
+
+## How These Principles Are Enforced
+
+Three mechanisms enforce these principles across all work in this repository:
+
+- **(a) `.claude/CLAUDE.md` summary** — the project-scope CLAUDE.md includes a `## Project Constitution` section that names both principles, summarises them, and points here as the canonical source. Any reader of the project-scope instructions sees the principles without needing the DM injection path.
+- **(b) DM injection** — `claude/agents/dungeonmaster.md`'s `### Project Constitution Injection` section specifies how DM inlines this file's contents into every Pathfinder, Bitsmith, and Ruinor delegation prompt. This is the primary enforcement path for globally-installed agents that cannot read repo-scoped files directly.
+- **(c) Agent-level hooks** — `claude/agents/ruinor.md`'s `### Constitution Compliance Check` section (in Phase 3) makes both principles explicit checklist items on every plan and implementation review. `claude/agents/bitsmith.md`'s "What Bitsmith Does NOT Touch" list names constitutional violations as a halt-and-escalate condition so conflicts surface before implementation rather than at review time.

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -55,6 +55,7 @@ When `WORKING_DIRECTORY` is absent from the delegation prompt: for read-only tas
 - **Code quality review** — that is Ruinor's hammer, not hers
 - **Plan files** — these are read-only scrolls from the architect's table; she does not alter them
 - **Scope expansion** — if the task grows, she surfaces it; she does not absorb it silently
+- **Constitutional violations** — if executing the plan would, in your judgment, violate either Project Constitution principle (per the injected `## Project Constitution` block in the delegation prompt), surface the conflict to DM via the structured failure-report path before implementing. This is a halt-and-escalate condition, not a Bitsmith-fixes-it-silently condition. If no `## Project Constitution` block is present in the delegation prompt, this bullet does not apply.
 
 ## The Masterwork Standard (Key Success Criteria)
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -143,7 +143,35 @@ REPO_SLUG: {REPO_SLUG}
 All file operations and Bash commands must use this directory as the working root.
 ```
 
-Ruinor and other reviewer agents do not receive this block — instead, pass worktree-absolute file paths directly in their delegation prompts.
+Ruinor and other reviewer agents do not receive this block — instead, pass worktree-absolute file paths directly in their delegation prompts. Note: Ruinor does receive the separate Project Constitution Injection block — see the Project Constitution Injection section below.
+
+### Project Constitution Injection
+
+**Rationale:** Globally-installed agents at `~/.claude/agents/` cannot read repo-scoped files at `.claude/CLAUDE.md` or `.claude/constitution.md` directly — they execute from `~/.claude/` and have no reliable path to the repo working tree. DM bridges this gap by inlining the constitution into every delegation prompt for the three agents that author plans, code, or constitution-bearing reviews.
+
+**Detection path (single, deterministic):** At the start of every Pathfinder, Bitsmith, or Ruinor delegation, DM checks whether the file at `${WORKING_DIRECTORY:-$(git rev-parse --show-toplevel)}/.claude/constitution.md` exists. When `WORKING_DIRECTORY` is set in conversation memory (constructive/investigative pipelines after the Worktree Creation Subroutine has run), it resolves to `{WORKTREE_PATH}/.claude/constitution.md`. When `WORKING_DIRECTORY` is unset (advisory sessions, or pipelines where the subroutine has not yet run), it falls back to `{REPO_ROOT}/.claude/constitution.md` derived from `git rev-parse --show-toplevel`. There is no other detection path. If both resolutions fail (e.g., DM is not inside a git repository), DM skips injection silently.
+
+**Bootstrap exception:** The very first session in this repository that creates `.claude/constitution.md` (e.g., the session executing the bootstrap plan that introduced this file) will not see injection during its own Pathfinder and Bitsmith delegations, because the file does not exist on the branch the worktree was cut from at the moment those delegations are issued. Injection begins to fire as soon as the step that creates `.claude/constitution.md` completes — meaning Ruinor reviewing the bootstrap implementation will see the constitution injected, even though Pathfinder and Bitsmith producing it did not. This is an accepted bootstrap asymmetry; subsequent sessions in the same worktree (or any worktree cut from a branch where the file exists) will see injection from the first delegation onward.
+
+**Mid-session amendment behavior:** If `.claude/constitution.md` is created or modified mid-session, subsequent delegations in the same session re-read the file at delegation time and pick up the latest contents — DM does not cache the file body across delegations.
+
+**Conditional/no-op behavior:** If the resolved constitution path does not exist (bootstrap session before the file is created; DM operating in a different repo; file deleted), DM skips injection silently — no warning, no error.
+
+**Agents that receive injection:** Pathfinder, Bitsmith, and Ruinor. Do NOT inject into Quill, Tracebloom, Askmaw, Reisannin, or specialist reviewer delegations — none of these agents author plans, code, or constitution-bearing reviews.
+
+**Injection placement:**
+- For Pathfinder and Bitsmith delegations: insert the injected block **after** the Worktree Context Block (`WORKING_DIRECTORY:` / `WORKTREE_BRANCH:` / `REPO_SLUG:` lines and the trailing scope sentence) and **before** the task-specific delegation content (e.g., `## Investigation Request`, `## Confirmed Scope`, `## Plan to Revise`, or the equivalent task header for the delegation type).
+- For Ruinor delegations: Ruinor does not receive the Worktree Context Block (per the rule above). Insert the injected block at the very top of the delegation prompt, before any task-specific content.
+
+**Injected block format:** Wrap the file's contents under a `## Project Constitution` heading and follow with this exact reminder line so the receiving agent knows to apply it:
+
+```
+## Project Constitution
+
+{verbatim contents of .claude/constitution.md}
+
+These principles govern this repository. Plans and implementations that violate either principle will be rejected by Ruinor.
+```
 
 ## Specialist Review Triggering
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -37,11 +37,13 @@ See `claude/references/review-gates.md` for the shared gate framework and operat
 - Assess plan feasibility, completeness, and soundness
 - Identify gaps, impossible steps, circular dependencies
 - Issue verdict on whether plan is executable
+- Constitution Compliance: apply the Constitution Compliance Check defined at the top of Phase 3.
 
 **Implementation Review Gate — Ruinor criteria:**
 - Assess correctness, edge cases, error paths
 - Check quality: maintainability, performance, security
 - Issue verdict on whether implementation is ready for merge
+- Constitution Compliance: apply the Constitution Compliance Check defined at the top of Phase 3.
 
 ## Key Responsibilities
 
@@ -95,6 +97,15 @@ Verify factual claims and assumptions:
 - Do estimates and scope assessments align with reality?
 
 ### Phase 3: Multi-Perspective Review
+
+#### Constitution Compliance Check
+
+When a `## Project Constitution` block is present in your delegation prompt (injected by DM per `claude/agents/dungeonmaster.md`'s Project Constitution Injection logic), apply both principles as verification criteria during this Phase 3 review, exactly as stated in the injected block. The injected block is the authoritative copy — do not attempt to read `.claude/constitution.md` directly, as you do not receive the Worktree Context Block and have no reliable path to the file. If no `## Project Constitution` block is present in the delegation prompt, skip this section.
+
+**Severity rule:** A demonstrable violation of either principle is at minimum a MAJOR finding and may be CRITICAL depending on impact. The verdict for an artifact containing an unresolved constitutional violation must not be ACCEPT.
+
+**Worked example:** Positive (anti-pattern, must reject): a plan step that writes `~/.ai-tpk/foo/current.json` is a violation. Negative (acceptable, do not flag): a plan step that creates `.claude/constitution.md` at a fixed path is acceptable because `.claude/constitution.md` is a static artifact per the injected Definitions section.
+
 Evaluate from multiple angles:
 
 For code reviews:

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -25,6 +25,8 @@ This document explains how Claude Code loads instructions at two levels in this 
 - **User scope** (`claude/`) — applied globally across all repositories
 - **Project scope** (`.claude/`) — applied only to this repository
 
-See `.claude/CLAUDE.md` for the full scope clarification rules and trigger cases.
+**Project Constitution:** `.claude/CLAUDE.md` carries a `## Project Constitution` section pointing to `.claude/constitution.md` as the canonical source of the repo's invariant principles. All plans, implementations, and reviews are evaluated against these principles; Ruinor enforces them as a mandatory checklist.
+
+See `.claude/CLAUDE.md` for the full scope clarification rules, trigger cases, and constitution summary.
 
 **Note:** Skill mandate enforcement depends on Claude Code's instruction precedence behavior. Project-level mandates are intended to supplement, not override, user-level mandates.

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -127,7 +127,7 @@ Or use the `/merged` command after a PR is merged — it removes the worktree an
 
 ## Worktree Awareness in Sub-Agents
 
-When a DungeonMaster session has an active worktree, all sub-agents (Pathfinder, Bitsmith, Quill, Tracebloom) automatically receive worktree context:
+When a DungeonMaster session has an active worktree, Pathfinder, Bitsmith, Quill, and Tracebloom automatically receive the worktree context block:
 
 ```
 WORKING_DIRECTORY: /absolute/path/to/.worktrees/feat-add-oauth-login
@@ -141,6 +141,8 @@ Sub-agents respect this context:
 - **Bitsmith:** Performs all code changes within the worktree; commits land on the worktree's branch
 - **Quill:** Writes documentation updates relative to the worktree
 - **Tracebloom:** Reads files from the worktree when investigating
+
+Ruinor does not receive the worktree context block. Instead, DM inserts a `## Project Constitution` block at the top of every Ruinor delegation prompt. For the full injection logic — detection path, bootstrap exception, and placement rules — see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) (Project Constitution Injection section).
 
 ### Bitsmith's Path Mismatch Guard
 

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -354,6 +354,7 @@ Existing workflows continue to work; they just run more efficiently now.
 - **Hard intermediate review gates** - After 2 consecutive Bitsmith invocations, a review gate is mandatory before continuing
 - **REJECT verdicts require remediation** - When Ruinor issues REJECT, Bitsmith must provide a written remediation brief before re-review to prevent rubber-stamp approvals
 - **Documentation follows implementation** - Quill is invoked only after implementation review is fully complete; any post-documentation code changes must re-enter the implementation review gate
+- **Constitution compliance is a mandatory review criterion** - Ruinor verifies every plan and implementation against the Project Constitution principles (see `.claude/constitution.md`) via its `#### Constitution Compliance Check` section. A demonstrable violation is at minimum MAJOR and blocks ACCEPT. The constitution is injected into Ruinor's delegation prompt by DM; see [`claude/agents/ruinor.md`](/claude/agents/ruinor.md) for the checklist and [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) for the injection logic.
 
 ## Future Enhancements
 


### PR DESCRIPTION
Introduces a two-principle Project Constitution enforced through DM injection, Ruinor review criteria, and a Bitsmith halt-and-escalate path. Motivated by PR #187's singleton-path anti-pattern, which this constitution explicitly prohibits. Principles: (1) Parallel Session Isolation — no singleton session artifacts, all session state must be namespaced; (2) Install-time Self-Containment — claude/ artifacts must be fully standalone after install.sh.