### PR TITLE
feat(commands): add /bug-issue and /feature-issue commands

### DIFF
--- a/claude/commands/bug-issue.md
+++ b/claude/commands/bug-issue.md
@@ -1,0 +1,29 @@
+---
+description: Fetch a GitHub issue (via gh CLI, github.com only) and route it as a bug — investigates via Tracebloom. Requires the gh CLI to be installed and authenticated.
+---
+
+INTENT: investigative
+
+$ARGUMENTS
+
+**Routing note for DM:** This message was submitted via the `/bug-issue` command. `$ARGUMENTS` contains a GitHub issue reference — either a bare issue number (e.g. `42`) or a `https://github.com/<owner>/<repo>/issues/<n>` URL (github.com only; GitHub Enterprise is not supported).
+
+Before invoking `gh`, perform the following checks:
+
+1. **Empty-arguments guard:** If `$ARGUMENTS` is empty or whitespace-only, ask the user for an issue number or URL. Do not invoke `gh`.
+
+2. **Argument shape validation:** Trim whitespace and strip any trailing slash, query string (`?...`), or fragment (`#...`). Confirm the result is (a) a positive integer or (b) a `https://github.com/<owner>/<repo>/issues/<n>` URL. On parse failure, ask the user to re-supply. Do not invoke `gh`.
+
+3. **Cross-repo URL guard:** If the argument is a full URL, compare the `<owner>/<repo>` segment against the worktree's `origin` remote. If they do not match, stop and ask the user to confirm intent before continuing.
+
+Once all guards pass, invoke `gh issue view <argument> --json title,body,labels,number,url` using the Bash tool. Use this exact flag set.
+
+**On gh failure:** If `gh` fails, surface the exact error message and ask the user to either fix the problem and retry, or provide the bug description manually.
+
+**On empty issue body:** If the returned `body` field is empty or whitespace-only, proceed with a header-only task description and surface a brief note to the user (e.g., "Issue #N has no body — proceeding with title-only context").
+
+**Constructing the task description:** Build a one-line header — `Issue #<number> (<url>) [<label1>, <label2>, ...]: <title>` (omit `[...]` if labels is empty) — followed by a blank line and the issue body verbatim (if non-empty).
+
+**Routing:** The `INTENT: investigative` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip heuristic classification and fire the Investigative Gate (Tracebloom) directly, using the constructed task description as the input. Strip this routing note and the `INTENT:` line — downstream agents see only the constructed task description.
+
+Phase 0 (session-variable capture) and the Phase 1 Worktree Creation Subroutine both apply: Phase 0 captures session variables, and because `INTENT: investigative` is set, the Intent Override branch invokes the Worktree Creation Subroutine before firing the Investigative Gate. All other Phase 1 gates apply normally. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.

--- a/claude/commands/feature-issue.md
+++ b/claude/commands/feature-issue.md
@@ -1,0 +1,29 @@
+---
+description: Fetch a GitHub issue (via gh CLI, github.com only) and route it as a feature request — enters the constructive planning pipeline. Requires the gh CLI to be installed and authenticated.
+---
+
+INTENT: constructive
+
+$ARGUMENTS
+
+**Routing note for DM:** This message was submitted via the `/feature-issue` command. `$ARGUMENTS` contains a GitHub issue reference — either a bare issue number (e.g. `42`) or a `https://github.com/<owner>/<repo>/issues/<n>` URL (github.com only; GitHub Enterprise is not supported).
+
+Before invoking `gh`, perform the following checks:
+
+1. **Empty-arguments guard:** If `$ARGUMENTS` is empty or whitespace-only, ask the user for an issue number or URL. Do not invoke `gh`.
+
+2. **Argument shape validation:** Trim whitespace and strip any trailing slash, query string (`?...`), or fragment (`#...`). Confirm the result is (a) a positive integer or (b) a `https://github.com/<owner>/<repo>/issues/<n>` URL. On parse failure, ask the user to re-supply. Do not invoke `gh`.
+
+3. **Cross-repo URL guard:** If the argument is a full URL, compare the `<owner>/<repo>` segment against the worktree's `origin` remote. If they do not match, stop and ask the user to confirm intent before continuing.
+
+Once all guards pass, invoke `gh issue view <argument> --json title,body,labels,number,url` using the Bash tool. Use this exact flag set.
+
+**On gh failure:** If `gh` fails, surface the exact error message and ask the user to either fix the problem and retry, or provide the feature description manually.
+
+**On empty issue body:** If the returned `body` field is empty or whitespace-only, proceed with a header-only task description and surface a brief note to the user (e.g., "Issue #N has no body — proceeding with title-only context").
+
+**Constructing the task description:** Build a one-line header — `Issue #<number> (<url>) [<label1>, <label2>, ...]: <title>` (omit `[...]` if labels is empty) — followed by a blank line and the issue body verbatim (if non-empty).
+
+**Routing:** The `INTENT: constructive` line above is an explicit routing signal. Per the Intent Override Block in Phase 1, skip the Investigative Gate entirely and proceed to the Intake Gate (which still evaluates whether Askmaw is needed or Pathfinder can be invoked directly), using the constructed task description as the input. Strip this routing note and the `INTENT:` line — downstream agents see only the constructed task description.
+
+Phase 0 (session-variable capture) and the Phase 1 Worktree Creation Subroutine both apply: Phase 0 captures session variables, and because `INTENT: constructive` is set, the Intent Override branch invokes the Worktree Creation Subroutine before proceeding to the Intake Gate. All other Phase 1 gates (Intake, Explore-Options, etc.) apply normally. Workflow flags (e.g., `--explore-options`) are unaffected by this override and continue to apply as documented.

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -9,7 +9,9 @@ Claude Code slash commands provide quick workflow shortcuts. Commands are instal
 | Command | Purpose |
 |---------|---------|
 | `/bug` | Report a bug or investigate unexpected behavior — routes directly to Tracebloom (Investigative Gate), bypassing heuristic task classification. |
+| `/bug-issue <issue-ref>` | Like `/bug`, but fetches the task description from a GitHub issue first. Accepts a bare issue number (e.g. `42`) or a full github.com issue URL (GitHub Enterprise URLs are not supported). Requires the `gh` CLI to be installed and authenticated. The DM runs `gh issue view` and constructs the task description from the returned title, body, and labels before routing to Tracebloom. |
 | `/feature` | Request a new feature or enhancement — routes directly to the constructive planning pipeline, bypassing the Investigative Gate. |
+| `/feature-issue <issue-ref>` | Like `/feature`, but fetches the task description from a GitHub issue first. Accepts a bare issue number or full github.com issue URL (GitHub Enterprise URLs are not supported). Requires the `gh` CLI to be installed and authenticated. The DM runs `gh issue view` and constructs the task description from the returned title, body, and labels before entering the Intake Gate (Askmaw or Pathfinder). |
 | `/ask` | Ask a question about the codebase, architecture, or approach — lightweight Q&A with no planning or implementation. Routes to the Advisory Workflow (Phases A-B-C) for read-only research and synthesis. |
 | `/ops` | Runs an advisory query and saves the synthesis output as a Markdown report to `reports/` in the current repo. Thin alias for `/ask --save-report`. |
 | `/open-pr` | Creates a pull request following the `open-pull-request` skill workflow: conventional branch naming, conventional title, draft mode, assigned to @me, and full pre-flight checklist. |


### PR DESCRIPTION
Introduce two new user-scope commands, /bug-issue and /feature-issue, that accept a GitHub issue number or URL and route it into the investigative or constructive pipeline respectively.

The commands fetch issue content via `gh issue view --json title,body,labels,number,url`, apply argument validation (shape check, cross-repo URL guard, URL normalization), handle gh failures gracefully, and route to Tracebloom or the Intake Gate using the existing INTENT mechanism.

Requires the gh CLI to be installed and authenticated. GitHub Enterprise URLs are not supported.