### PR TITLE
refactor(launcher): implement GoF command pattern for MCP config

### DIFF
--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -54,7 +54,7 @@ If the saved Grafana cluster ID no longer exists in `~/.config/grafana-clusters.
 
 ## Testing
 
-Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`env.test.ts`, `config.test.ts`, `utils.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
+Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`env.test.ts`, `resolve.test.ts`, `outro.test.ts`, `summary.test.ts`, `config.test.ts`, `utils.test.ts`, `mcp-command.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
 
 ```bash
 pnpm test
@@ -93,14 +93,67 @@ User selections are saved to `~/.config/myclaude/config.json` with mode 0600. If
 
 ## Architecture
 
-The wizard orchestration lives in `main.ts`. The summary screen gate (`promptSummaryAction`) is in `summary.ts`; the logic that reconstructs a `ResolvedConfig` from persisted data without re-prompting is in `resolve.ts`. Type definitions are in `types.ts`. MCP-specific logic is split across:
+The launcher uses the GoF Command pattern to eliminate per-MCP branching. Each MCP is a single `McpCommand` object that owns its full lifecycle; all orchestration files iterate a shared registry rather than switching on MCP name.
 
-- `mcp/grafana.ts` — Cluster YAML parsing and cluster/role selection
-- `mcp/cloudwatch.ts` — AWS profile parsing and profile selection
-- `mcp/gcp-observability.ts` — ADC credential check and project prompt
-- `mcp/kubernetes.ts` — `kubectx` context listing, selection prompt, and context switching
+### McpCommand pattern
 
-Shared utilities are split across `utils.ts` (exports `errorMessage` and `tryLoad`, where `tryLoad` returns `null` and emits `log.warn` on failure) and `prompts.ts` (exports `handleCancel` and `selectMcps`). Outro line construction — the text shown in the `Launching: …` summary — lives in `outro.ts` (exports the pure `buildOutroLines(resolved, effectiveSkipped)` function); this is the sole source of truth for which MCPs were configured vs. skipped. The `env.ts` module builds environment variables (using a private `writeDotfile` helper); `config.ts` handles persistence. Claude is launched inline in `main.ts` via `spawnSync`.
+`mcp-command-types.ts` defines the `McpCommand` interface and the `StaleResourceError` class. Each MCP module under `mcp/` exports a command instance implementing that interface. `mcp-command.ts` imports those four instances and exports the `registry: McpCommand[]` array in canonical order (Grafana → CloudWatch → GCP Observability → Kubernetes). It re-exports `McpCommand` and `StaleResourceError` as the public entry point for consumers; command implementations import from `mcp-command-types.ts` directly to avoid a circular dependency.
+
+The `McpCommand` interface captures every per-MCP responsibility:
+
+| Member                                         | Responsibility                                                                                                                                                                                                  |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                           | Multiselect ID; also persisted in `LauncherConfig.selectedMcps`                                                                                                                                                 |
+| `skippedKey`                                   | Key in `SkippedMap` (differs from `id` only for `gcp-observability`, which uses `"gcp"`)                                                                                                                        |
+| `multiselectOption`                            | The `{ value, label, hint }` entry shown in the MCP selection prompt                                                                                                                                            |
+| `configureInteractive`                         | Loads resources (clusters, profiles, contexts), prompts the user, returns resolved + persistable fragments, or `null` on loader failure                                                                         |
+| `resolveFromSaved`                             | Reconstructs the resolved fragment from a persisted config without prompting. Returns `null` if the sub-object is absent; may throw `StaleResourceError` (Grafana only) when a saved reference no longer exists |
+| `emitEnvVars`                                  | Writes env vars and any dotfiles for this MCP into the shared env map                                                                                                                                           |
+| `buildOutroSuccessLine` / `buildOutroSkipLine` | Produces the text shown in the `Launching: …` outro                                                                                                                                                             |
+| `buildSummaryLine`                             | Produces the line shown in the saved-config summary screen                                                                                                                                                      |
+
+`StaleResourceError` is the signal for Grafana's stale-cluster fall-through. `resolve.ts` catches it and returns `null`, which triggers the configure flow in `main.ts`. No other command throws this error.
+
+### Orchestration files
+
+| File         | Responsibility                                                                                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.ts`    | Entry point. Configure flow iterates `registry` to call `configureInteractive` for each selected MCP. Calls `applyKubernetesContextSwitch` explicitly after `saveConfig` and before `buildEnvVars` |
+| `resolve.ts` | `buildResolvedFromSaved` — iterates `config.selectedMcps`, calls `cmd.resolveFromSaved`, catches `StaleResourceError`                                                                              |
+| `env.ts`     | `buildEnvVars` — iterates `registry`, calls `cmd.emitEnvVars`                                                                                                                                      |
+| `outro.ts`   | `buildOutroLines` — two registry passes: success lines first, then skip lines, both in registry order                                                                                              |
+| `summary.ts` | `formatSummaryLines` + `promptSummaryAction` — looks up each selected MCP in the registry by id                                                                                                    |
+| `prompts.ts` | `selectMcps` — derives multiselect options from `registry.map(c => c.multiselectOption)`                                                                                                           |
+| `config.ts`  | Persistence: load/save `~/.config/myclaude/config.json`                                                                                                                                            |
+| `types.ts`   | All shared TypeScript types (`ResolvedConfig`, `LauncherConfig`, `SkippedMap`, per-MCP config interfaces)                                                                                          |
+
+### Shared helpers
+
+- `utils.ts` — `tryLoad` (returns `null` and emits `log.warn` on failure) and `errorMessage`
+- `dotfile.ts` — `writeDotfile`: writes a named dotfile to `~/.claude/.<name>` with mode 0600; used by CloudWatch, GCP Observability, and Kubernetes command implementations
+- `cancel.ts` — `handleCancel`: exits the process if a prompt returns a cancel signal; extracted from `prompts.ts` to avoid a circular dep (`prompts.ts` → `mcp-command.ts` → `mcp/*.ts` → `prompts.ts`)
+
+### Kubernetes post-save side effect
+
+Kubernetes requires a context switch (`kubectx <ctx>`) after the user's choice is persisted but before env vars are built. This is handled by `applyKubernetesContextSwitch` exported from `mcp/kubernetes.ts` and called explicitly in `launchClaude`. It is a named function at a visible call site rather than a generic hook in the registry — intentionally, so the side effect is auditable without tracing an abstraction. A future MCP that needs post-save behavior follows the same pattern: add a named function in its module and an explicit call in `launchClaude`.
+
+### Adding a new MCP
+
+For an MCP with no post-save side effect (the common case), the required changes are:
+
+1. **Create `src/launcher/mcp/<name>.ts`** — export a `<name>Command: McpCommand` constant. Import `McpCommand` from `../mcp-command-types.js` (not `../mcp-command.js`) to avoid the circular dependency.
+2. **Register it** in `src/launcher/mcp-command.ts` — one import line and one entry in the `registry` array.
+3. **Extend `src/launcher/types.ts`** with four additions:
+   - A config interface for the resolved sub-shape (e.g., `DatadogConfig`)
+   - `datadog?: DatadogConfig` on `ResolvedConfig`
+   - `datadog?: false | "loader-failed"` on `SkippedMap`
+   - `datadog?: { /* persisted fields */ }` on `LauncherConfig`
+
+No edits to `main.ts`, `env.ts`, `resolve.ts`, `outro.ts`, `summary.ts`, or `prompts.ts` are needed.
+
+For an MCP that requires a post-save side effect, additionally export a named function from its module (e.g., `applyDatadogPostSave`) and add an explicit import and call site in `launchClaude` in `main.ts`.
+
+The comment block at the top of `mcp-command.ts` repeats this checklist as an in-code reference.
 
 ## Integration with install.sh
 
@@ -160,7 +213,7 @@ If the dotfile is absent or empty, and no project was set another way, the wrapp
 
 When "Kubernetes" is selected in the MCP multiselect, the launcher runs `kubectx` (no arguments) to list available contexts and presents a `select` prompt. The previously saved context is offered as the default; if none is saved, the current active context from `kubectl config current-context` is used as the fallback, then the first context in the list.
 
-If the selected context differs from the saved previous context, the launcher runs `kubectx <selected>` to switch the active context in `~/.kube/config` before launching Claude. Re-selecting the same context skips the switch. The switch happens in `main.ts` immediately after the prompt, before `buildEnvVars` is called — see `mcp/kubernetes.ts` (`switchContext`) for the exact behavior.
+If the selected context differs from the saved previous context, the launcher runs `kubectx <selected>` to switch the active context in `~/.kube/config` before launching Claude. Re-selecting the same context skips the switch. The switch happens via `applyKubernetesContextSwitch` (exported from `mcp/kubernetes.ts`), called in `launchClaude` after `saveConfig` completes and before `buildEnvVars` is called. See `mcp/kubernetes.ts` for `switchContext` (the underlying kubectx call) and `applyKubernetesContextSwitch` (the post-save orchestration).
 
 ### What env var and dotfile are written
 
@@ -168,7 +221,7 @@ If the selected context differs from the saved previous context, the launcher ru
 
 `~/.claude/.current-kube-context` is also written (mode 0600) for symmetry with the CloudWatch and GCP patterns, and to support potential future wrapper scripts or slash commands that need the selected context at runtime.
 
-If the `kubectx` switch fails, `launchClaude` sets `kubernetes: undefined` on the config passed to `buildEnvVars`, so neither `K8S_CONTEXT` nor `~/.claude/.current-kube-context` are written. The outro line reflects the skip, keeping the display, env export, and dotfile consistent.
+If the `kubectx` switch fails, `applyKubernetesContextSwitch` clears `kubernetes` from the resolved config and sets `effectiveSkipped.kubernetes = "switch-failed"`. As a result, `buildEnvVars` emits neither `K8S_CONTEXT` nor the dotfile, and the outro line reflects the skip — keeping display, env export, and dotfile consistent.
 
 ### Persistence
 
@@ -178,5 +231,7 @@ The selected context is saved under `kubernetes.context` in `~/.config/myclaude/
 
 - **`src/mcp/wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
 - **`src/mcp/wrappers/mcp-gcp-observability.sh`** — Bash wrapper that resolves the GCP project from the dotfile and launches the Observability MCP server
-- **`src/launcher/mcp/kubernetes.ts`** — `kubectx` context listing, selection prompt, and context switching logic
+- **`src/launcher/mcp-command-types.ts`** — `McpCommand` interface and `StaleResourceError` class
+- **`src/launcher/mcp-command.ts`** — Registry, re-exports of core types, and the "how to add a new MCP" comment block
+- **`src/launcher/mcp/kubernetes.ts`** — `kubectx` context listing, selection prompt, context switching, and `applyKubernetesContextSwitch`
 - **`src/installer/launcher-install.ts`** — Installation logic for the launcher

--- a/src/launcher/cancel.ts
+++ b/src/launcher/cancel.ts
@@ -1,0 +1,19 @@
+import { isCancel, cancel } from "@clack/prompts";
+
+/**
+ * Asserts that a prompt value is not a cancellation signal.
+ * Exits the process if the user cancelled the prompt.
+ *
+ * Extracted from prompts.ts into a standalone module so that MCP command
+ * implementations can import it without pulling in the registry (which would
+ * create a circular dependency: mcp-command.ts → mcp/*.ts → prompts.ts →
+ * mcp-command.ts).
+ */
+export function handleCancel(
+  value: unknown,
+): asserts value is NonNullable<unknown> {
+  if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(0);
+  }
+}

--- a/src/launcher/dotfile.ts
+++ b/src/launcher/dotfile.ts
@@ -1,0 +1,13 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+export function writeDotfile(name: string, value: string): void {
+  const dotfilePath = path.join(os.homedir(), ".claude", "." + name);
+  const dotfileDir = path.dirname(dotfilePath);
+  fs.mkdirSync(dotfileDir, { recursive: true });
+  fs.writeFileSync(dotfilePath, value + "\n", {
+    mode: 0o600,
+    encoding: "utf8",
+  });
+}

--- a/src/launcher/env.ts
+++ b/src/launcher/env.ts
@@ -1,68 +1,10 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
 import type { ResolvedConfig } from "./types.js";
-
-function writeDotfile(name: string, value: string): void {
-  const dotfilePath = path.join(os.homedir(), ".claude", "." + name);
-  const dotfileDir = path.dirname(dotfilePath);
-  fs.mkdirSync(dotfileDir, { recursive: true });
-  fs.writeFileSync(dotfilePath, value + "\n", {
-    mode: 0o600,
-    encoding: "utf8",
-  });
-}
+import { registry } from "./mcp-command.js";
 
 export function buildEnvVars(config: ResolvedConfig): Record<string, string> {
   const envVars: Record<string, string> = {};
-
-  if (config.grafana) {
-    const { cluster, role } = config.grafana;
-    envVars["GRAFANA_URL"] = cluster.url;
-
-    if (role === "viewer") {
-      envVars["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.viewer_token;
-      envVars["GRAFANA_DISABLE_WRITE"] = "true";
-    } else {
-      // editor role — no GRAFANA_DISABLE_WRITE
-      envVars["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.editor_token;
-    }
+  for (const cmd of registry) {
+    cmd.emitEnvVars(config, envVars);
   }
-
-  if (config.cloudwatch) {
-    const profile = config.cloudwatch.profile;
-    envVars["AWS_PROFILE"] = profile;
-
-    // mcp-cloudwatch.sh reads ~/.claude/.current-aws-profile and overrides AWS_PROFILE.
-    // Write the dotfile so both paths agree — same behaviour as /set-aws-profile command.
-    writeDotfile("current-aws-profile", profile);
-  }
-
-  if (config.gcpObservability) {
-    const project = config.gcpObservability.project;
-    envVars["GOOGLE_CLOUD_PROJECT"] = project;
-
-    // mcp-gcp-observability.sh reads ~/.claude/.current-gcp-project and overrides GOOGLE_CLOUD_PROJECT.
-    // Write the dotfile so both paths agree.
-    // Note: GOOGLE_CLOUD_PROJECT is used by google-auth-library's getProjectId() for project ID resolution.
-    // getProjectId() checks the GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT env var group (GCLOUD_PROJECT first,
-    // then GOOGLE_CLOUD_PROJECT), before credential files or the metadata server.
-    // It does NOT auto-populate tool call parameters.
-    writeDotfile("current-gcp-project", project);
-  }
-
-  if (config.kubernetes) {
-    const context = config.kubernetes.context;
-    // K8S_CONTEXT: explicit context override for mcp-server-kubernetes.
-    // Takes higher priority than ~/.kube/config active context, ensuring the
-    // selected context is respected even when other kubeconfig env vars
-    // (KUBECONFIG, K8S_SERVER, etc.) are present in the environment.
-    envVars["K8S_CONTEXT"] = context;
-
-    // Write dotfile for symmetry with cloudwatch/gcp patterns and potential
-    // future use by wrapper scripts or slash commands.
-    writeDotfile("current-kube-context", context);
-  }
-
   return envVars;
 }

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -1,24 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { intro, outro } from "@clack/prompts";
 import { loadConfig, saveConfig } from "./config.js";
-import { loadGrafanaClusters, configureGrafana } from "./mcp/grafana.js";
-import { loadAwsProfiles, configureCloudWatch } from "./mcp/cloudwatch.js";
-import {
-  checkAdcCredentials,
-  configureGcpObservability,
-  loadGcpProjects,
-} from "./mcp/gcp-observability.js";
-import {
-  loadKubectxContexts,
-  configureKubernetes,
-  switchContext,
-} from "./mcp/kubernetes.js";
 import { selectMcps } from "./prompts.js";
 import { buildEnvVars } from "./env.js";
-import { tryLoad } from "./utils.js";
 import { buildOutroLines } from "./outro.js";
 import { promptSummaryAction } from "./summary.js";
 import { buildResolvedFromSaved } from "./resolve.js";
+import { registry } from "./mcp-command.js";
+import { applyKubernetesContextSwitch } from "./mcp/kubernetes.js";
 import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
 
 function launchClaude(
@@ -27,29 +16,11 @@ function launchClaude(
   skipped: SkippedMap = {},
 ): never {
   // Switch Kubernetes context AFTER config is persisted (avoids inconsistency if switchContext fails)
-  let switchAttempted = false;
-  let switchResult: void | null | undefined;
-  if (resolved.kubernetes !== undefined) {
-    switchAttempted = true;
-    switchResult = tryLoad(
-      () =>
-        switchContext(
-          resolved.kubernetes!.context,
-          savedConfig.kubernetes?.context,
-        ),
-      "kubernetes-switch",
-      `Failed to switch Kubernetes context to "${resolved.kubernetes!.context}" — launching with the previously active context.`,
-    );
-  }
-
-  const switchFailed = switchAttempted && switchResult === null;
-  const effectiveSkipped: SkippedMap = {
-    ...skipped,
-    kubernetes: switchFailed ? "switch-failed" : (skipped.kubernetes ?? false),
-  };
-  const outroResolved: ResolvedConfig = switchFailed
-    ? { ...resolved, kubernetes: undefined }
-    : resolved;
+  const { effectiveSkipped, outroResolved } = applyKubernetesContextSwitch(
+    resolved,
+    savedConfig,
+    skipped,
+  );
 
   // Build env vars summary for outro
   const envVars = buildEnvVars(outroResolved);
@@ -108,106 +79,23 @@ async function main(): Promise<void> {
     ...savedConfig,
     selectedMcps,
   };
+  const skipped: SkippedMap = {};
 
-  // Grafana configuration
-  let grafanaSkipped: false | "loader-failed" = false;
-  if (selectedMcps.includes("grafana")) {
-    const clusters = tryLoad(() => loadGrafanaClusters(), "grafana");
-
-    if (clusters !== null) {
-      const grafanaConfig = await configureGrafana(
-        clusters,
-        savedConfig.grafana?.clusterId,
-        savedConfig.grafana?.role,
-      );
-
-      resolved.grafana = grafanaConfig;
-      updatedConfig.grafana = {
-        clusterId: grafanaConfig.cluster.id,
-        role: grafanaConfig.role,
-      };
-    } else {
-      grafanaSkipped = "loader-failed";
+  // eslint-disable-next-line no-await-in-loop -- configure prompts must be sequential (each one blocks on user input)
+  for (const cmd of registry) {
+    if (!selectedMcps.includes(cmd.id)) continue;
+    const result = await cmd.configureInteractive(updatedConfig); // eslint-disable-line no-await-in-loop
+    if (result === null) {
+      skipped[cmd.skippedKey] = "loader-failed";
+      continue;
     }
-  }
-
-  // CloudWatch configuration
-  let cloudwatchSkipped: false | "loader-failed" = false;
-  if (selectedMcps.includes("cloudwatch")) {
-    const profiles = tryLoad(() => loadAwsProfiles(), "cloudwatch");
-
-    if (profiles !== null) {
-      const cwConfig = await configureCloudWatch(
-        profiles,
-        savedConfig.cloudwatch?.profile,
-      );
-
-      resolved.cloudwatch = cwConfig;
-      updatedConfig.cloudwatch = {
-        profile: cwConfig.profile,
-      };
-    } else {
-      cloudwatchSkipped = "loader-failed";
-    }
-  }
-
-  // GCP Observability configuration
-  let gcpSkipped: false | "loader-failed" = false;
-  if (selectedMcps.includes("gcp-observability")) {
-    const projects = tryLoad(
-      () => loadGcpProjects(),
-      "gcp",
-      "GCP project list unavailable — skipping gcp-observability MCP. Run `gcloud auth login` and re-launch.",
-    );
-    const adcOk =
-      projects !== null &&
-      tryLoad(
-        () => checkAdcCredentials(),
-        "gcp-adc",
-        "GCP ADC credentials unavailable — skipping gcp-observability MCP. Run `gcloud auth application-default login` and re-launch.",
-      ) !== null;
-
-    if (projects !== null && adcOk) {
-      const gcpConfig = await configureGcpObservability(
-        projects,
-        savedConfig.gcpObservability?.project,
-      );
-
-      resolved.gcpObservability = gcpConfig;
-      updatedConfig.gcpObservability = {
-        project: gcpConfig.project,
-      };
-    } else {
-      gcpSkipped = "loader-failed";
-    }
-  }
-
-  // Kubernetes configuration
-  let kubernetesSkipped: false | "loader-failed" = false;
-  if (selectedMcps.includes("kubernetes")) {
-    const contexts = tryLoad(() => loadKubectxContexts(), "kubernetes");
-
-    if (contexts !== null) {
-      const k8sConfig = await configureKubernetes(
-        contexts,
-        savedConfig.kubernetes?.context,
-      );
-
-      resolved.kubernetes = k8sConfig;
-      updatedConfig.kubernetes = { context: k8sConfig.context };
-    } else {
-      kubernetesSkipped = "loader-failed";
-    }
+    Object.assign(resolved, result.resolved);
+    Object.assign(updatedConfig, result.persistable);
   }
 
   // Persist updated selections (configure path only -- user changed config)
   saveConfig(updatedConfig);
-  launchClaude(resolved, updatedConfig, {
-    grafana: grafanaSkipped,
-    cloudwatch: cloudwatchSkipped,
-    gcp: gcpSkipped,
-    kubernetes: kubernetesSkipped,
-  });
+  launchClaude(resolved, updatedConfig, skipped);
 }
 
 main().catch((err: unknown) => {

--- a/src/launcher/mcp-command-types.ts
+++ b/src/launcher/mcp-command-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Core types for the McpCommand pattern.
+ *
+ * This file is intentionally kept separate from mcp-command.ts to break the
+ * circular dependency that would arise if the command implementations (e.g.,
+ * grafana.ts) imported StaleResourceError directly from mcp-command.ts, which
+ * in turn imports the command instances from those same files.
+ *
+ * Consumers of the public API import from mcp-command.ts, which re-exports
+ * everything from here. Command implementations (mcp/*.ts) import from this
+ * file to avoid the cycle.
+ */
+
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
+
+/**
+ * Thrown by an McpCommand's resolveFromSaved when a saved resource is no
+ * longer available (e.g., Grafana cluster id no longer in the clusters file).
+ * buildResolvedFromSaved catches this and returns null so main.ts falls
+ * through to the configure flow. Only Grafana throws this today.
+ */
+export class StaleResourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StaleResourceError";
+  }
+}
+
+export interface McpCommand {
+  /** Multiselect ID, also the value persisted in LauncherConfig.selectedMcps. */
+  readonly id: string;
+  /** SkippedMap key. For most MCPs this equals id; for gcp-observability it is "gcp". */
+  readonly skippedKey: keyof SkippedMap;
+  /** Multiselect option as shown in selectMcps(). */
+  readonly multiselectOption: { value: string; label: string; hint: string };
+
+  /** Configure flow: load resources (e.g., clusters, profiles), prompt, return resolved + persistable. Returns null if loading failed (caller marks skipped="loader-failed"). */
+  configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>; // partial of ResolvedConfig keyed by this MCP
+    persistable: Partial<LauncherConfig>; // partial of LauncherConfig keyed by this MCP
+  } | null>;
+
+  /**
+   * Resolve from a saved LauncherConfig without prompting. Returns:
+   *   - Partial<ResolvedConfig> on success (the per-MCP fragment to merge into the resolved config)
+   *   - null if the MCP was selected but its sub-object is missing (silent skip)
+   * May throw StaleResourceError if a saved reference no longer exists; caller
+   * (buildResolvedFromSaved) catches this and returns null to trigger configure flow.
+   * Only Grafana throws StaleResourceError today; the other three commands never throw.
+   */
+  resolveFromSaved(
+    config: LauncherConfig,
+    grafanaClustersPath?: string,
+  ): Partial<ResolvedConfig> | null;
+
+  /** Emit env vars and write any associated dotfiles for this MCP. Mutates the env map in place. */
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void;
+
+  /** Outro success line, or null if this MCP did not emit a success line for the given resolved config. */
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null;
+
+  /** Outro skip line for the given skip discriminant, or null if no skip line should appear. */
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null;
+
+  /** Summary screen line for this MCP from a persisted config. */
+  buildSummaryLine(config: LauncherConfig): string;
+}

--- a/src/launcher/mcp-command.test.ts
+++ b/src/launcher/mcp-command.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Behavioural-equivalence tests for the McpCommand registry.
+ *
+ * These tests verify that iterating the registry and calling each command's
+ * methods produces exactly the same output as the current orchestration
+ * functions (buildEnvVars, buildOutroLines, formatSummaryLines). They use the
+ * same fixtures as the existing test files as the comparison oracle.
+ *
+ * At the end of Step 2 these tests FAIL because the registry is empty. They
+ * become passing after Steps 3 and 5 populate the registry and wire the
+ * orchestration files to use it.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { registry } from "./mcp-command.js";
+import { buildEnvVars } from "./env.js";
+import { buildOutroLines } from "./outro.js";
+import { formatSummaryLines } from "./summary.js";
+import type {
+  ResolvedConfig,
+  SkippedMap,
+  LauncherConfig,
+  GrafanaCluster,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Dotfile isolation (mirrors env.test.ts strategy)
+// ---------------------------------------------------------------------------
+
+const dotfileDir = path.join(os.homedir(), ".claude");
+const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
+const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
+const kubeDotfilePath = path.join(dotfileDir, ".current-kube-context");
+
+let priorDotfileContent: string | null = null;
+let priorGcpDotfileContent: string | null = null;
+let priorKubeDotfileContent: string | null = null;
+
+before(() => {
+  if (fs.existsSync(dotfilePath)) {
+    priorDotfileContent = fs.readFileSync(dotfilePath, "utf8");
+  }
+  if (fs.existsSync(gcpDotfilePath)) {
+    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, "utf8");
+  }
+  if (fs.existsSync(kubeDotfilePath)) {
+    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, "utf8");
+  }
+});
+
+after(() => {
+  if (priorDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(dotfilePath, priorDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(dotfilePath)) {
+    fs.rmSync(dotfilePath);
+  }
+
+  if (priorGcpDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(gcpDotfilePath, priorGcpDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(gcpDotfilePath)) {
+    fs.rmSync(gcpDotfilePath);
+  }
+
+  if (priorKubeDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(kubeDotfilePath, priorKubeDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(kubeDotfilePath)) {
+    fs.rmSync(kubeDotfilePath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirrors env.test.ts and outro.test.ts)
+// ---------------------------------------------------------------------------
+
+const fakeCluster: GrafanaCluster = {
+  id: "test-cluster",
+  name: "Test Cluster",
+  url: "https://grafana.test.example.com",
+  viewer_token: "viewer-token-abc",
+  editor_token: "editor-token-xyz",
+};
+
+const allMcpsResolved: ResolvedConfig = {
+  grafana: { cluster: fakeCluster, role: "viewer" },
+  cloudwatch: { profile: "my-dev-profile" },
+  gcpObservability: { project: "my-gcp-project" },
+  kubernetes: { context: "my-cluster" },
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build env map by iterating the registry (the new contract)
+// ---------------------------------------------------------------------------
+
+function buildEnvVarsViaRegistry(
+  resolved: ResolvedConfig,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const cmd of registry) {
+    cmd.emitEnvVars(resolved, env);
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build outro lines by iterating the registry (the new contract)
+// ---------------------------------------------------------------------------
+
+function buildOutroLinesViaRegistry(
+  resolved: ResolvedConfig,
+  effectiveSkipped: SkippedMap,
+): string[] {
+  const lines: string[] = [];
+  // Success lines first
+  for (const cmd of registry) {
+    const isSkipped = Boolean(effectiveSkipped[cmd.skippedKey]);
+    if (!isSkipped) {
+      const line = cmd.buildOutroSuccessLine(resolved);
+      if (line !== null) lines.push(line);
+    }
+  }
+  // Skip lines second (same canonical order)
+  for (const cmd of registry) {
+    const line = cmd.buildOutroSkipLine(effectiveSkipped[cmd.skippedKey]);
+    if (line !== null) lines.push(line);
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build summary lines by iterating the registry
+// ---------------------------------------------------------------------------
+
+function formatSummaryLinesViaRegistry(config: LauncherConfig): string[] {
+  if (config.selectedMcps.length === 0) return ["No MCPs configured."];
+  return config.selectedMcps.map((name) => {
+    const cmd = registry.find((c) => c.id === name);
+    if (cmd === undefined) return `${name}: (unknown MCP)`;
+    return cmd.buildSummaryLine(config);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// registry length assertion (Step 3 acceptance check)
+// ---------------------------------------------------------------------------
+
+describe("registry", () => {
+  it("contains exactly four entries in canonical order", () => {
+    assert.strictEqual(registry.length, 4);
+    assert.deepStrictEqual(
+      registry.map((c) => c.id),
+      ["grafana", "cloudwatch", "gcp-observability", "kubernetes"],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Env var behavioural-equivalence tests
+// ---------------------------------------------------------------------------
+
+describe("registry emitEnvVars: behavioural equivalence with buildEnvVars", () => {
+  it("all MCPs resolved: registry produces same env map as buildEnvVars", () => {
+    const oracle = buildEnvVars(allMcpsResolved);
+    const actual = buildEnvVarsViaRegistry(allMcpsResolved);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("Grafana viewer only: registry produces same env map as buildEnvVars", () => {
+    const resolved: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "viewer" },
+    };
+    const oracle = buildEnvVars(resolved);
+    const actual = buildEnvVarsViaRegistry(resolved);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("Grafana editor only: registry produces same env map as buildEnvVars", () => {
+    const resolved: ResolvedConfig = {
+      grafana: { cluster: fakeCluster, role: "editor" },
+    };
+    const oracle = buildEnvVars(resolved);
+    const actual = buildEnvVarsViaRegistry(resolved);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("CloudWatch only: registry produces same env map as buildEnvVars", () => {
+    const resolved: ResolvedConfig = {
+      cloudwatch: { profile: "my-dev-profile" },
+    };
+    const oracle = buildEnvVars(resolved);
+    const actual = buildEnvVarsViaRegistry(resolved);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("empty config: registry produces same empty env map as buildEnvVars", () => {
+    const resolved: ResolvedConfig = {};
+    const oracle = buildEnvVars(resolved);
+    const actual = buildEnvVarsViaRegistry(resolved);
+    assert.deepStrictEqual(actual, oracle);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outro line behavioural-equivalence tests
+// (mirrors outro.test.ts cases (a), (b), (e), (e2), (g))
+// ---------------------------------------------------------------------------
+
+describe("registry buildOutroLines: behavioural equivalence with buildOutroLines", () => {
+  it("(a) all MCPs configured and none skipped: same lines as buildOutroLines", () => {
+    const resolved: ResolvedConfig = {
+      grafana: {
+        cluster: {
+          id: "prod-us-east",
+          name: "Production US-East",
+          url: "https://grafana.prod.example.com",
+          viewer_token: "viewer-token",
+          editor_token: "editor-token",
+        },
+        role: "viewer",
+      },
+      cloudwatch: { profile: "my-aws-profile" },
+      gcpObservability: { project: "my-gcp-project" },
+      kubernetes: { context: "prod-us-east" },
+    };
+    const effectiveSkipped: SkippedMap = {};
+    const oracle = buildOutroLines(resolved, effectiveSkipped);
+    const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("(b) all MCPs skipped via loader failure: same lines as buildOutroLines", () => {
+    const resolved: ResolvedConfig = {};
+    const effectiveSkipped: SkippedMap = {
+      grafana: "loader-failed",
+      cloudwatch: "loader-failed",
+      gcp: "loader-failed",
+      kubernetes: "loader-failed",
+    };
+    const oracle = buildOutroLines(resolved, effectiveSkipped);
+    const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("(e) success lines before skip lines in canonical order: same as buildOutroLines", () => {
+    const resolved: ResolvedConfig = {
+      grafana: {
+        cluster: {
+          id: "prod-us-east",
+          name: "Production US-East",
+          url: "https://grafana.prod.example.com",
+          viewer_token: "viewer-token",
+          editor_token: "editor-token",
+        },
+        role: "viewer",
+      },
+      gcpObservability: { project: "my-gcp-project" },
+      kubernetes: { context: "prod-us-east" },
+    };
+    const effectiveSkipped: SkippedMap = { cloudwatch: "loader-failed" };
+    const oracle = buildOutroLines(resolved, effectiveSkipped);
+    const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("(e2) success-first ordering when skipped MCP ranks before resolved: same as buildOutroLines", () => {
+    const resolved: ResolvedConfig = {
+      cloudwatch: { profile: "my-aws-profile" },
+    };
+    const effectiveSkipped: SkippedMap = { grafana: "loader-failed" };
+    const oracle = buildOutroLines(resolved, effectiveSkipped);
+    const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("(g) effectiveSkipped=false does not suppress success line: same as buildOutroLines", () => {
+    const resolved: ResolvedConfig = {
+      grafana: {
+        cluster: {
+          id: "prod-us-east",
+          name: "Production US-East",
+          url: "https://grafana.prod.example.com",
+          viewer_token: "viewer-token",
+          editor_token: "editor-token",
+        },
+        role: "viewer",
+      },
+    };
+    const effectiveSkipped: SkippedMap = { grafana: false };
+    const oracle = buildOutroLines(resolved, effectiveSkipped);
+    const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
+    assert.deepStrictEqual(actual, oracle);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary line behavioural-equivalence tests
+// ---------------------------------------------------------------------------
+
+describe("registry buildSummaryLine: behavioural equivalence with formatSummaryLines", () => {
+  it("empty selectedMcps: same result as formatSummaryLines", () => {
+    const config: LauncherConfig = { selectedMcps: [] };
+    const oracle = formatSummaryLines(config);
+    const actual = formatSummaryLinesViaRegistry(config);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("all four MCPs configured: same lines as formatSummaryLines", () => {
+    const config: LauncherConfig = {
+      selectedMcps: [
+        "grafana",
+        "cloudwatch",
+        "gcp-observability",
+        "kubernetes",
+      ],
+      grafana: { clusterId: "prod-us", role: "editor" },
+      cloudwatch: { profile: "prod" },
+      gcpObservability: { project: "gcp-prod" },
+      kubernetes: { context: "prod-cluster" },
+    };
+    const oracle = formatSummaryLines(config);
+    const actual = formatSummaryLinesViaRegistry(config);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("single MCP cloudwatch: same line as formatSummaryLines", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["cloudwatch"],
+      cloudwatch: { profile: "prod" },
+    };
+    const oracle = formatSummaryLines(config);
+    const actual = formatSummaryLinesViaRegistry(config);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("unknown MCP in selectedMcps: same '(unknown MCP)' line as formatSummaryLines", () => {
+    const config: LauncherConfig = { selectedMcps: ["future-mcp"] };
+    const oracle = formatSummaryLines(config);
+    const actual = formatSummaryLinesViaRegistry(config);
+    assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("MCP in selectedMcps with missing sub-object: same '(not yet configured)' line as formatSummaryLines", () => {
+    const config: LauncherConfig = { selectedMcps: ["grafana"] };
+    const oracle = formatSummaryLines(config);
+    const actual = formatSummaryLinesViaRegistry(config);
+    assert.deepStrictEqual(actual, oracle);
+  });
+});

--- a/src/launcher/mcp-command.ts
+++ b/src/launcher/mcp-command.ts
@@ -1,0 +1,57 @@
+/**
+ * McpCommand — GoF Command pattern for MCP lifecycle management.
+ *
+ * Each MCP is represented by a single McpCommand instance that owns its full
+ * lifecycle: load → configure → resolve from saved → emit env → produce
+ * display lines. Orchestration files (main.ts, env.ts, resolve.ts, outro.ts,
+ * summary.ts, prompts.ts) iterate over the registry rather than branching on
+ * MCP name.
+ *
+ * The McpCommand interface and StaleResourceError class are defined in
+ * mcp-command-types.ts and re-exported from here. They live in a separate
+ * file to break the circular dependency that would arise if the command
+ * implementations imported StaleResourceError directly from this file (which
+ * in turn imports those same command instances).
+ *
+ * ## How to add a new MCP (e.g., "datadog") with no post-save side effect:
+ *
+ * 1. Create `src/launcher/mcp/datadog.ts` exporting `datadogCommand: McpCommand`
+ *    and any free functions it needs (loaders, configurers, etc.).
+ *    Import McpCommand from `../mcp-command-types.js` (not `../mcp-command.js`)
+ *    to avoid the circular dependency.
+ *
+ * 2. Add `datadogCommand` to the `registry` array in this file:
+ *    - One import line: `import { datadogCommand } from "./mcp/datadog.js";`
+ *    - One array entry: add `datadogCommand` to the registry array below.
+ *
+ * 3. Extend `src/launcher/types.ts` with the four required type extensions:
+ *    a. Add a `DatadogConfig` interface describing the resolved sub-shape.
+ *    b. Add `datadog?: DatadogConfig` to the `ResolvedConfig` interface.
+ *    c. Add `datadog?: false | "loader-failed"` to the `SkippedMap` type.
+ *    d. Add `datadog?: { someKey: string }` to the `LauncherConfig` interface.
+ *
+ * 4. (Only if the new MCP requires a post-save side effect — datadog does not.)
+ *    Add a named function (e.g., `applyDatadogPostSave`) in `mcp/datadog.ts`
+ *    and an explicit import + call site in `launchClaude` in `main.ts`. This
+ *    is not a generic mechanism — it is a deliberate, visible call site.
+ *
+ * No edits to main.ts, env.ts, resolve.ts, outro.ts, summary.ts, or prompts.ts
+ * are required for an MCP without a post-save side effect.
+ */
+
+// Re-export the core types so consumers can import from a single location.
+export type { McpCommand } from "./mcp-command-types.js";
+export { StaleResourceError } from "./mcp-command-types.js";
+
+import type { McpCommand } from "./mcp-command-types.js";
+import { grafanaCommand } from "./mcp/grafana.js";
+import { cloudwatchCommand } from "./mcp/cloudwatch.js";
+import { gcpObservabilityCommand } from "./mcp/gcp-observability.js";
+import { kubernetesCommand } from "./mcp/kubernetes.js";
+
+export const registry: McpCommand[] = [
+  grafanaCommand,
+  cloudwatchCommand,
+  gcpObservabilityCommand,
+  kubernetesCommand,
+];

--- a/src/launcher/mcp/cloudwatch.ts
+++ b/src/launcher/mcp/cloudwatch.ts
@@ -3,7 +3,11 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { select } from "@clack/prompts";
 import type { CloudWatchConfig } from "../types.js";
-import { handleCancel } from "../prompts.js";
+import { handleCancel } from "../cancel.js";
+import type { McpCommand } from "../mcp-command-types.js";
+import { tryLoad } from "../utils.js";
+import { writeDotfile } from "../dotfile.js";
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
 
 const DEFAULT_CONFIG_PATH = path.join(os.homedir(), ".aws", "config");
 const DEFAULT_CREDENTIALS_PATH = path.join(os.homedir(), ".aws", "credentials");
@@ -122,3 +126,60 @@ export async function configureCloudWatch(
 
   return { profile: profileValue as string };
 }
+
+export const cloudwatchCommand: McpCommand = {
+  id: "cloudwatch",
+  skippedKey: "cloudwatch",
+  multiselectOption: {
+    value: "cloudwatch",
+    label: "CloudWatch",
+    hint: "AWS profile",
+  },
+
+  async configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>;
+    persistable: Partial<LauncherConfig>;
+  } | null> {
+    const profiles = tryLoad(() => loadAwsProfiles(), "cloudwatch");
+    if (profiles === null) return null;
+    const result = await configureCloudWatch(
+      profiles,
+      savedConfig.cloudwatch?.profile,
+    );
+    return {
+      resolved: { cloudwatch: result },
+      persistable: { cloudwatch: { profile: result.profile } },
+    };
+  },
+
+  resolveFromSaved(config: LauncherConfig): Partial<ResolvedConfig> | null {
+    if (config.cloudwatch === undefined) return null;
+    return { cloudwatch: { profile: config.cloudwatch.profile } };
+  },
+
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
+    if (!resolved.cloudwatch) return;
+    const profile = resolved.cloudwatch.profile;
+    env["AWS_PROFILE"] = profile;
+    // mcp-cloudwatch.sh reads ~/.claude/.current-aws-profile and overrides AWS_PROFILE.
+    // Write the dotfile so both paths agree — same behaviour as /set-aws-profile command.
+    writeDotfile("current-aws-profile", profile);
+  },
+
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
+    if (!resolved.cloudwatch) return null;
+    return `CloudWatch: ${resolved.cloudwatch.profile}`;
+  },
+
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
+    if (!skipped) return null;
+    return "CloudWatch: skipped (profiles unavailable)";
+  },
+
+  buildSummaryLine(config: LauncherConfig): string {
+    if (config.cloudwatch === undefined) {
+      return "CloudWatch: (not yet configured)";
+    }
+    return `CloudWatch: profile ${config.cloudwatch.profile}`;
+  },
+};

--- a/src/launcher/mcp/gcp-observability.ts
+++ b/src/launcher/mcp/gcp-observability.ts
@@ -4,7 +4,11 @@ import * as os from "node:os";
 import { spawnSync } from "node:child_process";
 import { select } from "@clack/prompts";
 import type { GcpObservabilityConfig } from "../types.js";
-import { handleCancel } from "../prompts.js";
+import { handleCancel } from "../cancel.js";
+import type { McpCommand } from "../mcp-command-types.js";
+import { tryLoad } from "../utils.js";
+import { writeDotfile } from "../dotfile.js";
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
 
 export interface GcloudResult {
   status: number | null;
@@ -124,3 +128,78 @@ export async function configureGcpObservability(
 
   return { project: projectValue as string };
 }
+
+export const gcpObservabilityCommand: McpCommand = {
+  id: "gcp-observability",
+  skippedKey: "gcp",
+  multiselectOption: {
+    value: "gcp-observability",
+    label: "GCP Observability",
+    hint: "GCP project",
+  },
+
+  async configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>;
+    persistable: Partial<LauncherConfig>;
+  } | null> {
+    const projects = tryLoad(
+      () => loadGcpProjects(),
+      "gcp",
+      "GCP project list unavailable — skipping gcp-observability MCP. Run `gcloud auth login` and re-launch.",
+    );
+    if (projects === null) return null;
+
+    const adcResult = tryLoad(
+      () => checkAdcCredentials(),
+      "gcp-adc",
+      "GCP ADC credentials unavailable — skipping gcp-observability MCP. Run `gcloud auth application-default login` and re-launch.",
+    );
+    // checkAdcCredentials returns void on success; tryLoad propagates void as undefined, not null.
+    // Use !== null (not falsy !) to distinguish success (undefined) from failure (null).
+    if (adcResult === null) return null;
+
+    const result = await configureGcpObservability(
+      projects,
+      savedConfig.gcpObservability?.project,
+    );
+    return {
+      resolved: { gcpObservability: result },
+      persistable: { gcpObservability: { project: result.project } },
+    };
+  },
+
+  resolveFromSaved(config: LauncherConfig): Partial<ResolvedConfig> | null {
+    if (config.gcpObservability === undefined) return null;
+    return { gcpObservability: { project: config.gcpObservability.project } };
+  },
+
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
+    if (!resolved.gcpObservability) return;
+    const project = resolved.gcpObservability.project;
+    env["GOOGLE_CLOUD_PROJECT"] = project;
+    // mcp-gcp-observability.sh reads ~/.claude/.current-gcp-project and overrides GOOGLE_CLOUD_PROJECT.
+    // Write the dotfile so both paths agree.
+    // Note: GOOGLE_CLOUD_PROJECT is used by google-auth-library's getProjectId() for project ID resolution.
+    // getProjectId() checks the GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT env var group (GCLOUD_PROJECT first,
+    // then GOOGLE_CLOUD_PROJECT), before credential files or the metadata server.
+    // It does NOT auto-populate tool call parameters.
+    writeDotfile("current-gcp-project", project);
+  },
+
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
+    if (!resolved.gcpObservability) return null;
+    return `GCP Observability: ${resolved.gcpObservability.project}`;
+  },
+
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
+    if (!skipped) return null;
+    return "GCP Observability: skipped (auth unavailable)";
+  },
+
+  buildSummaryLine(config: LauncherConfig): string {
+    if (config.gcpObservability === undefined) {
+      return "GCP Observability: (not yet configured)";
+    }
+    return `GCP Observability: project ${config.gcpObservability.project}`;
+  },
+};

--- a/src/launcher/mcp/grafana.ts
+++ b/src/launcher/mcp/grafana.ts
@@ -4,7 +4,11 @@ import * as os from "node:os";
 import { parse as parseYaml } from "yaml";
 import { log, select, cancel } from "@clack/prompts";
 import type { GrafanaCluster, GrafanaConfig, GrafanaRole } from "../types.js";
-import { handleCancel } from "../prompts.js";
+import { handleCancel } from "../cancel.js";
+import type { McpCommand } from "../mcp-command-types.js";
+import { StaleResourceError } from "../mcp-command-types.js";
+import { tryLoad } from "../utils.js";
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
 
 const DEFAULT_CONFIG_PATH = path.join(
   os.homedir(),
@@ -150,3 +154,92 @@ export async function configureGrafana(
     role: roleValue as GrafanaRole,
   };
 }
+
+export const grafanaCommand: McpCommand = {
+  id: "grafana",
+  skippedKey: "grafana",
+  multiselectOption: {
+    value: "grafana",
+    label: "Grafana",
+    hint: "cluster + role",
+  },
+
+  async configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>;
+    persistable: Partial<LauncherConfig>;
+  } | null> {
+    const clusters = tryLoad(() => loadGrafanaClusters(), "grafana");
+    if (clusters === null) return null;
+    const result = await configureGrafana(
+      clusters,
+      savedConfig.grafana?.clusterId,
+      savedConfig.grafana?.role,
+    );
+    return {
+      resolved: { grafana: result },
+      persistable: {
+        grafana: { clusterId: result.cluster.id, role: result.role },
+      },
+    };
+  },
+
+  resolveFromSaved(
+    config: LauncherConfig,
+    grafanaClustersPath?: string,
+  ): Partial<ResolvedConfig> | null {
+    if (config.grafana === undefined) {
+      return null;
+    }
+    let clusters: GrafanaCluster[];
+    try {
+      clusters = loadGrafanaClusters(grafanaClustersPath);
+    } catch (err) {
+      log.warn(
+        `Could not load Grafana clusters: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
+      );
+      // Message arg is for diagnostic use only; user warning is emitted above.
+      throw new StaleResourceError("Grafana clusters file unavailable");
+    }
+    const cluster = clusters.find((c) => c.id === config.grafana!.clusterId);
+    if (cluster === undefined) {
+      log.warn(
+        `Grafana cluster "${config.grafana.clusterId}" not found in clusters file. Falling through to configure flow.`,
+      );
+      // Message arg is for diagnostic use only; user warning is emitted above.
+      throw new StaleResourceError(
+        `Grafana cluster ${config.grafana.clusterId} no longer exists`,
+      );
+    }
+    return { grafana: { cluster, role: config.grafana.role } };
+  },
+
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
+    if (!resolved.grafana) return;
+    const { cluster, role } = resolved.grafana;
+    env["GRAFANA_URL"] = cluster.url;
+    if (role === "viewer") {
+      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.viewer_token;
+      env["GRAFANA_DISABLE_WRITE"] = "true";
+    } else {
+      // editor role — no GRAFANA_DISABLE_WRITE
+      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.editor_token;
+    }
+  },
+
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
+    if (!resolved.grafana) return null;
+    return `Grafana: ${resolved.grafana.cluster.name} (${resolved.grafana.role})`;
+  },
+
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
+    if (!skipped) return null;
+    return "Grafana: skipped (clusters unavailable)";
+  },
+
+  buildSummaryLine(config: LauncherConfig): string {
+    if (config.grafana === undefined) {
+      return "Grafana: (not yet configured)";
+    }
+    return `Grafana: cluster ${config.grafana.clusterId}, role ${config.grafana.role}`;
+  },
+};

--- a/src/launcher/mcp/kubernetes.ts
+++ b/src/launcher/mcp/kubernetes.ts
@@ -1,7 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { select } from "@clack/prompts";
 import type { KubernetesConfig } from "../types.js";
-import { handleCancel } from "../prompts.js";
+import { handleCancel } from "../cancel.js";
+import type { McpCommand } from "../mcp-command-types.js";
+import { tryLoad } from "../utils.js";
+import { writeDotfile } from "../dotfile.js";
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
 
 /**
  * Parses stdout from `kubectx` (no args) into a list of context names.
@@ -100,4 +104,116 @@ export async function configureKubernetes(
   handleCancel(selected);
 
   return { context: selected as string };
+}
+
+export const kubernetesCommand: McpCommand = {
+  id: "kubernetes",
+  skippedKey: "kubernetes",
+  multiselectOption: {
+    value: "kubernetes",
+    label: "Kubernetes",
+    hint: "cluster context",
+  },
+
+  async configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>;
+    persistable: Partial<LauncherConfig>;
+  } | null> {
+    const contexts = tryLoad(() => loadKubectxContexts(), "kubernetes");
+    if (contexts === null) return null;
+    const result = await configureKubernetes(
+      contexts,
+      savedConfig.kubernetes?.context,
+    );
+    return {
+      resolved: { kubernetes: result },
+      persistable: { kubernetes: { context: result.context } },
+    };
+  },
+
+  resolveFromSaved(config: LauncherConfig): Partial<ResolvedConfig> | null {
+    if (config.kubernetes === undefined) return null;
+    return { kubernetes: { context: config.kubernetes.context } };
+  },
+
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
+    if (!resolved.kubernetes) return;
+    const context = resolved.kubernetes.context;
+    // K8S_CONTEXT: explicit context override for mcp-server-kubernetes.
+    // Takes higher priority than ~/.kube/config active context, ensuring the
+    // selected context is respected even when other kubeconfig env vars
+    // (KUBECONFIG, K8S_SERVER, etc.) are present in the environment.
+    env["K8S_CONTEXT"] = context;
+    // Write dotfile for symmetry with cloudwatch/gcp patterns and potential
+    // future use by wrapper scripts or slash commands.
+    writeDotfile("current-kube-context", context);
+  },
+
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
+    if (!resolved.kubernetes) return null;
+    return `Kubernetes: ${resolved.kubernetes.context}`;
+  },
+
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
+    if (skipped === "loader-failed")
+      return "Kubernetes: skipped (contexts unavailable)";
+    if (skipped === "switch-failed")
+      return "Kubernetes: skipped (context switch failed)";
+    return null;
+  },
+
+  buildSummaryLine(config: LauncherConfig): string {
+    if (config.kubernetes === undefined) {
+      return "Kubernetes: (not yet configured)";
+    }
+    return `Kubernetes: context ${config.kubernetes.context}`;
+  },
+};
+
+/**
+ * Apply the post-save Kubernetes context switch. Called from launchClaude
+ * AFTER saveConfig has persisted the user's choice but BEFORE buildEnvVars
+ * is called. Returns a new (effectiveSkipped, outroResolved) pair reflecting
+ * whether the switch succeeded.
+ *
+ * If resolved.kubernetes is undefined (Kubernetes not selected, or already
+ * skipped at load time), this is a no-op: returns the inputs unchanged.
+ *
+ * If the switch fails, sets effectiveSkipped.kubernetes = "switch-failed"
+ * and clears outroResolved.kubernetes so downstream callers (buildEnvVars,
+ * buildOutroLines) do not emit Kubernetes data.
+ */
+export function applyKubernetesContextSwitch(
+  resolved: ResolvedConfig,
+  savedConfig: LauncherConfig,
+  skipped: SkippedMap,
+): { effectiveSkipped: SkippedMap; outroResolved: ResolvedConfig } {
+  if (resolved.kubernetes === undefined) {
+    // Preserve byte-equivalence with old launchClaude: always set kubernetes key explicitly
+    return {
+      effectiveSkipped: { ...skipped, kubernetes: skipped.kubernetes ?? false },
+      outroResolved: resolved,
+    };
+  }
+  const switchResult = tryLoad(
+    () =>
+      switchContext(
+        resolved.kubernetes!.context,
+        savedConfig.kubernetes?.context,
+      ),
+    "kubernetes-switch",
+    `Failed to switch Kubernetes context to "${resolved.kubernetes!.context}" — launching with the previously active context.`,
+  );
+  const switchFailed = switchResult === null;
+  return {
+    effectiveSkipped: {
+      ...skipped,
+      kubernetes: switchFailed
+        ? "switch-failed"
+        : (skipped.kubernetes ?? false),
+    },
+    outroResolved: switchFailed
+      ? { ...resolved, kubernetes: undefined }
+      : resolved,
+  };
 }

--- a/src/launcher/outro.ts
+++ b/src/launcher/outro.ts
@@ -1,4 +1,5 @@
 import type { ResolvedConfig, SkippedMap } from "./types.js";
+import { registry } from "./mcp-command.js";
 
 export function buildOutroLines(
   resolved: ResolvedConfig,
@@ -6,36 +7,22 @@ export function buildOutroLines(
 ): string[] {
   const lines: string[] = [];
 
-  // Success lines, in canonical order. Each is gated on BOTH resolved.<mcp>
+  // Success lines, in canonical registry order. Each is gated on BOTH resolved.<mcp>
   // truthy AND effectiveSkipped.<mcp> falsy, so the function cannot emit
   // both a success line and a skip line for the same MCP — even if a caller
   // passes a contradictory pair.
-  if (resolved.grafana && !effectiveSkipped.grafana) {
-    lines.push(
-      `Grafana: ${resolved.grafana.cluster.name} (${resolved.grafana.role})`,
-    );
-  }
-  if (resolved.cloudwatch && !effectiveSkipped.cloudwatch) {
-    lines.push(`CloudWatch: ${resolved.cloudwatch.profile}`);
-  }
-  if (resolved.gcpObservability && !effectiveSkipped.gcp) {
-    lines.push(`GCP Observability: ${resolved.gcpObservability.project}`);
-  }
-  if (resolved.kubernetes && !effectiveSkipped.kubernetes) {
-    lines.push(`Kubernetes: ${resolved.kubernetes.context}`);
+  for (const cmd of registry) {
+    const isSkipped = Boolean(effectiveSkipped[cmd.skippedKey]);
+    if (!isSkipped) {
+      const line = cmd.buildOutroSuccessLine(resolved);
+      if (line !== null) lines.push(line);
+    }
   }
 
   // Skip lines, in the same canonical order: Grafana → CloudWatch → GCP → Kubernetes.
-  if (effectiveSkipped.grafana)
-    lines.push("Grafana: skipped (clusters unavailable)");
-  if (effectiveSkipped.cloudwatch)
-    lines.push("CloudWatch: skipped (profiles unavailable)");
-  if (effectiveSkipped.gcp)
-    lines.push("GCP Observability: skipped (auth unavailable)");
-  if (effectiveSkipped.kubernetes === "loader-failed") {
-    lines.push("Kubernetes: skipped (contexts unavailable)");
-  } else if (effectiveSkipped.kubernetes === "switch-failed") {
-    lines.push("Kubernetes: skipped (context switch failed)");
+  for (const cmd of registry) {
+    const line = cmd.buildOutroSkipLine(effectiveSkipped[cmd.skippedKey]);
+    if (line !== null) lines.push(line);
   }
 
   return lines;

--- a/src/launcher/prompts.ts
+++ b/src/launcher/prompts.ts
@@ -1,29 +1,13 @@
-import { multiselect, isCancel, cancel } from "@clack/prompts";
-
-export function handleCancel(
-  value: unknown,
-): asserts value is NonNullable<unknown> {
-  if (isCancel(value)) {
-    cancel("Operation cancelled.");
-    process.exit(0);
-  }
-}
+import { multiselect } from "@clack/prompts";
+import { registry } from "./mcp-command.js";
+import { handleCancel } from "./cancel.js";
 
 export async function selectMcps(
   previousSelections: string[],
 ): Promise<string[]> {
   const value = await multiselect({
     message: "Select MCPs to configure for this session:",
-    options: [
-      { value: "grafana", label: "Grafana", hint: "cluster + role" },
-      { value: "cloudwatch", label: "CloudWatch", hint: "AWS profile" },
-      {
-        value: "gcp-observability",
-        label: "GCP Observability",
-        hint: "GCP project",
-      },
-      { value: "kubernetes", label: "Kubernetes", hint: "cluster context" },
-    ],
+    options: registry.map((c) => c.multiselectOption),
     initialValues: previousSelections,
     required: false,
   });

--- a/src/launcher/resolve.ts
+++ b/src/launcher/resolve.ts
@@ -1,6 +1,5 @@
-import { log } from "@clack/prompts";
-import { loadGrafanaClusters } from "./mcp/grafana.js";
 import type { ResolvedConfig, LauncherConfig } from "./types.js";
+import { registry, StaleResourceError } from "./mcp-command.js";
 
 export function buildResolvedFromSaved(
   config: LauncherConfig,
@@ -9,63 +8,17 @@ export function buildResolvedFromSaved(
   const resolved: ResolvedConfig = {};
 
   for (const name of config.selectedMcps) {
-    switch (name) {
-      case "grafana": {
-        if (config.grafana === undefined) {
-          // Sub-object missing — silently skip
-          break;
-        }
-        let clusters;
-        try {
-          clusters = loadGrafanaClusters(grafanaClustersPath);
-        } catch (err) {
-          log.warn(
-            `Could not load Grafana clusters: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
-          );
-          return null;
-        }
-        const cluster = clusters.find(
-          (c) => c.id === config.grafana!.clusterId,
-        );
-        if (cluster === undefined) {
-          log.warn(
-            `Grafana cluster "${config.grafana.clusterId}" not found in clusters file. Falling through to configure flow.`,
-          );
-          return null;
-        }
-        resolved.grafana = { cluster, role: config.grafana.role };
-        break;
+    const cmd = registry.find((c) => c.id === name);
+    if (cmd === undefined) continue; // unknown MCP — silently skip (preserves current default-case behaviour)
+    try {
+      const fragment = cmd.resolveFromSaved(config, grafanaClustersPath);
+      if (fragment === null) continue; // sub-object missing — silent skip
+      Object.assign(resolved, fragment);
+    } catch (err) {
+      if (err instanceof StaleResourceError) {
+        return null; // trigger fall-through to configure flow
       }
-
-      case "cloudwatch": {
-        if (config.cloudwatch === undefined) {
-          break;
-        }
-        resolved.cloudwatch = { profile: config.cloudwatch.profile };
-        break;
-      }
-
-      case "gcp-observability": {
-        if (config.gcpObservability === undefined) {
-          break;
-        }
-        resolved.gcpObservability = {
-          project: config.gcpObservability.project,
-        };
-        break;
-      }
-
-      case "kubernetes": {
-        if (config.kubernetes === undefined) {
-          break;
-        }
-        resolved.kubernetes = { context: config.kubernetes.context };
-        break;
-      }
-
-      default:
-        // Unknown MCP — silently skip in resolved config
-        break;
+      throw err;
     }
   }
 

--- a/src/launcher/summary.ts
+++ b/src/launcher/summary.ts
@@ -1,6 +1,7 @@
 import { note, select } from "@clack/prompts";
-import { handleCancel } from "./prompts.js";
+import { handleCancel } from "./cancel.js";
 import type { LauncherConfig } from "./types.js";
+import { registry } from "./mcp-command.js";
 
 export function formatSummaryLines(config: LauncherConfig): string[] {
   if (config.selectedMcps.length === 0) {
@@ -8,34 +9,9 @@ export function formatSummaryLines(config: LauncherConfig): string[] {
   }
 
   return config.selectedMcps.map((name) => {
-    switch (name) {
-      case "grafana":
-        if (config.grafana === undefined) {
-          return "Grafana: (not yet configured)";
-        }
-        return `Grafana: cluster ${config.grafana.clusterId}, role ${config.grafana.role}`;
-
-      case "cloudwatch":
-        if (config.cloudwatch === undefined) {
-          return "CloudWatch: (not yet configured)";
-        }
-        return `CloudWatch: profile ${config.cloudwatch.profile}`;
-
-      case "gcp-observability":
-        if (config.gcpObservability === undefined) {
-          return "GCP Observability: (not yet configured)";
-        }
-        return `GCP Observability: project ${config.gcpObservability.project}`;
-
-      case "kubernetes":
-        if (config.kubernetes === undefined) {
-          return "Kubernetes: (not yet configured)";
-        }
-        return `Kubernetes: context ${config.kubernetes.context}`;
-
-      default:
-        return `${name}: (unknown MCP)`;
-    }
+    const cmd = registry.find((c) => c.id === name);
+    if (cmd === undefined) return `${name}: (unknown MCP)`;
+    return cmd.buildSummaryLine(config);
   });
 }
 


### PR DESCRIPTION
Each MCP (Grafana, CloudWatch, GCP Observability, Kubernetes) is now encapsulated as a `McpCommand` object implementing a shared interface, registered in a single `registry` array. This replaces six parallel if-chains across `main.ts`, `env.ts`, `resolve.ts`, `outro.ts`, `summary.ts`, and `prompts.ts`.

Adding a new MCP now requires creating one file and extending `types.ts` — no edits to orchestration code. All 185 existing tests pass unchanged; public function signatures are preserved.

Two auxiliary files (`mcp-command-types.ts`, `cancel.ts`) were added beyond the original plan scope to break circular dependencies introduced by the registry import graph.