### PR TITLE
refactor(agents): remove duplicate trigger_keywords from specialist agent frontmatter

### DIFF
--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -7,7 +7,6 @@ model: claude-opus-4-7
 permissionMode: auto
 level: 3
 mandatory: false
-trigger_keywords: ["refactor", "architecture", "abstraction", "framework", "pattern", "generalize", "reusable", "complexity", "simplify", "redesign", "restructure"]
 invoke_when: "major refactors, new abstractions, or when Ruinor flags complexity concerns"
 ---
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -7,7 +7,6 @@ permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false
-trigger_keywords: ["auth", "authentication", "authorization", "session", "jwt", "token", "password", "crypto", "encrypt", "decrypt", "secret", "credential", "payment", "pii", "personal data", "api key", "oauth", "saml", "security"]
 invoke_when: "security-sensitive features or when Ruinor flags security concerns"
 ---
 

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -7,7 +7,6 @@ permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"
 mandatory: false
-trigger_keywords: ["changelog", "breaking change", "deprecated", "upgrade path", "migration guide", "compatibility matrix", "release notes"]
 invoke_when: "plans or code reference specific external system behavior, or when Ruinor flags factual verification concerns"
 ---
 
@@ -22,7 +21,6 @@ invoke_when: "plans or code reference specific external system behavior, or when
 - Migration or upgrade steps reference behavior of specific tool versions
 - When Ruinor flags factual verification concerns
 - User explicitly requests factual validation (--verify-facts)
-- Plan or request contains high-signal keywords: changelog, breaking change, deprecated, upgrade path, migration guide, compatibility matrix, release notes
 
 **Not invoked for:** Internal business logic, pure refactoring with no external dependencies, UI changes with no API calls, or work that makes no claims about external system behavior.
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -7,7 +7,6 @@ permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash"
 mandatory: false
-trigger_keywords: ["database", "query", "performance", "scale", "scalability", "optimization", "cache", "index", "pagination", "algorithm", "batch", "real-time", "throughput", "latency", "memory", "cpu"]
 invoke_when: "performance-critical features or when Ruinor flags performance concerns"
 ---
 

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -126,7 +126,7 @@ For the authoritative provides list and configuration, see [`claude/agents/ruino
 - User explicitly requests with `--review-security` flag, OR
 - Plan/code contains security keywords (heuristic fallback)
 
-For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/riskmancer.md`](/claude/agents/riskmancer.md).
+For the authoritative provides list and configuration metadata, see [`claude/agents/riskmancer.md`](/claude/agents/riskmancer.md). For trigger keywords, see [`claude/references/specialist-triggering.md`](/claude/references/specialist-triggering.md).
 
 #### Windwarden - Performance Specialist
 
@@ -135,7 +135,7 @@ For the authoritative provides list, configuration metadata, and trigger keyword
 - User explicitly requests with `--review-performance` flag, OR
 - Plan/code contains performance keywords (heuristic fallback)
 
-For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/windwarden.md`](/claude/agents/windwarden.md).
+For the authoritative provides list and configuration metadata, see [`claude/agents/windwarden.md`](/claude/agents/windwarden.md). For trigger keywords, see [`claude/references/specialist-triggering.md`](/claude/references/specialist-triggering.md).
 
 #### Knotcutter - Complexity Specialist
 
@@ -144,7 +144,7 @@ For the authoritative provides list, configuration metadata, and trigger keyword
 - User explicitly requests with `--review-complexity` flag, OR
 - Plan/code contains complexity keywords (heuristic fallback)
 
-For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/knotcutter.md`](/claude/agents/knotcutter.md).
+For the authoritative provides list and configuration metadata, see [`claude/agents/knotcutter.md`](/claude/agents/knotcutter.md). For trigger keywords, see [`claude/references/specialist-triggering.md`](/claude/references/specialist-triggering.md).
 
 #### Truthhammer - Factual Validation Specialist
 
@@ -153,7 +153,7 @@ For the authoritative provides list, configuration metadata, and trigger keyword
 - User explicitly requests with `--verify-facts` flag, OR
 - Plan/code contains factual-validation keywords (heuristic fallback)
 
-For the authoritative provides list, configuration metadata, and trigger keywords, see [`claude/agents/truthhammer.md`](/claude/agents/truthhammer.md).
+For the authoritative provides list and configuration metadata, see [`claude/agents/truthhammer.md`](/claude/agents/truthhammer.md). For trigger keywords, see [`claude/references/specialist-triggering.md`](/claude/references/specialist-triggering.md).
 
 ## Triggering Mechanisms
 
@@ -322,7 +322,7 @@ See `claude/agents/dungeonmaster.md` for the orchestrator implementation and `cl
 - Specialist triggering via Ruinor recommendations (primary)
 - User flags for explicit specialist requests
 - Keyword-based heuristic fallback
-- Agent metadata (`mandatory`, `trigger_keywords`, `invoke_when`)
+- Agent metadata (`mandatory`, `invoke_when`)
 
 **Unchanged:**
 - Review verdict taxonomy (REJECT/REVISE/ACCEPT-WITH-RESERVATIONS/ACCEPT)


### PR DESCRIPTION
Specialist agent files (riskmancer, windwarden, knotcutter, truthhammer) each duplicated their trigger keyword lists in frontmatter, which were already canonically maintained in specialist-triggering.md — creating five independent locations that could drift.

Removed the trigger_keywords frontmatter arrays from all four agents, and stripped an inline keyword restatement from the truthhammer.md body. Updated cross-references in REVIEW_WORKFLOW.md to point to specialist-triggering.md as the single source of truth.

Future edits to any keyword set now require touching exactly one file, eliminating the risk of the canonical list and agent frontmatter diverging silently.

Closes #198