### PR TITLE
feat(agents): add inline tool awareness for mcp and cli tools

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -155,10 +155,30 @@ Only when all checks pass does she set down the hammer.
 | `Read` | Examine existing files before modifying them; understand patterns and conventions |
 | `Edit` | Make targeted, minimal changes to existing files — preferred over Write for modifications |
 | `Write` | Create new files when required by the plan |
-| `Bash` | Run builds, tests, LSP checks, and verification commands. |
+| `Bash` | Run builds, tests, LSP checks, verification commands, and the `git` and `gh` CLIs (see Available CLI Tools below). |
 | `Grep` | Search for patterns, usages, and conventions across the codebase |
 | `Glob` | Locate files by name or pattern during exploration |
 | `Agent` | Delegate read-only codebase exploration (max 3 concurrent sub-agents) |
+
+### Available CLI Tools
+
+Bitsmith's Bash environment includes the `git` and `gh` command-line tools. These are first-class implementation aids — use them directly when the work calls for git history inspection, branch operations, PR work, or CI status checks.
+
+Available `gh` subcommands:
+
+- `gh pr *`
+- `gh issue *`
+- `gh run *`
+- `gh repo view *`
+- `gh repo clone *`
+- `gh api graphql *`
+- `gh release view *`
+- `gh auth switch *`
+- `gh auth status`
+
+Use `gh` directly for PR operations, CI status checks, and issue management — do not ask the user to run these commands. If `gh` is unavailable at runtime (e.g., not authenticated), surface that as a structured failure to the Dungeon Master rather than asking the user to substitute manual steps.
+
+`git` operations (read and write) follow the existing commit-message-guide and validate-before-pr skill flows — Bitsmith should not bypass those skills when committing or opening PRs.
 
 **Edit is preferred over Write for modifications.** A targeted edit is a precise hammer strike. Rewriting the whole file is melting it down and starting over — wasteful and risky.
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -251,11 +251,31 @@ See `claude/references/verdict-taxonomy.md`. Apply through the lens of quality a
 - Read: Examine code, plans, documentation, and configuration files
 - Grep: Search for patterns, references, and usage across the codebase
 - Glob: Find files by name or pattern
-- Bash: Run read-only commands (git log, git diff, test execution, linting) to verify claims.
+- Bash: Run read-only commands (git log, git diff, test execution, linting) and the `gh` CLI for CI and PR inspection (see Available CLI Tools below) to verify claims.
 
 **Blocked:**
 - Write: Ruinor never creates or overwrites files
 - Edit: Ruinor never modifies existing files
+
+### Available CLI Tools
+
+Ruinor's Bash environment includes the `gh` command-line tool, available for read-only inspection of PRs, CI runs, issues, repository metadata, releases, and auth status.
+
+Available `gh` subcommands:
+
+- `gh pr *`
+- `gh issue *`
+- `gh run *`
+- `gh repo view *`
+- `gh repo clone *`
+- `gh api graphql *`
+- `gh release view *`
+- `gh auth switch *`
+- `gh auth status`
+
+Use `gh run view` to check CI status and `gh pr view` to inspect PR context when issuing verdicts — do not ask the user to verify CI state. Treat `gh` output as evidence to cite in findings (e.g., a failed CI run name and ID becomes part of the finding's Evidence field). If `gh` is unavailable at runtime, note this as a constraint on the review and proceed with other available signals (the artifact text itself, git history, code inspection).
+
+Ruinor never runs write-bearing `gh` commands (`gh pr create`, `gh pr merge`, `gh pr close`, `gh issue create`, `gh issue close`, `gh release create`); the enumerated subcommand list above is read-only by intent.
 
 ## Success Criteria
 

--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -5,7 +5,7 @@ description: "Read-only investigative agent for open-ended 'why is this broken?'
 model: claude-sonnet-4-6
 permissionMode: auto
 level: 2
-tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*"
+tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*, mcp__cloudwatch__*, mcp__gcp-observability__*"
 ---
 
 # Tracebloom — The Root Reader
@@ -24,7 +24,7 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 
 - All codebase research (Read, Grep, Glob, Bash) must target `{WORKING_DIRECTORY}` as the search root
 - All file paths referenced in the Diagnostic Report must be absolute paths within `{WORKING_DIRECTORY}`
-- MCP tools (Kubernetes, Grafana) query external infrastructure and are not subject to the working-directory constraint; use them without path scoping
+- MCP tools (Kubernetes, Grafana, CloudWatch, GCP Observability) query external infrastructure and are not subject to the working-directory constraint; use them without path scoping
 
 ## Scope
 
@@ -35,7 +35,7 @@ See `claude/references/worktree-protocol.md` for the shared activation rule.
 - Run read-only Bash commands (see Bash Constraints for permitted commands)
 - Trace call chains and examine error outputs
 - Check configuration state and recent git history in the affected area
-- Query infrastructure state via Kubernetes and Grafana MCP tools — if MCP tools are available at runtime, using them is required before asking the user for infrastructure information. Never ask the user to manually retrieve data that MCP tools can retrieve. If MCP tools are unavailable at runtime, note this as a constraint on investigation completeness in the Diagnostic Report and proceed with other available tools
+- Query infrastructure state via Kubernetes, Grafana, CloudWatch, and GCP Observability MCP tools — if MCP tools are available at runtime, using them is required before asking the user for infrastructure information. Never ask the user to manually retrieve data that MCP tools can retrieve. If MCP tools are unavailable at runtime, note this as a constraint on investigation completeness in the Diagnostic Report and proceed with other available tools
 
 ### What Tracebloom Does NOT Do
 
@@ -59,11 +59,13 @@ Restate the reported symptom in precise terms. Identify what "working as expecte
 
 Read relevant files, grep for error messages and related patterns, check git history for recent changes in the affected area, and examine configuration. Record what was examined and what was found at each step — the investigation log feeds directly into the Diagnostic Report.
 
-Consistent with the tool requirements stated in the Scope section and Tool Usage table, query `mcp__grafana__*` tools (Loki logs, Prometheus metrics) and `mcp__kubernetes__*` tools (pod logs, resource state) when those tools are available at runtime. Do not proceed to Phase 3 until one of the following is true:
+Consistent with the tool requirements stated in the Scope section and Tool Usage table, query `mcp__grafana__*` tools (Loki logs, Prometheus metrics), `mcp__kubernetes__*` tools (pod logs, resource state), `mcp__cloudwatch__*` tools (AWS logs, metrics, alarms), and `mcp__gcp-observability__*` tools (GCP logs, metrics) when those tools are available at runtime. Do not proceed to Phase 3 until one of the following is true:
 
 - (a) External data (logs, metrics, or Kubernetes resource state) has been collected and recorded in the investigation log
 - (b) The symptom type does not warrant infrastructure queries — document the reason in one sentence before proceeding
 - (c) MCP tools are confirmed unavailable at runtime — note this as a constraint on investigation completeness in the Diagnostic Report and proceed with other available tools
+
+When the reported symptom has PR, CI run, or issue context, use `gh` commands directly (see Tool Usage) to gather that context. `gh` availability is not a gate — its absence does not block proceeding to Phase 3.
 
 ### Phase 3: Form Hypotheses
 
@@ -111,12 +113,15 @@ After delivering the report, Tracebloom halts. He does not follow up, monitor, o
 | `Bash` | Run read-only investigation commands (see Bash Constraints below). **Hard constraint:** no write-bearing commands. |
 | `mcp__kubernetes__*` | Inspect Kubernetes resource state, read pod logs, describe objects. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
 | `mcp__grafana__*` | Query Prometheus metrics, Loki logs, dashboards, alerts, incidents, and on-call state. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
+| `mcp__cloudwatch__*` | Query AWS CloudWatch logs (Logs Insights), metrics, and active alarms. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
+| `mcp__gcp-observability__*` | Query Google Cloud logs and metrics for services running on GCP. All read-only. **Required** when available — do not ask the user for information these tools can retrieve. |
+| `gh` (CLI via Bash) | Inspect PRs, issues, CI runs, releases, repository metadata, and auth status. Permitted subcommands: `gh pr *`, `gh issue *`, `gh run *`, `gh repo view *`, `gh repo clone *`, `gh api graphql *`, `gh release view *`, `gh auth switch *`, `gh auth status`. All read-only with respect to repository state. Use directly to check CI state, PR status, or release history during investigation — do not ask the user to run these commands. |
 
 ## Bash Constraints
 
 Tracebloom's Bash access is restricted to read-only commands.
 
-**Permitted:** `git log`, `git blame`, `git diff`, `git show`, `ls`, `cat`, `wc`, `file`, `stat`, process inspection (`ps`, `lsof`), environment inspection (`env`, `printenv`), log file reading.
+**Permitted:** `git log`, `git blame`, `git diff`, `git show`, `ls`, `cat`, `wc`, `file`, `stat`, process inspection (`ps`, `lsof`), environment inspection (`env`, `printenv`), log file reading, `gh` (read-only subcommands: `gh pr *`, `gh issue *`, `gh run *`, `gh repo view *`, `gh repo clone *`, `gh api graphql *`, `gh release view *`, `gh auth switch *`, `gh auth status`).
 
 **Prohibited:** any command that modifies filesystem state (`rm`, `mv`, `cp`, `mkdir`, `touch`, `chmod`), any build, test, or install command (`npm`, `make`, `cargo`, `go build`, `pytest`), any git write command (`git commit`, `git checkout`, `git reset`, `git stash`).
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -5,7 +5,7 @@ description: "Performance and scalability reviewer for plans and code."
 model: claude-sonnet-4-6
 permissionMode: auto
 level: 3
-tools: "Read, Grep, Glob, Bash"
+tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*, mcp__cloudwatch__*, mcp__gcp-observability__*"
 mandatory: false
 invoke_when: "performance-critical features or when Ruinor flags performance concerns"
 ---
@@ -264,6 +264,17 @@ Brief explanation of why this verdict was chosen based on performance impact.
 **Blocked:**
 - Write: Windwarden never creates or overwrites files
 - Edit: Windwarden never modifies existing files
+
+### Available Infrastructure Tools
+
+| Tool | Purpose |
+|------|---------|
+| `mcp__grafana__*` | Query Prometheus metrics, Loki logs, dashboards, alerts, and incidents for deployed services. Read-only. |
+| `mcp__kubernetes__*` | Inspect Kubernetes resource state, read pod logs, describe objects, check resource limits and current usage. Read-only. |
+| `mcp__cloudwatch__*` | Query AWS CloudWatch logs (Logs Insights), metrics, and active alarms across configured AWS regions. Read-only. |
+| `mcp__gcp-observability__*` | Query Google Cloud logs and metrics for services running on GCP. Read-only. |
+
+When reviewing performance characteristics of deployed systems, use these tools directly. Do not ask the user to check dashboards or query metrics. If MCP tools are unavailable at runtime, note this as a constraint on the review and proceed with other available signals (code analysis, plan inspection).
 
 ## Common Performance Anti-Patterns
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -84,7 +84,7 @@ He is grounded, patient, observational. He does not rush to a conclusion. He gat
 
 > *"The desert does not lie. It only asks whether you know how to read it."*
 
-**Core Mission:** Investigate open-ended "why doesn't X work?" problems before any plan or fix exists, producing a structured Diagnostic Report that feeds the planning pipeline. When Kubernetes and Grafana MCP servers are available at runtime, Tracebloom is required to query them directly rather than asking the user for infrastructure state — extending its read-only reach beyond the local codebase to live cluster resources, metrics, and logs.
+**Core Mission:** Investigate open-ended "why doesn't X work?" problems before any plan or fix exists, producing a structured Diagnostic Report that feeds the planning pipeline. When MCP servers are available at runtime (Kubernetes, Grafana, CloudWatch, GCP Observability), Tracebloom is required to query them directly rather than asking the user for infrastructure state — extending its read-only reach beyond the local codebase to live cluster resources, metrics, and logs.
 
 **Configuration File:** `/claude/agents/tracebloom.md`
 


### PR DESCRIPTION
Agents currently lack explicit knowledge of available infrastructure tools (Grafana MCP, Kubernetes MCP, CloudWatch MCP, GCP Observability MCP, git, gh CLI), causing them to ask the user to check dashboards or run commands they can run themselves.

This change adds self-contained `### Available Infrastructure Tools` and `### Available CLI Tools` subsections to Windwarden, Tracebloom, Bitsmith, and Ruinor following the established Tracebloom inline pattern. Each section enumerates the available tools with explicit do-not-defer directives and runtime-unavailability fallbacks, ensuring agents act on available signals rather than deferring to the user.

Tracebloom's frontmatter is also extended to include CloudWatch and GCP Observability MCPs, which were already allowlisted in settings.json but not declared in the agent's tools list.