### PR TITLE
refactor(references): extract conflict-resolution rebase logic into shared reference

### DIFF
--- a/claude/commands/resolve-conflicts.md
+++ b/claude/commands/resolve-conflicts.md
@@ -24,86 +24,16 @@ If the exit code is non-zero (the directory does not exist), abort immediately a
 user: "No rebase in progress. Start a rebase first, then run /resolve-conflicts when conflicts
 appear."
 
-## Step 2 — Detect conflicted files
+## Step 2 — Resolve conflicts and complete the rebase
 
-Run: `git diff --name-only --diff-filter=U`
+Apply the procedure in `claude/references/conflict-resolution-rebase.md`. In this command's
+context, "incoming branch" is the branch currently being rebased and "upstream" is whatever
+branch the rebase is replaying onto — these are not necessarily a PR branch and `main`. The
+reference handles detection, resolution, the `git rebase --continue` cycle, all abort cases,
+the per-commit 3-round limit, the empty-commit `--skip` handling including the post-`--skip`
+rebase-still-in-progress check, and the inner cycling between commits.
 
-- If the output is **empty** (no conflicted files — the rebase is paused for another reason),
-  run `git rebase --abort` as a separate standalone call and abort the entire command, telling
-  the user: "Rebase is paused but no conflicted files were found. The rebase has been aborted.
-  Check `git status` for details."
-- If the output lists **more than 10 conflicted files**, run `git rebase --abort` as a separate
-  standalone call and abort the entire command, telling the user: "Too many conflicted files ({N})
-  for automated resolution. The rebase has been aborted. Resolve conflicts manually."
-- If the output lists between **1 and 10 conflicted files** (inclusive) → proceed to Step 3.
-
-## Step 3 — Resolve conflicts
-
-A "round" is defined as one attempt to resolve conflicts for the **current commit** being
-rebased. The 3-round limit is **per-commit**: each time `git rebase --continue` succeeds and
-moves on to the next commit (which then stops again with new conflicts), the round counter
-resets to 0. A round only increments when the same commit fails to be resolved and
-`git rebase --continue` exits non-zero again. The round counter also resets to 0 when a commit
-is skipped via `git rebase --skip` (empty-commit case), since the next commit begins a fresh
-resolution attempt.
-
-For each conflicted file listed:
-
-1. Read the file contents and understand the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
-2. Write a resolved version that **preserves the incoming branch's changes as the primary
-   intent**. In a rebase, the incoming branch's commits are being replayed onto the upstream
-   branch — so the incoming branch's logic, behaviour, and scope must be kept intact. The
-   resolution should do the minimum necessary to make the incoming branch's changes apply cleanly
-   against what has changed upstream. Do not expand scope, introduce new behaviour, or favour the
-   upstream version of a line unless the incoming version is genuinely incompatible. If in doubt,
-   keep the incoming branch's change and adjust only what is structurally required by the
-   conflict.
-3. After writing the resolved file, scan it for remaining conflict markers (`<<<<<<<`, `=======`,
-   `>>>>>>>`). If any remain, re-read and re-resolve.
-   - If markers still persist in the same file after a second attempt, run `git rebase --abort`
-     as a separate standalone call and abort the entire command, telling the user: "Unable to
-     resolve all conflict markers in `<file>`. The rebase has been aborted. Resolve conflicts
-     manually."
-4. Stage each resolved file (confirmed marker-free) with a separate standalone call:
-   `git add <file>`
-
-*Note: In PR rebase contexts (e.g., when invoked from `/sync-pr`), "incoming branch" refers to
-the PR's branch and "upstream" refers to `main`.*
-
-## Step 4 — Continue rebase
-
-Run: `GIT_EDITOR=true git rebase --continue`
-
-(The `GIT_EDITOR=true` env var skips the editor prompt for the commit message.)
-
-- If `git rebase --continue` reports that the resulting commit is **empty**, run
-  `git rebase --skip` as a separate standalone call (to skip the now-empty commit). Then check
-  whether the rebase is still in progress:
-  - Run: `git rev-parse --git-dir` to get the git directory path. Store the result as `<git-dir>`.
-  - Run: `test -d <git-dir>/rebase-merge`
-  - If the directory **does not exist** (exit non-zero) → the rebase is complete. Print
-    "Conflicts resolved. Rebase completed successfully." and return control to the caller (or
-    exit cleanly if invoked standalone).
-  - If the directory **still exists** (exit zero) → the rebase is still in progress (more
-    commits to replay). Reset the per-commit round counter to 0. Run
-    `git diff --name-only --diff-filter=U` as a separate standalone call to check for conflicts
-    in the next commit:
-    - If conflicted files are listed → return to Step 3 for the next commit.
-    - If no conflicted files are listed → proceed to run `GIT_EDITOR=true git rebase --continue`
-      again (continuing with the normal Step 4 exit-code handling for the next commit).
-- If `git rebase --continue` exits with **zero** → print "Conflicts resolved. Rebase completed
-  successfully." and return control to the caller (or exit cleanly if invoked standalone).
-- If `git rebase --continue` exits **non-zero** → run `git diff --name-only --diff-filter=U`
-  as a separate standalone call.
-  - If the output is **empty** (no conflicted files), run `git rebase --abort` as a separate
-    standalone call and abort the entire command, telling the user: "Rebase failed during
-    `--continue` for a reason other than merge conflicts. The rebase has been aborted. Check
-    `git status` for details."
-  - If there are still conflicted files and fewer than 3 rounds have been attempted for this
-    commit → return to Step 3 for another resolution round (incrementing the per-commit round
-    counter).
-  - If 3 rounds have been attempted for this commit without success → run `git rebase --abort`
-    as a separate standalone call and abort the entire command, telling the user: "Unable to
-    fully resolve the rebase conflicts after 3 attempts on the same commit. The rebase has been
-    aborted. Resolve conflicts manually by running your rebase command again, fixing each
-    conflict, and running `git rebase --continue`."
+When the reference reports the rebase is complete (no `<git-dir>/rebase-merge` directory after
+the final `--continue` or `--skip`), print *"Conflicts resolved. Rebase completed
+successfully."* and exit (or return control to the caller for the inline-from-`/sync-pr`
+case). When the reference reports an abort, propagate the abort message to the user and exit.

--- a/claude/references/conflict-resolution-rebase.md
+++ b/claude/references/conflict-resolution-rebase.md
@@ -1,0 +1,168 @@
+# Conflict-Resolution Rebase — Shared Reference
+
+This file defines the canonical procedure for resolving merge conflicts during a
+`git rebase` that has stopped due to conflicts. It is the authoritative source for
+this algorithm. Consumers (skills, commands) reference this file and supply their
+own context mapping.
+
+**Term definitions used throughout this file:**
+
+- **Incoming branch** — the branch whose commits are being replayed (i.e., the branch
+  you are rebasing).
+- **Upstream** — the branch the rebase is replaying the incoming branch's commits onto.
+
+Consumers map their own context to these terms. For example, in the `open-pull-request`
+skill, "incoming branch" is the PR's branch and "upstream" is `main`. In the standalone
+`/resolve-conflicts` command, "incoming branch" is whatever branch is currently being
+rebased and "upstream" is whatever branch the rebase is replaying onto.
+
+---
+
+## Detect Conflicted Files
+
+Run: `git diff --name-only --diff-filter=U`
+
+Evaluate the output:
+
+- If the output is **empty** (no conflicted files — the rebase is paused for another
+  reason): run `git rebase --abort` as a standalone call and abort, telling the user:
+  "Rebase failed for a reason other than merge conflicts. The rebase has been aborted.
+  Check `git status` for details."
+- If the output lists **more than 10 conflicted files**: run `git rebase --abort` as a
+  standalone call and abort, telling the user: "Too many conflicted files ({N}) for
+  automated resolution. The rebase has been aborted. Resolve conflicts manually."
+- If the output lists between **1 and 10 conflicted files** (inclusive): proceed to
+  "Resolve Conflicts (Per Round)" below.
+
+---
+
+## Resolve Conflicts (Per Round)
+
+A **round** is one attempt to resolve conflicts for the **current commit** being rebased.
+The 3-round limit is **per-commit**. The round counter resets to 0 in two cases:
+
+1. When `git rebase --continue` succeeds and the rebase moves on to the next commit
+   (which then stops again with new conflicts).
+2. When a commit is skipped via `git rebase --skip` (the empty-commit case), since the
+   next commit begins a fresh resolution attempt.
+
+A round only increments when the same commit fails to resolve and
+`git rebase --continue` exits non-zero again.
+
+For each conflicted file listed:
+
+1. Read the file contents and understand the conflict markers (`<<<<<<<`, `=======`,
+   `>>>>>>>`).
+2. Write a resolved version that **preserves the incoming branch's changes as the primary
+   intent**. In a rebase, the incoming branch's commits are being replayed onto the
+   upstream — so the incoming branch's logic, behaviour, and scope must be kept intact.
+   The resolution should do the minimum necessary to make the incoming branch's changes
+   apply cleanly against what has changed upstream. Do not expand scope, introduce new
+   behaviour, or favour the upstream version of a line unless the incoming version is
+   genuinely incompatible. If in doubt, keep the incoming branch's change and adjust only
+   what is structurally required by the conflict.
+3. After writing the resolved file, scan it for remaining conflict markers (`<<<<<<<`,
+   `=======`, `>>>>>>>`). If any remain, re-read and re-resolve.
+   - If markers still persist in the same file after a second attempt: run
+     `git rebase --abort` as a standalone call and abort, telling the user: "Unable to
+     resolve all conflict markers in `{file}`. The rebase has been aborted. Resolve
+     conflicts manually."
+4. Stage each resolved file (confirmed marker-free) with a separate standalone call:
+   `git add {file}`
+
+After all conflicted files are staged, proceed to "Continue the Rebase" below.
+
+---
+
+## Continue the Rebase
+
+Run: `GIT_EDITOR=true git rebase --continue`
+
+(The `GIT_EDITOR=true` env var skips the editor prompt for the commit message.)
+
+Handle three exit conditions:
+
+### Empty commit reported
+
+Run `git rebase --skip` as a standalone call (to skip the now-empty commit). Then check
+whether the rebase is still in progress:
+
+Run: `git rev-parse --git-dir`
+
+Store the result as `<git-dir>`.
+
+Run: `test -d <git-dir>/rebase-merge`
+
+- If the directory **does not exist** (exit non-zero) → the rebase is complete. The
+  consumer's wrapper decides what to do next (print a success message and exit, or
+  proceed to the next wrapper step).
+- If the directory **still exists** (exit zero) → the rebase has more commits to replay.
+  Reset the per-commit round counter to 0. Run
+  `git diff --name-only --diff-filter=U` as a standalone call to check for conflicts in
+  the next commit:
+  - If conflicted files are listed → return to "Resolve Conflicts (Per Round)" for the
+    next commit.
+  - If no conflicted files are listed → run `GIT_EDITOR=true git rebase --continue`
+    again as a standalone call, applying the same three exit-condition handling defined in
+    this section.
+
+### Exit code zero (non-empty commit, success)
+
+Check whether the rebase is still in progress:
+
+Run: `git rev-parse --git-dir`
+
+Store the result as `<git-dir>`.
+
+Run: `test -d <git-dir>/rebase-merge`
+
+- If the directory **does not exist** (exit non-zero) → the rebase is complete. The
+  consumer decides what to do next.
+- If the directory **still exists** (exit zero) → the rebase has more commits to replay.
+  Reset the per-commit round counter to 0. Run
+  `git diff --name-only --diff-filter=U` as a standalone call to check for conflicts in
+  the next commit:
+  - If conflicted files are listed → return to "Resolve Conflicts (Per Round)" for the
+    next commit.
+  - If no conflicted files are listed → run `GIT_EDITOR=true git rebase --continue`
+    again as a standalone call, applying the same three exit-condition handling defined in
+    this section.
+
+### Exit code non-zero
+
+Run: `git diff --name-only --diff-filter=U`
+
+- If the output is **empty** (no conflicted files): run `git rebase --abort` as a
+  standalone call and abort, telling the user: "Rebase failed during `--continue` for a
+  reason other than merge conflicts. The rebase has been aborted. Check `git status` for
+  details."
+- If conflicted files are listed and **fewer than 3 rounds** have been attempted for this
+  commit → return to "Resolve Conflicts (Per Round)", incrementing the per-commit round
+  counter.
+- If **3 rounds** have been attempted for this commit without success → run
+  `git rebase --abort` as a standalone call and abort, telling the user: "Unable to fully
+  resolve the rebase conflicts after 3 attempts on the same commit. The rebase has been
+  aborted. Resolve conflicts manually."
+
+---
+
+## Consumer Responsibilities
+
+Consumers of this reference are responsible for:
+
+1. **Pre-conditions.** The standalone `/resolve-conflicts` command guards that a rebase is
+   already in progress before entering this algorithm. The `open-pull-request` skill
+   invokes `git rebase` itself in its preceding sub-step (6c.1), so the rebase is always
+   in progress when this reference is entered.
+2. **Terminal actions.** At the algorithm's terminal success points (the rebase is
+   complete), the consumer decides what to do next — for example: print a success message
+   and exit (standalone command), re-run `validate-before-pr` and then push (SKILL), or
+   return control to a calling command (inline invocation from `/sync-pr`).
+3. **Abort propagation.** When this algorithm reports an abort, the consumer propagates
+   the abort message to the user and stops — it does not proceed to any subsequent step.
+
+All Bash commands in this reference follow the repo bash-style rules: no `&&` or `;`
+chaining, no process substitution, no `$(...)` command substitution in commit commands.
+Pipes are permitted only for data transformation per `claude/references/bash-style.md`.
+The `<git-dir>` notation is a documentation placeholder — store the actual value returned
+by `git rev-parse --git-dir` and use it in the subsequent `test -d` call.

--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -71,38 +71,16 @@ Every PR must:
    - If the rebase exits with **zero** → proceed to step 7 (Push).
    - If the rebase exits **non-zero** → continue to 6c.2.
 
-   **6c.2** — Run: `git diff --name-only --diff-filter=U`
-
-   - If the output is **empty** (no conflicted files — this is a different rebase error): run `git rebase --abort` as a standalone call, stop, and tell the user: "Rebase failed for a reason other than merge conflicts. The rebase has been aborted. Check `git status` for details."
-   - If the output lists **more than 10 conflicted files**: run `git rebase --abort` as a standalone call, stop, and tell the user: "Too many conflicted files ({N}) for automated resolution. The rebase has been aborted. Resolve conflicts manually."
-   - If the output lists between **1 and 10 conflicted files** (inclusive) → continue to 6c.3.
-
-   **6c.3 — Resolve conflicts**
-
-   A "round" is defined as one attempt to resolve conflicts for the **current commit** being rebased. The 3-round limit is **per-commit**: each time `git rebase --continue` succeeds and moves on to the next commit (which then stops again with new conflicts), the round counter resets to 0. A round only increments when the same commit fails to be resolved and `git rebase --continue` exits non-zero again.
-
-   For each conflicted file listed:
-
-   1. Read the file contents and understand the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
-   2. Write a resolved version that **preserves the PR's original changes as the primary intent**. In a rebase, the PR's commits are being replayed onto main — so the PR's logic, behaviour, and scope must be kept intact. The resolution should do the minimum necessary to make the PR's changes apply cleanly against what has changed in main. Do not expand the PR's scope, introduce new behaviour, or favour main's version of a line unless the PR's version is genuinely incompatible. If in doubt, keep the PR's change and adjust only what is structurally required by the conflict.
-   3. After writing the resolved file, scan it for remaining conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). If any remain, re-read and re-resolve.
-      - If markers still persist in the same file after a second attempt, run `git rebase --abort` as a standalone call and stop: "Unable to resolve all conflict markers in `{file}`. The rebase has been aborted. Resolve conflicts manually."
-   4. Stage each resolved file (confirmed marker-free) with a separate standalone call: `git add {file}`
-
-   **6c.4** — After all conflicted files are staged, run: `GIT_EDITOR=true git rebase --continue`
-
-   (The `GIT_EDITOR=true` env var skips the editor prompt for the commit message.)
-
-   - If `git rebase --continue` reports that the resulting commit is **empty**: run `git rebase --skip` as a standalone call (to skip the now-empty commit) and treat this as a successful continue — proceed to step 7 (Push).
-   - If `git rebase --continue` exits with **zero** → print "Conflicts resolved. Rebase completed successfully." and proceed to step 7 (Push).
-   - If `git rebase --continue` exits **non-zero** → run `git diff --name-only --diff-filter=U` as a standalone call.
-     - If the output is **empty** (no conflicted files): run `git rebase --abort` as a standalone call and stop: "Rebase failed during `--continue` for a reason other than merge conflicts. The rebase has been aborted."
-     - If there are still conflicted files and **fewer than 3 rounds** have been attempted for this commit → return to 6c.3 (incrementing the per-commit round counter).
-     - If **3 rounds** have been attempted for this commit without success → run `git rebase --abort` as a standalone call and stop: "Unable to fully resolve rebase conflicts after 3 attempts. The rebase has been aborted. Resolve manually by running `git rebase refs/remotes/origin/main`, fixing each conflict, and running `git rebase --continue`."
+   **6c.2** — Apply the procedure in `claude/references/conflict-resolution-rebase.md`. In this
+   skill's context, "incoming branch" is the PR's branch and "upstream" is `main`. The reference
+   handles detection, resolution, and the `git rebase --continue` cycle including all abort and
+   round-counter cases. After the procedure completes successfully (the reference reports the rebase
+   is complete), proceed to **6d** (re-validate). If the procedure aborts at any point, propagate
+   the abort and stop — do not proceed to 6d or push.
 
    **6d. Re-validate if conflicts were resolved**
 
-   If any conflicts were resolved during sub-steps 6c.3–6c.4 (i.e., the rebase did not complete cleanly in 6c.1), re-run the `validate-before-pr` skill before proceeding to step 7 (Push). Conflict resolution can modify file contents in ways that introduce lint or formatting violations that the earlier validation already cleared.
+   If any conflicts were resolved during sub-step 6c.2 (i.e., the rebase did not complete cleanly in 6c.1), re-run the `validate-before-pr` skill before proceeding to step 7 (Push). Conflict resolution can modify file contents in ways that introduce lint or formatting violations that the earlier validation already cleared.
 
    If `validate-before-pr` fails on re-run, stop — do not push or open a PR. Report the failures and request fixes.
 
@@ -230,5 +208,5 @@ After push, open with draft + assignee, e.g. `gh pr create --draft --assignee @m
 ## Relationship to other skills
 
 - **Commits**: Follow **commit-message-guide** for message bodies and footers. It also documents **WIP** and **fixup!** subject lines—pair fixup commits with `git rebase -i --autosquash` to merge them into the target commit.
-- **Sync with main**: Step 6 fetches remote refs and rebases the branch onto `refs/remotes/origin/main` with automated conflict resolution before pushing. The rebase logic is inlined from `sync-pr` semantics — no separate `sync-branch-to-main` skill exists. The `/sync-pr` command performs the same rebase logic independently for post-PR-creation syncing. If conflicts were resolved during the rebase, `validate-before-pr` is re-run before proceeding to push.
+- **Sync with main**: Step 6 fetches remote refs and rebases the branch onto `refs/remotes/origin/main` with automated conflict resolution before pushing. The conflict-resolution algorithm is defined in `claude/references/conflict-resolution-rebase.md`; step 6c.2 delegates to that reference. The `/sync-pr` command performs the same rebase logic independently for post-PR-creation syncing. If conflicts were resolved during the rebase, `validate-before-pr` is re-run before proceeding to push.
 - **MCP / automation**: Skills named like “open-pull-request” on catalogs (e.g. [MCP Market](https://mcpmarket.com/tools/skills/open-pull-request)) usually wrap the same steps; this document defines **naming** and **titles** so any tool or CLI you use stays consistent.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -37,6 +37,8 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`specialist-triggering.md`** — Canonical keyword list for the Dungeon Master's heuristic-fallback specialist-routing logic. Covers four keyword categories (security, performance, complexity, factual validation) and their corresponding specialist suggestions. DM consults this only when no user flag is present and Ruinor has not recommended specialists. Also documents why Truthhammer's keyword set is intentionally narrow. See [docs/adrs/REVIEW_WORKFLOW.md](/docs/adrs/REVIEW_WORKFLOW.md) for the broader specialist-triggering decision model.
 
+- **`conflict-resolution-rebase.md`** — Canonical algorithm for resolving merge conflicts during a `git rebase`. Covers conflict detection, per-file resolution strategy (preserving the incoming branch's intent), round-limit guardrails, abort conditions, and the rebase-continue loop. Consumed by the `open-pull-request` skill (sub-step 6c) and the `/resolve-conflicts` command as thin pointers to this single authoritative source.
+
 When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
 
 ## Skills (`claude/skills/`)


### PR DESCRIPTION
The conflict-detection, per-file resolution, round-limit guardrails, abort conditions, and rebase-continue loop were duplicated verbatim between the `open-pull-request` skill (sub-steps 6c.2–6c.4) and the `/resolve-conflicts` command (Steps 2–4).

Extracts the canonical algorithm into `claude/references/conflict-resolution-rebase.md` and collapses both consumers to thin pointers. Each consumer supplies its own context mapping (which branch is "incoming" and which is "upstream"). Adds a catalog entry in `docs/SKILLS.md`.

Closes #200