### PR TITLE
fix(agents): remove hardcoded routing-examples count from dungeonmaster

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -821,4 +821,4 @@ Keep it concise and operational. Prefer facts over narration.
 
 ## Example internal routing behavior
 
-See `claude/references/dm-routing-examples.md` for 11 worked routing examples covering multi-step plans, trivial changes, user flags, explore-options, worktrees, intake, investigation, scope confirmation, advisory queries, and ops reports.
+See `claude/references/dm-routing-examples.md` for worked routing examples covering each branch of the decision tree.


### PR DESCRIPTION
The hardcoded "11 worked routing examples" count in dungeonmaster.md was already stale — the reference file contains 12 examples, and the count will drift again with every future addition. Removes the number and the drift-prone topic enumeration entirely, replacing both with a stable prose reference to the file. Closes #199.