### PR TITLE
fix(hooks): write OSC tab rename sequences to /dev/tty instead of stdout

### DIFF
--- a/claude/hooks/lib-tab-rename.sh
+++ b/claude/hooks/lib-tab-rename.sh
@@ -51,8 +51,13 @@ _tab_rename_set_title() {
   local TITLE="$1"
   if [ "$TERMINAL" = "tmux" ]; then
     tmux rename-window "$TITLE" 2>/dev/null
+  # OSC writes go to /dev/tty (not stdout) so they reach the terminal even when
+  # this hook runs as `async: true` and Claude's hook-runner captures stdout.
+  # If /dev/tty cannot be opened (non-interactive / CI), any Bash diagnostic goes
+  # to the inherited stderr, which the hook-runner discards; printf returns non-zero
+  # and is ignored by the caller (no set -e in either hook entry point).
   elif [ "$TERMINAL" = "iterm2" ]; then
-    printf '\033]0;%s\007' "$TITLE" 2>/dev/null
+    printf '\033]0;%s\007' "$TITLE" >/dev/tty 2>/dev/null
   elif [ "$TERMINAL" = "cmux" ]; then
     if command -v cmux >/dev/null 2>&1; then
       if ! cmux rename-workspace "$TITLE" 2>/dev/null; then
@@ -60,7 +65,7 @@ _tab_rename_set_title() {
       fi
     else
       printf 'tab-rename: cmux not found in PATH — falling back to OSC escape sequence\n' >&2
-      printf '\033]0;%s\007' "$TITLE"
+      printf '\033]0;%s\007' "$TITLE" >/dev/tty 2>/dev/null
     fi
   fi
 }


### PR DESCRIPTION
## Problem

The iTerm2 and cmux OSC fallback branches in `lib-tab-rename.sh` wrote the OSC 0 escape sequence (`\033]0;TITLE\007`) to stdout. When the SessionStart and Stop hooks run as `"async": true`, Claude's hook-runner subprocess captures stdout and never forwards it to the terminal's TTY device. The iTerm2 tab was therefore never renamed, even though `TERM_PROGRAM=iTerm.app` was correctly detected. The tmux branch was unaffected because it uses an out-of-band socket call.

## Fix

Redirect the OSC writes in `_tab_rename_set_title` to `/dev/tty` with stderr suppressed (`>/dev/tty 2>/dev/null`). Both the iTerm2 branch and the cmux OSC fallback branch are fixed in the shared library, so both hook entry points (`session-start.sh` and `tab-rename-stop.sh`) pick up the change for free. If `/dev/tty` is unavailable (non-interactive shell, CI), the redirect fails silently — the printf returns non-zero but neither caller checks the return value, and neither hook runs with `set -e`. A comment above the OSC writes documents the contract.

## Smoke Tests

After running `install.sh` to sync `~/.claude/hooks/lib-tab-rename.sh`, verify iTerm2 behavior (no tmux):

**Test A — fresh-start path (`session-start.sh`):**
1. Open a new iTerm2 tab in a git repo (e.g. `cd ~/personal/ai-tpk`).
2. Run `claude` (no `--name`, no `--resume`).
3. Observe the iTerm2 tab title within ~1 second of launch. **Expected:** the tab is renamed to the repo basename (e.g. `ai-tpk`). **Before the fix:** the tab title is whatever iTerm2 had assigned (often the working directory or shell name).

**Test B — title-applied path (`tab-rename-stop.sh`):**
1. In the same iTerm2 session, send a single user message (e.g. "summarize this repo in one sentence").
2. Wait for Claude's response to complete (Stop hook fires).
3. Wait up to ~10 seconds for the AI title generation (`claude -p --bare --model haiku`).
4. Observe the iTerm2 tab title. **Expected:** the tab is renamed to a short 2–5-word AI-generated phrase summarizing the exchange. **Before the fix:** the tab title remains the repo basename from Test A (or unchanged from before).

**Test C — title-restore path (`session-start.sh` resume branch):**
1. Note the tab title from Test B.
2. Exit Claude (`Ctrl-C` or `/quit`).
3. Re-launch with `claude --resume <session-id>` (or use `/resume` from the menu) targeting the same session.
4. **Expected:** the tab is renamed to the same AI-generated title from Test B (restored from `~/.claude/session-titles/<session-id>`).

**Test D — graceful no-op when no TTY:**
1. Run `bash ~/.claude/hooks/session-start.sh < /dev/null > /tmp/hook-stdout.log 2>/tmp/hook-stderr.log`.
2. **Expected:** exit code 0, both log files empty (or containing only legitimate diagnostics, not raw `\033]0;...\007` bytes). No OSC bytes in `/tmp/hook-stdout.log`.