### PR TITLE
refactor(agents): extract specialist-routing keyword tables into shared reference

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -195,21 +195,7 @@ Parse Ruinor's review output for "Specialist Review Recommended" field:
 
 ### Keyword Detection (Heuristic Fallback)
 
-If no user flags and Ruinor doesn't recommend specialists, check plan/request for keywords:
-
-**Security keywords** (suggest Riskmancer):
-- auth, authentication, authorization, session, jwt, token, password, crypto, encrypt, secret, credential, payment, pii, oauth, api key
-
-**Performance keywords** (suggest Windwarden):
-- database, query, performance, scale, optimization, cache, index, pagination, algorithm, batch, real-time, throughput, latency
-
-**Complexity keywords** (suggest Knotcutter):
-- refactor, architecture, abstraction, framework, pattern, generalize, redesign, restructure, simplify
-
-**Factual validation keywords** (suggest Truthhammer):
-- changelog, breaking change, deprecated, upgrade path, migration guide, compatibility matrix, release notes
-
-**Note:** Keyword detection is a fallback heuristic. Prefer Ruinor's recommendations as the primary trigger mechanism. Truthhammer's factual-validation keywords are intentionally narrow (7 high-signal terms only) — generic infrastructure terms are excluded to avoid triggering Truthhammer on nearly every task. Ruinor's intelligent recommendations and the `--verify-facts` user flag are the primary trigger mechanisms for Truthhammer.
+If no user flags and Ruinor doesn't recommend specialists, check the plan/request against the canonical keyword list maintained in `claude/references/specialist-triggering.md` (security, performance, complexity, and factual-validation keywords with their corresponding specialist suggestions). That reference also documents why Truthhammer's keyword set is intentionally narrow.
 
 ## Important constraints
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -133,6 +133,8 @@ For plan reviews:
 ### Phase 5: Specialist Assessment
 After completing the multi-perspective review, assess whether specialist-level concerns warrant deeper investigation:
 
+Note: The Dungeon Master's heuristic-fallback specialist-routing keyword list is maintained in `claude/references/specialist-triggering.md`. The criteria below are Ruinor's own prose-based specialist-flagging logic and are intentionally distinct from that keyword list, but the two should remain semantically aligned — when adding or removing a specialist-flagging condition here, consider whether the corresponding keyword list also needs an update.
+
 **Flag for Riskmancer (Security Specialist) when:**
 - Authentication, authorization, or access control logic is involved
 - Cryptography, encryption, or key management is present

--- a/claude/references/specialist-triggering.md
+++ b/claude/references/specialist-triggering.md
@@ -1,0 +1,19 @@
+# Specialist Review Triggering — Keyword Reference
+
+This file is the canonical keyword list used by the Dungeon Master's heuristic-fallback specialist-routing logic. DM consults these keywords only when no user flag is present (e.g., `--review-security`) and Ruinor has not recommended specialists in its review output. Ruinor's specialist-flagging prose criteria in `claude/agents/ruinor.md` Phase 5 are a parallel but distinct mechanism — both should remain semantically aligned, but they are not auto-synced.
+
+## Keyword Detection (Heuristic Fallback)
+
+**Security keywords** (suggest Riskmancer):
+- auth, authentication, authorization, session, jwt, token, password, crypto, encrypt, secret, credential, payment, pii, oauth, api key
+
+**Performance keywords** (suggest Windwarden):
+- database, query, performance, scale, optimization, cache, index, pagination, algorithm, batch, real-time, throughput, latency
+
+**Complexity keywords** (suggest Knotcutter):
+- refactor, architecture, abstraction, framework, pattern, generalize, redesign, restructure, simplify
+
+**Factual validation keywords** (suggest Truthhammer):
+- changelog, breaking change, deprecated, upgrade path, migration guide, compatibility matrix, release notes
+
+**Note:** Keyword detection is a fallback heuristic. Prefer Ruinor's recommendations as the primary trigger mechanism. Truthhammer's factual-validation keywords are intentionally narrow (7 high-signal terms only) — generic infrastructure terms are excluded to avoid triggering Truthhammer on nearly every task. Ruinor's intelligent recommendations and the `--verify-facts` user flag are the primary trigger mechanisms for Truthhammer.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -35,6 +35,8 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`quill-documentation-style.md`** — Documentation style guide used by Quill when authoring and updating documentation.
 
+- **`specialist-triggering.md`** — Canonical keyword list for the Dungeon Master's heuristic-fallback specialist-routing logic. Covers four keyword categories (security, performance, complexity, factual validation) and their corresponding specialist suggestions. DM consults this only when no user flag is present and Ruinor has not recommended specialists. Also documents why Truthhammer's keyword set is intentionally narrow. See [docs/adrs/REVIEW_WORKFLOW.md](/docs/adrs/REVIEW_WORKFLOW.md) for the broader specialist-triggering decision model.
+
 When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
 
 ## Skills (`claude/skills/`)

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -209,7 +209,7 @@ Recommend performance specialist review.
 
 If no user flags present AND Ruinor doesn't recommend specialists, the orchestrator checks plan/code content for specialist keywords.
 
-The full keyword lists are defined per-agent in the agent files: [`claude/agents/riskmancer.md`](/claude/agents/riskmancer.md) (security), [`claude/agents/windwarden.md`](/claude/agents/windwarden.md) (performance), [`claude/agents/knotcutter.md`](/claude/agents/knotcutter.md) (complexity), and [`claude/agents/truthhammer.md`](/claude/agents/truthhammer.md) (factual validation). Truthhammer's list is intentionally narrow — see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) "Keyword Detection (Heuristic Fallback)" section for the rationale.
+The canonical keyword list (security, performance, complexity, and factual-validation keywords with their specialist mappings) is maintained in [`claude/references/specialist-triggering.md`](/claude/references/specialist-triggering.md). Truthhammer's list is intentionally narrow — see that reference for the rationale.
 
 **Limitations:**
 - Less precise than Ruinor recommendations


### PR DESCRIPTION
The four specialist-routing keyword tables in `claude/agents/dungeonmaster.md` were extracted into a new shared reference file `claude/references/specialist-triggering.md`. Both the DM and Ruinor now reference the canonical location, making future keyword updates a single-file edit and eliminating the drift risk between the two agents. The REVIEW_WORKFLOW ADR and SKILLS catalog were updated to reflect the new location.