### PR TITLE
feat(github): add general-purpose issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/alkofu/ai-tpk/security/advisories/new
+    about: Use GitHub's Private Vulnerability Reporting for security issues. Do not open a public issue. See .github/SECURITY.md for the full policy.

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,79 @@
+---
+name: General issue
+about: Report a bug, request a feature, or open an action item.
+title: ""
+---
+
+## Type
+
+- [ ] Bug
+- [ ] Feature
+- [ ] Action item
+- [ ] Enhancement
+- [ ] Tech debt
+- [ ] Docs
+- [ ] Investigation
+
+## Summary
+
+Briefly describe the issue, the change you want, or the action to take. One or two sentences is usually enough.
+
+## Impact
+
+- Affected users / systems:
+- Frequency (always / sometimes / once):
+- Scope / scale:
+- Business or user impact:
+- Workaround (if any):
+
+## Acceptance criteria
+
+What does "done" look like? List concrete, checkable outcomes. If this is a bug, this can be as simple as the expected behavior being restored.
+
+- [ ]
+- [ ]
+
+## Steps to reproduce
+
+If this is a bug, list the minimal steps to reproduce it. Otherwise write N/A.
+
+1.
+2.
+3.
+
+## Desired outcome
+
+What should happen when this is complete?
+
+## Current state
+
+What actually happens today, or what limitation / gap exists now?
+
+## Evidence
+
+Attach anything that helps. Write N/A if none yet.
+
+- Error messages:
+- Logs:
+- Screenshots:
+- Links (related issues, PRs, docs):
+
+## Environment
+
+If the issue is environment-dependent, fill these in. Otherwise write N/A.
+
+- App / service:
+- Version / commit SHA:
+- Platform / device / browser:
+- Region / tenant:
+- Time observed (with timezone):
+
+## Hypotheses
+
+Possible causes or design directions, clearly marked as unconfirmed. Optional.
+
+## Open questions
+
+Things you do not yet know and want a maintainer or reviewer to weigh in on. Optional.
+
+-


### PR DESCRIPTION
Adds a single general-purpose issue template covering bugs, feature requests, and action items — with neutral phrasing and "Acceptance criteria" at the top. Also adds `config.yml` to keep blank issues enabled and surface GitHub's Private Vulnerability Reporting path for security reporters.