### PR TITLE
fix(claude-md): replace inline bash style rules with pointer to canonical reference

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -20,9 +20,7 @@ The `validate-before-pr` skill MUST be invoked before any PR creation. It runs l
 
 ## Bash Command Style
 
-- Never chain commands using `&&` or `;`, and never use process substitution (`<(...)` / `>(...)`). Pipes (`|`) are permitted only for data transformation — see `claude/references/bash-style.md` for full guidance.
-- Always issue each command as a separate, standalone Bash call.
-- Never use command substitution (`$(...)`) or heredoc temp-file patterns in git commit commands. Use multiple `-m` flags instead: `git commit -m "type(scope): subject" -m "Body paragraph."`. Each `-m` value becomes a separate paragraph. See `claude/references/bash-style.md` for details.
+All Bash tool usage is governed by `claude/references/bash-style.md`. The rules there are mandatory and enforced by the `permission-learn.sh` PermissionRequest hook in `claude/settings.json`. Read that reference before issuing any Bash command.
 
 ## Think Before Coding
 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -14,7 +14,7 @@ This document explains how Claude Code loads instructions at two levels in this 
 
 **Behavioral constraints** — directives that govern how Claude Code behaves before and during execution:
 
-- **Bash Command Style** — prohibits command chaining (`&&`, `;`), process substitution, and command substitution (`$(...)`) or heredoc patterns in git commit commands; each command must be issued as a standalone Bash call; git commits must use multiple `-m` flags instead of shell constructs
+- **Bash Command Style** — mandatory rules for all Bash tool usage; full details in `claude/references/bash-style.md`
 - **Think Before Coding** — requires surfacing ambiguous interpretations before acting, disclosing non-obvious assumptions, proposing simpler alternatives when they exist, and stopping to ask rather than guessing when context is insufficient
 
 ## Project-Level Instructions (.claude/CLAUDE.md)


### PR DESCRIPTION
Closes #201. Eliminates the DRY violation where CLAUDE.md and docs/INSTRUCTIONS.md restated bash style rules already canonically defined in claude/references/bash-style.md. Phrasing had already diverged across the copies — the fix reduces both files to a single pointer sentence, leaving the rules in one place only.