### PR TITLE
refactor(agents): consolidate constitution enforcement contract to single source

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,4 +44,4 @@ This self-containment constraint applies to everything `install.sh` installs —
 
 ## Project Constitution
 
-This repository has a Project Constitution defining repo-scoped invariants that govern all work here. See `.claude/constitution.md` for the full text, definitions, and enforcement details. All plans, implementations, and reviews are evaluated against these principles; Ruinor enforces them as a mandatory checklist.
+This repository has a Project Constitution defining repo-scoped invariants that govern all work here. See `.claude/constitution.md` for the full text, definitions, severity rules, and the canonical enumeration of how these principles are enforced.

--- a/.claude/constitution.md
+++ b/.claude/constitution.md
@@ -4,7 +4,7 @@ This file defines repo-scoped invariants that govern all work in this repository
 
 ## Definitions
 
-**Session artifact:** any file written during a session that captures session-specific runtime state, output, or context. Canonical positive example (anti-pattern): `~/.ai-tpk/session-context/current.json` from PR #187. Session artifacts MUST be session-namespaced (e.g., prefixed with `SESSION_TS` or a session-unique identifier) and MUST NOT use fixed/singleton paths shared across sessions.
+**Session artifact:** any file written during a session that captures session-specific runtime state, output, or context. **Canonical anti-pattern (do not remove):** `~/.ai-tpk/session-context/current.json` from PR #187 — this example is the canonical reference for session-artifact violations across all agent definitions. Session artifacts MUST be session-namespaced (e.g., prefixed with `SESSION_TS` or a session-unique identifier) and MUST NOT use fixed/singleton paths shared across sessions.
 
 **Static artifact:** any file that is not a session artifact — including documentation (e.g., `.claude/constitution.md`, `.claude/CLAUDE.md`), agent definitions (e.g., `~/.claude/agents/*.md`), configuration files (e.g., `claude/settings.json`), and per-repo (not per-session) artifacts. Static artifacts MAY use fixed paths. The shared parent directory `~/.ai-tpk/plans/{REPO_SLUG}/` is itself static; the per-session files inside it are session artifacts and ARE session-namespaced (e.g., `{SESSION_TS}-{feature-slug}.md`).
 
@@ -13,7 +13,7 @@ This file defines repo-scoped invariants that govern all work in this repository
 ai-tpk is designed to support multiple sessions running concurrently. Every design, plan, and implementation must respect this invariant.
 
 - Each session runs in its own isolated worktree — no two sessions share a working directory.
-- No agent, hook, or artifact may write to a fixed/singleton path shared across sessions. "Session artifact" means any file written during a session that captures session-specific runtime state, output, or context (e.g., `~/.ai-tpk/session-context/current.json` from PR #187 is the canonical anti-pattern). Static documentation, agent definitions, configuration files, and per-repo (not per-session) artifacts are NOT session artifacts and may use fixed paths.
+- No agent, hook, or artifact may write to a fixed/singleton path shared across sessions. (See Definitions above for what counts as a session artifact and the canonical anti-pattern.)
 - All session artifacts (plan files, sidecar files, open-questions files) must be session-namespaced (e.g., prefixed with `SESSION_TS` or a session-unique identifier).
 - No agent definition may assume it is the only active session.
 
@@ -26,5 +26,9 @@ All artifacts in `claude/` (agents, skills, commands, hooks, references, setting
 Three mechanisms enforce these principles across all work in this repository:
 
 - **(a) `.claude/CLAUDE.md` summary** — the project-scope CLAUDE.md includes a `## Project Constitution` section that names both principles, summarises them, and points here as the canonical source. Any reader of the project-scope instructions sees the principles without needing the DM injection path.
-- **(b) DM injection** — `claude/agents/dungeonmaster.md`'s `### Project Constitution Injection` section specifies how DM inlines this file's contents into every Pathfinder, Bitsmith, and Ruinor delegation prompt. This is the primary enforcement path for globally-installed agents that cannot read repo-scoped files directly.
-- **(c) Agent-level hooks** — `claude/agents/ruinor.md`'s `### Constitution Compliance Check` section (in Phase 3) makes both principles explicit checklist items on every plan and implementation review. `claude/agents/bitsmith.md`'s "What Bitsmith Does NOT Touch" list names constitutional violations as a halt-and-escalate condition so conflicts surface before implementation rather than at review time.
+- **(b) DM injection** — `claude/agents/dungeonmaster.md`'s `### Project Constitution Injection` section specifies how DM inlines this file's contents into every Pathfinder, Bitsmith, and Ruinor delegation prompt. This is the primary enforcement path — see the preamble above for why.
+- **(c) Agent-level hooks** — `claude/agents/ruinor.md`'s `#### Constitution Compliance Check` section (in Phase 3) makes both principles explicit checklist items on every plan and implementation review. `claude/agents/bitsmith.md`'s "What Bitsmith Does NOT Touch" list names constitutional violations as a halt-and-escalate condition so conflicts surface before implementation rather than at review time.
+
+**Severity rule.** A demonstrable violation of either principle is at minimum a MAJOR finding and may be CRITICAL depending on impact. The verdict for an artifact containing an unresolved constitutional violation must not be ACCEPT.
+
+**Worked example.** Positive (anti-pattern, must reject): a plan step that writes `~/.ai-tpk/foo/current.json` is a violation. Negative (acceptable, do not flag): a plan step that creates `.claude/constitution.md` at a fixed path is acceptable because `.claude/constitution.md` is a static artifact per the Definitions section above.

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -55,7 +55,7 @@ When `WORKING_DIRECTORY` is absent from the delegation prompt: for read-only tas
 - **Code quality review** — that is Ruinor's hammer, not hers
 - **Plan files** — these are read-only scrolls from the architect's table; she does not alter them
 - **Scope expansion** — if the task grows, she surfaces it; she does not absorb it silently
-- **Constitutional violations** — if executing the plan would, in your judgment, violate either Project Constitution principle (per the injected `## Project Constitution` block in the delegation prompt), surface the conflict to DM via the structured failure-report path before implementing. This is a halt-and-escalate condition, not a Bitsmith-fixes-it-silently condition. If no `## Project Constitution` block is present in the delegation prompt, this bullet does not apply.
+- **Constitutional violations** — Halt and escalate to DM via the structured failure-report path before implementing; if no `## Project Constitution` block is present in your delegation prompt, this bullet does not apply. See `.claude/constitution.md` for the canonical contract.
 
 ## The Masterwork Standard (Key Success Criteria)
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -147,7 +147,7 @@ Ruinor and other reviewer agents do not receive this block — instead, pass wor
 
 ### Project Constitution Injection
 
-**Rationale:** Globally-installed agents at `~/.claude/agents/` cannot read repo-scoped files at `.claude/CLAUDE.md` or `.claude/constitution.md` directly — they execute from `~/.claude/` and have no reliable path to the repo working tree. DM bridges this gap by inlining the constitution into every delegation prompt for the three agents that author plans, code, or constitution-bearing reviews.
+**DM's role:** DM is the sole injector of the project constitution into agent delegation prompts — globally-installed agents at `~/.claude/agents/` cannot read repo-scoped `.claude/` files directly, so DM bridges that gap at delegation time. See `.claude/constitution.md` for the canonical contract.
 
 **Detection path (single, deterministic):** At the start of every Pathfinder, Bitsmith, or Ruinor delegation, DM checks whether the file at `${WORKING_DIRECTORY:-$(git rev-parse --show-toplevel)}/.claude/constitution.md` exists. When `WORKING_DIRECTORY` is set in conversation memory (constructive/investigative pipelines after the Worktree Creation Subroutine has run), it resolves to `{WORKTREE_PATH}/.claude/constitution.md`. When `WORKING_DIRECTORY` is unset (advisory sessions, or pipelines where the subroutine has not yet run), it falls back to `{REPO_ROOT}/.claude/constitution.md` derived from `git rev-parse --show-toplevel`. There is no other detection path. If both resolutions fail (e.g., DM is not inside a git repository), DM skips injection silently.
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -100,11 +100,7 @@ Verify factual claims and assumptions:
 
 #### Constitution Compliance Check
 
-When a `## Project Constitution` block is present in your delegation prompt (injected by DM per `claude/agents/dungeonmaster.md`'s Project Constitution Injection logic), apply both principles as verification criteria during this Phase 3 review, exactly as stated in the injected block. The injected block is the authoritative copy — do not attempt to read `.claude/constitution.md` directly, as you do not receive the Worktree Context Block and have no reliable path to the file. If no `## Project Constitution` block is present in the delegation prompt, skip this section.
-
-**Severity rule:** A demonstrable violation of either principle is at minimum a MAJOR finding and may be CRITICAL depending on impact. The verdict for an artifact containing an unresolved constitutional violation must not be ACCEPT.
-
-**Worked example:** Positive (anti-pattern, must reject): a plan step that writes `~/.ai-tpk/foo/current.json` is a violation. Negative (acceptable, do not flag): a plan step that creates `.claude/constitution.md` at a fixed path is acceptable because `.claude/constitution.md` is a static artifact per the injected Definitions section.
+**Ruinor's role:** When a `## Project Constitution` block is present in your delegation prompt, apply both principles as verification criteria during this Phase 3 review using the severity rule, definitions, and worked example stated in the injected block. The injected block is the authoritative copy — do not attempt to read `.claude/constitution.md` directly, as you do not receive the Worktree Context Block and have no reliable path to the file. If no `## Project Constitution` block is present, do not skip this check — apply this fallback rule instead: treat any demonstrable violation of session isolation or install-time self-containment as at minimum a MAJOR finding — never ACCEPT.
 
 Evaluate from multiple angles:
 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -25,7 +25,7 @@ This document explains how Claude Code loads instructions at two levels in this 
 - **User scope** (`claude/`) — applied globally across all repositories
 - **Project scope** (`.claude/`) — applied only to this repository
 
-**Project Constitution:** `.claude/CLAUDE.md` carries a `## Project Constitution` section pointing to `.claude/constitution.md` as the canonical source of the repo's invariant principles. All plans, implementations, and reviews are evaluated against these principles; Ruinor enforces them as a mandatory checklist.
+**Project Constitution:** `.claude/CLAUDE.md` carries a `## Project Constitution` section pointing to `.claude/constitution.md` as the canonical source of the repo's invariant principles — including the principle definitions, severity rules, and the full enumeration of how these principles are enforced.
 
 See `.claude/CLAUDE.md` for the full scope clarification rules, trigger cases, and constitution summary.
 

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -354,7 +354,7 @@ Existing workflows continue to work; they just run more efficiently now.
 - **Hard intermediate review gates** - After 2 consecutive Bitsmith invocations, a review gate is mandatory before continuing
 - **REJECT verdicts require remediation** - When Ruinor issues REJECT, Bitsmith must provide a written remediation brief before re-review to prevent rubber-stamp approvals
 - **Documentation follows implementation** - Quill is invoked only after implementation review is fully complete; any post-documentation code changes must re-enter the implementation review gate
-- **Constitution compliance is a mandatory review criterion** - Ruinor verifies every plan and implementation against the Project Constitution principles (see `.claude/constitution.md`) via its `#### Constitution Compliance Check` section. A demonstrable violation is at minimum MAJOR and blocks ACCEPT. The constitution is injected into Ruinor's delegation prompt by DM; see [`claude/agents/ruinor.md`](/claude/agents/ruinor.md) for the checklist and [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) for the injection logic.
+- **Constitution compliance is a mandatory review criterion** - Ruinor verifies every plan and implementation against the Project Constitution principles via its `#### Constitution Compliance Check` section. The constitution — including principle definitions, severity rules, and worked examples — is injected into Ruinor's delegation prompt by DM; see [`.claude/constitution.md`](/.claude/constitution.md) for the canonical contract, [`claude/agents/ruinor.md`](/claude/agents/ruinor.md) for the operational instruction, and [`claude/agents/dungeonmaster.md`](/claude/agents/dungeonmaster.md) for the injection logic.
 
 ## Future Enhancements
 


### PR DESCRIPTION
The enforcement contract (principle names, severity rules, canonical examples, enforcement paths) was restated in five separate files. Each of DM, Ruinor, and Bitsmith now states only its own role-specific responsibility; the full canonical contract lives in .claude/constitution.md. Docs updated to point to the canonical source. Closes #202.