### PR TITLE
feat(dm): add premise-check pause to investigative gate

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -328,11 +328,42 @@ If the task was classified as investigative (see "When to call Tracebloom" routi
 
 1. Delegate to Tracebloom with the user's reported symptom and any error messages or context using the delegation template below
 2. When Tracebloom returns a Diagnostic Report, evaluate the "Recommended next action" field:
-   - **"Route to Pathfinder for planning a fix"**: Proceed to step 2 (Planning), passing the Diagnostic Report to Pathfinder as context using the handoff template below
+   - **"Route to Pathfinder for planning a fix"**: Run the **Premise Check** in step 3 below before delegating. Once the user confirms (or adjusts) the premise, proceed to step 2 (Planning), passing the Diagnostic Report to Pathfinder as context using the handoff template below.
    - **"Fix is trivial -- route to Bitsmith directly"**: Skip Pathfinder. Delegate the fix directly to Bitsmith with the Diagnostic Report as context. Proceed to Phase 4 (Implementation Review) after Bitsmith completes.
    - **"Inconclusive"**: Present the Diagnostic Report findings to the user. Ask: "Tracebloom's investigation was inconclusive. Would you like to (a) investigate further with a narrower focus, (b) proceed to planning based on what we know, or (c) provide additional context?" Act on the user's choice.
    - **"No bug found"**: Present the explanation to the user. Session ends unless the user disagrees and wants further investigation.
-3. Present a one-line summary of the Diagnostic Report to the user before proceeding (e.g., "Tracebloom identified [root cause] in [file]. Proceeding to planning.").
+3. **Premise Check** (fires only when step 2 selected the "Route to Pathfinder for planning a fix" branch — skip this step for the other three branches):
+
+   a. Extract three scope-bearing items from the Diagnostic Report:
+      - **Root cause:** the one-sentence statement from the Diagnostic Report's `Root cause` field. If the field is multi-sentence, use the first sentence; do not paraphrase.
+      - **Affected files/components:** the file paths (and component names where given) listed in the Diagnostic Report's `Evidence` field. Present them as a short bullet list. If Evidence contains non-file entries (log queries, metric results, git commits), include only the file/component entries here; the user will see the full Diagnostic Report in the handoff. If Evidence contains no file/component entries at all (e.g., infrastructure-only evidence consisting of logs, metrics, or Kubernetes state), render this as a single line: `- (No file-scope evidence — see Diagnostic Report for runtime evidence)`.
+      - **Recommended next action:** the verbatim string from the Diagnostic Report's `Recommended next action` field (which, on this branch, will be "Route to Pathfinder for planning a fix").
+
+   b. Surface this disclosure to the user using the **Premise Check template** below.
+
+   c. **Wait for explicit user response.** Do not delegate to Pathfinder until the user replies. There is no implicit timeout.
+
+   d. Interpret the response:
+      - If the user replies with "proceed", "go ahead", "continue", "yes", "ok", or any clearly affirmative variant: invoke Pathfinder using the unchanged Diagnostic Report handoff template (defined later in this gate). Pass the Diagnostic Report verbatim with no modifications.
+      - If the user provides corrections, scope adjustments, or additional context: invoke Pathfinder using the Diagnostic Report handoff template, and **append** the user's corrections as an additional `## User-supplied scope adjustments` section after the verbatim Diagnostic Report and before the `[Rest of Pathfinder delegation as normal]` marker. Do not edit or rewrite the Diagnostic Report itself.
+      - If the user rejects the diagnosis outright (e.g., "this is wrong", "not the right area"): do not invoke Pathfinder. Ask the user whether to (i) re-invoke Tracebloom with a narrower or different focus, or (ii) abandon the investigative path and re-state the request. Act on their choice.
+
+**Premise Check template** (use this exact format when surfacing the disclosure to the user):
+
+~~~
+Tracebloom completed its investigation. Before I hand this off to Pathfinder for planning, please confirm the diagnosis matches your understanding of the problem.
+
+**Root cause:** {one-sentence root cause}
+
+**Affected files/components:**
+- {file or component 1}
+- {file or component 2}
+- {…}
+
+**Recommended next action:** {verbatim recommended next action}
+
+Reply with "proceed" to continue to planning, or describe any corrections or scope adjustments you would like Pathfinder to incorporate.
+~~~
 
 When not triggered: skip directly to the Intake Gate.
 

--- a/claude/references/dm-routing-examples.md
+++ b/claude/references/dm-routing-examples.md
@@ -162,6 +162,7 @@ Action:
 
 Example 11:
 User asks (via /ops): "What authentication patterns are used in this codebase?"
+
 Action:
 - **Intent override fires:** `INTENT: advisory --save-report`. Log: "Intent override: advisory. Heuristic classification skipped." Capture `--save-report` as active workflow flag. Strip `INTENT: advisory --save-report` from message.
 - **Session variables captured:** `SESSION_TS` = `20260413-110000`, `SESSION_SLUG` = `auth-patterns-codebase`
@@ -173,3 +174,28 @@ Action:
 - **`--save-report` post-synthesis:** DM runs `git rev-parse --show-toplevel` → succeeds, returns `/home/user/my-project`. Delegates to Bitsmith: write report to `/home/user/my-project/reports/20260413-110000-auth-patterns-codebase.md`. Bitsmith creates directory and writes file. DM logs: "Report saved to `/home/user/my-project/reports/20260413-110000-auth-patterns-codebase.md`"
 - Session complete — no review, no plan, no PR prompt
 - Output contract: Question, Agents consulted (Tracebloom), Answer summary, Sources, Report saved: `/home/user/my-project/reports/20260413-110000-auth-patterns-codebase.md`
+
+Example 12:
+User asks (via /bug): "Why are API responses slow for the search endpoint?"
+Action:
+- **Phase 1 Worktree Creation Subroutine:** DM invokes the subroutine (`INTENT: investigative` from `/bug`), delegates to Bitsmith to create the worktree at `.worktrees/fix-api-responses-slow-search` on branch `fix/api-responses-slow-search`. Investigative Gate fires.
+- **Phase 1, step 1:** DM clarifies goal: "Determine why API responses are slow for the search endpoint."
+- **Investigative Gate triggers**
+- Invoke Tracebloom with symptom: "API responses slow for the search endpoint"
+- Tracebloom returns Diagnostic Report:
+  - Symptom: `GET /api/search` P95 latency > 4 s under normal load
+  - Root cause: Full-table scan on `items` table — the `tags` column used in the search filter has no index
+  - Evidence: `src/search/repository.ts` (query construction), `db/schema.sql` (no index on `tags`)
+  - Recommended next action: "Route to Pathfinder for planning a fix"
+- **Premise Check fires** (Pathfinder branch selected):
+  - DM extracts: Root cause (one sentence), Affected files (`src/search/repository.ts`, `db/schema.sql`), Recommended next action (verbatim)
+  - DM surfaces the Premise Check template to the user and waits
+
+  **Path A — user replies "proceed":**
+  - DM invokes Pathfinder with the Diagnostic Report handoff template, Diagnostic Report passed verbatim. Pathfinder skips Section 4 (Diagnostic Report present), writes plan to `~/.ai-tpk/plans/{REPO_SLUG}/20260419-143000-api-responses-slow-search.md`. Continue with Phase 2 (Plan Review Gate), Phase 3, Phase 4, Phase 5 as normal.
+
+  **Path B — user provides corrections:** "The `name` column is also unindexed — please include that."
+  - DM invokes Pathfinder with the Diagnostic Report handoff template, appending a `## User-supplied scope adjustments` section: "Also add an index on the `name` column." Diagnostic Report itself is unchanged. Pathfinder incorporates the adjustment in the plan. Continue with Phase 2 onward.
+
+  **Path C — user rejects the diagnosis:** "That's not right — search is backed by Elasticsearch, not SQL."
+  - DM does not invoke Pathfinder. DM asks: "Would you like to (i) re-invoke Tracebloom with a narrower or different focus, or (ii) abandon the investigative path and re-state the request?" User selects (i). DM re-invokes Tracebloom with updated context targeting the Elasticsearch integration. Investigative Gate restarts from step 1 with the new Diagnostic Report.

--- a/docs/WORKFLOW_ENTRY_POINTS.md
+++ b/docs/WORKFLOW_ENTRY_POINTS.md
@@ -23,7 +23,7 @@ The Dungeon Master now supports two distinct entry points for development tasks,
 2. Tracebloom produces a **Diagnostic Report**. For the authoritative report schema and the five required fields, see [`claude/agents/tracebloom.md`](/claude/agents/tracebloom.md#diagnostic-report).
 3. DM evaluates the report's recommendation and routes accordingly: For the authoritative routing logic for each of the four "Recommended next action" values, see [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md#phase-1-planning) "Investigative Gate".
 
-**Key property:** Read-only investigation. Tracebloom never writes, edits, or runs write-bearing commands. The Diagnostic Report is structured to feed directly into Pathfinder's planning.
+**Key property:** Read-only investigation. Tracebloom never writes, edits, or runs write-bearing commands. The Diagnostic Report feeds into Pathfinder's planning after a user-facing Premise Check confirms the diagnosis.
 
 ---
 
@@ -57,14 +57,22 @@ The Dungeon Master now supports two distinct entry points for development tasks,
 
 ## Diagnostic Report as a Planning Input
 
-When Tracebloom's investigation produces a report recommending "Route to Pathfinder for planning a fix," the Diagnostic Report itself becomes Pathfinder's requirements input. Pathfinder:
+When Tracebloom's investigation produces a report recommending "Route to Pathfinder for planning a fix," the DM runs a **Premise Check** before delegating to Pathfinder. The Premise Check surfaces three scope-bearing items to the user and waits for explicit confirmation:
+
+- **Root cause** — the one-sentence statement from Tracebloom's report
+- **Affected files/components** — file paths and component names from the Evidence field
+- **Recommended next action** — the verbatim routing recommendation
+
+The user may reply with "proceed" (DM passes the Diagnostic Report to Pathfinder unchanged), provide corrections or scope adjustments (DM appends them to the handoff), or reject the diagnosis outright (DM offers to re-invoke Tracebloom or abandon the investigative path).
+
+Once the user confirms, the Diagnostic Report becomes Pathfinder's requirements input. Pathfinder:
 
 - **Uses the root cause and evidence directly** from the report as the problem definition
 - **Does NOT re-investigate** facts already established in the report
 - **May ask follow-up questions** about priorities, scope, or how to handle multiple contributing factors
 - **Notes in the plan** if the fix is trivial (as flagged by Tracebloom)
 
-This eliminates redundant investigation and ensures that Pathfinder builds on Tracebloom's findings rather than starting from scratch.
+This eliminates redundant investigation and ensures that Pathfinder builds on Tracebloom's findings rather than starting from scratch. The premise check ensures the user has a chance to correct a misdiagnosis or adjust scope before planning begins.
 
 ---
 
@@ -78,7 +86,11 @@ User request received
     │  │
     │  ├─ YES → Tracebloom → Diagnostic Report
     │  │            │
-    │  │            ├─ "Route to Pathfinder" → Pathfinder (uses report as context)
+    │  │            ├─ "Route to Pathfinder" → Premise Check (user confirms diagnosis)
+    │  │            │                              │
+    │  │            │                              ├─ Proceed → Pathfinder (report as context)
+    │  │            │                              ├─ Corrections → Pathfinder (report + adjustments)
+    │  │            │                              └─ Reject → Re-invoke Tracebloom or abandon
     │  │            ├─ "Fix is trivial" → Bitsmith (uses report as context)
     │  │            ├─ "Inconclusive" → Ask user how to proceed
     │  │            └─ "No bug found" → Session ends
@@ -121,7 +133,7 @@ Tracebloom investigates config and git history; finds a merge conflict marker in
 
 ### Scenario: "Why are database queries timing out?"
 
-Tracebloom examines slow query logs and schema history; identifies missing indexes on frequently-filtered columns (`email`, `status`). Diagnostic Report recommends **"Route to Pathfinder for planning a fix"**. Pathfinder uses the root cause directly (no re-investigation), produces a plan to add the missing indexes with monitoring. Ruinor and Windwarden both ACCEPT. Bitsmith executes the plan; Quill updates documentation at completion.
+Tracebloom examines slow query logs and schema history; identifies missing indexes on frequently-filtered columns (`email`, `status`). Diagnostic Report recommends **"Route to Pathfinder for planning a fix"**. DM runs the Premise Check, surfacing the root cause, affected files (`src/db/schema.ts`, `src/users/repository.ts`), and recommended next action. User replies "proceed". Pathfinder uses the root cause directly (no re-investigation), produces a plan to add the missing indexes with monitoring. Ruinor and Windwarden both ACCEPT. Bitsmith executes the plan; Quill updates documentation at completion.
 
 ---
 


### PR DESCRIPTION
The investigative pipeline had no user confirmation between Tracebloom's diagnosis and Pathfinder's planning — two compounding skip conditions (DM summary-only + Pathfinder Section 4 skip) meant the user never saw the scope before implementation began.

After Tracebloom returns 'Route to Pathfinder for planning a fix', the DM now surfaces a Premise Check: root cause, affected files/components, and recommended next action. The user must explicitly confirm before planning proceeds. Three response paths are defined: proceed (verbatim handoff), corrections (appended as scope adjustments), and rejection (offer Tracebloom re-invocation or abandon). The other three Diagnostic Report routing branches are unchanged.