### PR TITLE
feat(hooks): reliable per-session token tracking with optional SQLite index

### DIFF
--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -12,7 +12,7 @@ memory: user
 
 ## Core Mission
 
-Study Talekeeper session chronicles in `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to identify recurring failures, inefficiencies, and coordination breakdowns in the agent team. Translate raw observations into structured, minimal, testable configuration recommendations. Write those recommendations to `~/.ai-tpk/lessons/` as versioned JSONL records. Before writing, run `mkdir -p ~/.ai-tpk/lessons` defensively to ensure the directory exists.
+Study Talekeeper session chronicles in `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to identify recurring failures, inefficiencies, and coordination breakdowns in the agent team. When globbing chronicle files, **filter out any path whose basename matches `talekeeper-raw-[^/]*\.jsonl`** — these are per-session staging files, not enriched chronicles. Translate raw observations into structured, minimal, testable configuration recommendations. Write those recommendations to `~/.ai-tpk/lessons/` as versioned JSONL records. Before writing, run `mkdir -p ~/.ai-tpk/lessons` defensively to ensure the directory exists.
 
 Everwise does NOT perform tasks. She does NOT rewrite production configs. She does NOT produce vague advice. Every recommendation she makes is grounded in observed evidence, scoped to the smallest change that could help, and paired with a concrete evaluation plan.
 
@@ -37,7 +37,7 @@ For each session chronicle analysis, follow this sequence:
 
 This step runs once at the start of every Everwise invocation, before loading chronicles.
 
-1. Use `Glob` to find any existing Talekeeper chronicle file matching `~/.ai-tpk/logs/*/talekeeper-*.jsonl`. Read one of them with `Read`.
+1. Use `Glob` to find any existing Talekeeper chronicle file matching `~/.ai-tpk/logs/*/talekeeper-*.jsonl`. **Filter out any result whose basename matches `talekeeper-raw-[^/]*\.jsonl`** before selecting a file to read. Read one of the remaining files with `Read`.
 2. Scan the entries for any that contain an `agent_transcript_path` field (or an equivalent field whose value contains a `~/.claude/projects/`, `/.claude/projects/`, `~/.cursor/projects/`, or `/.cursor/projects/` path).
 3. From that path, extract `transcript_base_path` by stripping the trailing `/{session_id}/subagents/agent-{id}.jsonl` portion. The encoded project directory is the segment immediately after `projects/` and before the first `/{session_id}/` segment.
    - Example: from `/Users/alice/.claude/projects/-Users-alice-work-my-project/abc123/subagents/agent-xyz.jsonl`, extract `/Users/alice/.claude/projects/-Users-alice-work-my-project`
@@ -52,7 +52,7 @@ Note: this path is machine-specific and discovered dynamically — it must never
 
 ### Step 1: Load Chronicles
 
-Read all available `~/.ai-tpk/logs/*/talekeeper-*.jsonl` files. Parse each entry as a JSON object. Ignore malformed lines silently. Build a timeline of agent activations, verdicts, and handoffs per session.
+Read all available `~/.ai-tpk/logs/*/talekeeper-*.jsonl` files. **Before reading, filter out any path whose basename matches `talekeeper-raw-[^/]*\.jsonl`** — these are staging files, not chronicles, and must not be parsed as session data. Parse each remaining entry as a JSON object. Ignore malformed lines silently. Build a timeline of agent activations, verdicts, and handoffs per session.
 
 ### Step 2: Identify Problems
 
@@ -121,7 +121,7 @@ Use `Read` to load the `.meta.json` file. Confirm the `agentType` matches the `a
 > **Secret filtering:** The `observation` field in `transcript_evidence` must describe agent behavior abstractly, never reproducing literal values from tool results. Write "agent read .env file and extracted DATABASE_URL" — never include the actual connection string. If a transcript line contains what appears to be a credential, API key, token, connection string, or secret, record that the agent handled sensitive material but do not reproduce the value. When in doubt, describe the action, not the content.
 >
 > **File-read allowlist:** During drill-down, Everwise is permitted to read only files matching these path patterns:
-> - `~/.ai-tpk/logs/*/talekeeper-*.jsonl` (session chronicles)
+> - `~/.ai-tpk/logs/*/talekeeper-*.jsonl` (session chronicles — exclude basenames matching `talekeeper-raw-[^/]*\.jsonl`)
 > - `~/.ai-tpk/lessons/*.jsonl` (existing lessons)
 > - `claude/agents/*.md` (agent configurations, read-only)
 > - `~/.claude/projects/*/*/subagents/agent-*.jsonl` (subagent transcripts)
@@ -290,7 +290,7 @@ Everwise is invoked manually by the user when they want a meta-analysis of recen
 |------|--------------|
 | `Read` | Reading session chronicles in `~/.ai-tpk/logs/`, agent configs in `claude/agents/`, existing lessons in `~/.ai-tpk/lessons/`; reading subagent transcripts in `~/.claude/projects/` and their companion `.meta.json` files (drill-down only, with offset/limit) |
 | `Grep` | Searching chronicle entries for patterns, agent names, verdict strings |
-| `Glob` | Finding chronicle files matching `~/.ai-tpk/logs/*/talekeeper-*.jsonl`; discovering the transcript base path in `~/.claude/projects/` |
+| `Glob` | Finding chronicle files matching `~/.ai-tpk/logs/*/talekeeper-*.jsonl`; results must be filtered to exclude paths matching `talekeeper-raw-[^/]*\.jsonl` (staging files) before analysis; discovering the transcript base path in `~/.claude/projects/` |
 | `Write` | Appending lessons to `~/.ai-tpk/lessons/candidates.jsonl`, `~/.ai-tpk/lessons/recurring.jsonl`, `~/.ai-tpk/lessons/validated.jsonl` only |
 
 Write is permitted exclusively to the `~/.ai-tpk/lessons/` directory. Everwise has no mechanism to modify agent configs, plans, logs, or any other system file.

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -33,9 +33,10 @@ Only invoke Talekeeper after a session has fully ended and the Stop hook has had
 Talekeeper does not have a Bash tool and cannot run shell commands. To discover which repositories have chronicle files, use this procedure:
 
 1. Use `Glob` with the pattern `~/.ai-tpk/logs/*/talekeeper-*.jsonl`.
-2. From the returned paths, extract the directory name immediately after `logs/` — this is the REPO_SLUG for each file (e.g., from `~/.ai-tpk/logs/my-project/talekeeper-abc123.jsonl`, the REPO_SLUG is `my-project`).
-3. Group discovered chronicle files by REPO_SLUG.
-4. If only one REPO_SLUG exists, use it. If multiple REPO_SLUGs are found, process all of them and organize narrative output per repo. Alternatively, if the user specifies a project name, filter to that REPO_SLUG only.
+2. **Filter staging files:** From the glob results, discard any path whose basename matches the pattern `talekeeper-raw-[^/]*\.jsonl` — these are per-session staging files, not chronicles. Processing them would produce a bogus session ID like `raw-abc123` when the `talekeeper-` prefix is stripped.
+3. From the remaining paths, extract the directory name immediately after `logs/` — this is the REPO_SLUG for each file (e.g., from `~/.ai-tpk/logs/my-project/talekeeper-abc123.jsonl`, the REPO_SLUG is `my-project`).
+4. Group discovered chronicle files by REPO_SLUG.
+5. If only one REPO_SLUG exists, use it. If multiple REPO_SLUGs are found, process all of them and organize narrative output per repo. Alternatively, if the user specifies a project name, filter to that REPO_SLUG only.
 
 All subsequent references to log paths use `~/.ai-tpk/logs/{REPO_SLUG}/` as the base directory, where `{REPO_SLUG}` is the value discovered above.
 
@@ -58,6 +59,8 @@ Skip any JSONL entry where the `agent_type` field is `"talekeeper"`. Do not incl
 
 Use `Glob` with the pattern `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to find all enriched session chronicle files. Each file follows the naming convention `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-{session_id}.jsonl`.
 
+**Filter staging files immediately after globbing:** Discard any returned path whose basename matches the pattern `talekeeper-raw-[^/]*\.jsonl` — these are per-session staging files written by `talekeeper-capture.sh`, not enriched chronicles. They must not be parsed as chronicle entries.
+
 ### Tracking File
 
 Talekeeper tracks which sessions have been narrated in `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrated-sessions.json`.
@@ -76,7 +79,8 @@ Each line records one narrated session:
 
 ### Filtering Logic
 
-1. Glob `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to get the list of all chronicle files.
+0. **Filter staging files first (defence in depth):** Before any other filtering, discard any glob result whose basename matches `talekeeper-raw-[^/]*\.jsonl`. After stripping the `talekeeper-` prefix, also reject any result that starts with `raw-` — this catches any staging file that may have slipped through the basename filter.
+1. Glob `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to get the list of all chronicle files. Apply the staging-file filter from step 0 immediately.
 2. Read `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrated-sessions.json` to get the set of already-narrated session IDs (full UUIDs).
 3. Extract the session ID from each chronicle filename by stripping the `talekeeper-` prefix and the `.jsonl` suffix.
 4. Compute the difference: chronicle files whose session ID is not in the narrated set.
@@ -169,7 +173,7 @@ graph LR
 
 Follow these steps in order. Do not skip steps. Do not proceed to writing before completing discovery and filtering.
 
-1. Use `Glob` with pattern `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to discover all chronicle files across all repositories. Extract REPO_SLUG from each path (the directory name immediately after `logs/`). Group files by REPO_SLUG.
+1. Use `Glob` with pattern `~/.ai-tpk/logs/*/talekeeper-*.jsonl` to discover all chronicle files across all repositories. **Immediately discard any path whose basename matches `talekeeper-raw-[^/]*\.jsonl`** — these are staging files, not chronicles. Extract REPO_SLUG from each remaining path (the directory name immediately after `logs/`). Group files by REPO_SLUG.
 2. Use `Read` to load `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrated-sessions.json`. If the file does not exist, treat the narrated set as empty.
 3. Parse the tracking file contents natively (no Bash). Each non-empty line is a JSON object; extract the `session_id` field from each line to build the set of already-narrated IDs.
 4. For each chronicle file, extract the session ID from the filename. Exclude any session ID already in the narrated set.
@@ -205,7 +209,7 @@ Unlike the old hook-based Talekeeper, this agent is user-facing. Errors should b
 
 | Tool | Purpose |
 |------|---------|
-| `Glob` | Discover all `~/.ai-tpk/logs/*/talekeeper-*.jsonl` chronicle files |
+| `Glob` | Discover all `~/.ai-tpk/logs/*/talekeeper-*.jsonl` chronicle files; filter results to exclude staging files matching `talekeeper-raw-[^/]*\.jsonl` before processing |
 | `Read` | Load chronicle files, tracking file, and narrative file for native parsing |
 | `Write` | Append to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrative.md` and `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrated-sessions.json` |
 

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -172,7 +172,7 @@ Populate the fields as follows:
 - **Token usage:** Derive the current repo slug as in Step 6a. Then run (single Bash call):
 
   ```
-  ls -t ~/.ai-tpk/logs/<repo-slug>/talekeeper-*.jsonl 2>/dev/null | head -n1 | xargs -I{} jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' {}
+  bash ~/.claude/scripts/token-summary.sh "<repo-slug>" "${SESSION_ID:-}"
   ```
 
-  The pipeline (a) lists chronicle files for the repo by modification time, (b) selects the most recent, (c) feeds it to `jq -rs` which slurps all newline-delimited JSON records into a single array, filters to records that have an `input_tokens` key (token record fields are flat top-level keys — not nested under a `usage` object), reduces the four token fields, and formats the totals. If no chronicle file is found or `jq` exits non-zero, the pipeline produces empty output — report "unavailable".
+  The script reads from a per-session cache when `SESSION_ID` is set, falls back to the shared cache, and finally falls back to computing totals from the most-recent chronicle file. It always exits 0 and prints "unavailable" when no data can be found — report that value as-is.

--- a/claude/hooks/talekeeper-capture.sh
+++ b/claude/hooks/talekeeper-capture.sh
@@ -5,9 +5,6 @@
 
 REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
-LOG_FILE="$LOG_DIR/talekeeper-raw.jsonl"
-
-mkdir -p "$LOG_DIR"
 
 # Read stdin (hook event JSON) with a timeout to avoid hanging
 # Use bash built-in read with -t for macOS compatibility (not `timeout` command)
@@ -18,6 +15,18 @@ read -r -t 2 STDIN_DATA 2>/dev/null || true
 if [ -z "$STDIN_DATA" ]; then
   STDIN_DATA='{}'
 fi
+
+# Extract SESSION_ID from stdin; fall back to a unique unknown-session name
+if command -v jq &>/dev/null; then
+  SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+fi
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="unknown-$(date -u +%s)-$$"
+fi
+
+LOG_FILE="$LOG_DIR/talekeeper-raw-${SESSION_ID}.jsonl"
+
+mkdir -p "$LOG_DIR"
 
 # Skip hook-agent self-capture events (Stop hook agents, not real subagents)
 if command -v jq &>/dev/null; then

--- a/claude/hooks/talekeeper-enrich.sh
+++ b/claude/hooks/talekeeper-enrich.sh
@@ -2,19 +2,39 @@
 # Talekeeper enrichment: process raw SubagentStop events into session chronicles
 # Runs as an async Stop hook command — has full filesystem access (unlike agent hooks)
 # Never blocks the session; exits 0 in all cases
+# Stop event schema verified: session_id present in stdin JSON (see tab-rename-stop.sh lines 16-19 for evidence)
 
 REPO_SLUG="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
 LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
 mkdir -p "$LOG_DIR"
-RAW_LOG="$LOG_DIR/talekeeper-raw.jsonl"
 
-# Exit immediately if raw log is missing or empty
-if [ ! -s "$RAW_LOG" ]; then
-  exit 0
+# Read Stop event payload from stdin (2-second timeout, same pattern as tab-rename-stop.sh)
+STDIN_DATA=""
+read -r -t 2 STDIN_DATA 2>/dev/null || true
+if [ -z "$STDIN_DATA" ]; then
+  STDIN_DATA='{}'
 fi
 
 # Require jq — without it we cannot safely process JSON
 if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+# Extract SESSION_ID from Stop event stdin.
+# Constitution Principle 1: if SESSION_ID is absent, exit silently — do NOT scan or
+# touch any other session's talekeeper-raw-*.jsonl file.
+SESSION_ID=$(echo "$STDIN_DATA" | jq -r '.session_id // ""' 2>/dev/null)
+if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
+  TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+  printf 'talekeeper-enrich: missing session_id in Stop event stdin at %s\n' "$TIMESTAMP" \
+    >> "$LOG_DIR/talekeeper-enrich-error-${TIMESTAMP}.log" 2>/dev/null || true
+  exit 0
+fi
+
+RAW_LOG="$LOG_DIR/talekeeper-raw-${SESSION_ID}.jsonl"
+
+# Exit immediately if this session's raw log is missing or empty
+if [ ! -s "$RAW_LOG" ]; then
   exit 0
 fi
 
@@ -27,18 +47,16 @@ VALID_ENTRIES=$(jq -c 'select(
 )' "$RAW_LOG" 2>/dev/null)
 
 if [ -z "$VALID_ENTRIES" ]; then
-  # No valid entries — still clear the raw log
-  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' > "$RAW_LOG"
+  # No valid entries — remove this session's staging file (only filtered noise)
+  rm -f "$RAW_LOG"
   exit 0
 fi
 
-# Extract session_id from first valid entry; fallback to timestamp
-SESSION_ID=$(echo "$VALID_ENTRIES" | head -1 | jq -r '.session_id // ""' 2>/dev/null)
-if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
-  SESSION_ID=$(date -u +"%Y-%m-%d-%H%M%S")
-fi
-
 OUTPUT_FILE="$LOG_DIR/talekeeper-${SESSION_ID}.jsonl"
+# Single-writer assumption: each session has its own chronicle and staging file.
+# A concurrent write from this session's hook is not possible (Stop fires once per session).
+# Therefore, cat >> is safe here — no other writer races on this chronicle file.
+TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
 
 # Reviewer agent types that may contain verdicts
 REVIEWER_TYPES="ruinor|knotcutter|riskmancer|windwarden"
@@ -113,19 +131,31 @@ echo "$VALID_ENTRIES" | while IFS= read -r entry; do
     --argjson cache_read_input_tokens "$cache_read_input_tokens" \
     '{timestamp: $ts, event_type: $event_type, agent_type: $agent_type, agent_id: $agent_id, session_id: $session_id, summary: $summary, verdict: $verdict, agent_transcript_path: $agent_transcript_path, input_tokens: $input_tokens, output_tokens: $output_tokens, cache_creation_input_tokens: $cache_creation_input_tokens, cache_read_input_tokens: $cache_read_input_tokens}'
 
-done >> "$OUTPUT_FILE" 2>/dev/null
+done >> "$TMP_OUTPUT" 2>/dev/null
 
-# Only clear the raw log if output was actually written
-if [ -s "$OUTPUT_FILE" ]; then
-  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' > "$RAW_LOG"
+# Append temp output to chronicle if non-empty, then clean up
+if [ -s "$TMP_OUTPUT" ]; then
+  # Single-writer assumption: each session has its own chronicle and staging file.
+  # A concurrent write from this session's hook is not possible (Stop fires once per session).
+  # Therefore, cat >> is safe here — no other writer races on this chronicle file.
+  cat "$TMP_OUTPUT" >> "$OUTPUT_FILE" 2>/dev/null
+  rm -f "$TMP_OUTPUT"
+  # Remove this session's staging file now that enrichment succeeded
+  rm -f "$RAW_LOG"
+else
+  rm -f "$TMP_OUTPUT"
+  # No entries written — still remove the staging file (only filtered noise)
+  rm -f "$RAW_LOG"
 fi
 
 # Pre-compute token summary for fast-path reads by token-summary.sh
 # Reads from the just-written chronicle, not the (now-cleared) raw log.
+# Writes to both the per-session cache and the shared last-writer-wins cache.
 # Any failure here is silently swallowed — hook must always exit 0.
 if [ -s "$OUTPUT_FILE" ] && command -v jq &>/dev/null; then
   TOKEN_SUMMARY=$(jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' "$OUTPUT_FILE" 2>/dev/null || true)
   if [ -n "$TOKEN_SUMMARY" ]; then
+    printf '%s\n' "$TOKEN_SUMMARY" > "$LOG_DIR/latest-token-summary-${SESSION_ID}.txt" 2>/dev/null || true
     printf '%s\n' "$TOKEN_SUMMARY" > "$LOG_DIR/latest-token-summary.txt" 2>/dev/null || true
   fi
 fi

--- a/claude/hooks/test-talekeeper-enrich.sh
+++ b/claude/hooks/test-talekeeper-enrich.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# test-talekeeper-enrich.sh — Test suite for talekeeper-enrich.sh per-session behavior
+# Run from the repo root: bash claude/hooks/test-talekeeper-enrich.sh
+# Exits 0 on success, non-zero on failure.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENRICH_SCRIPT="$SCRIPT_DIR/talekeeper-enrich.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# --- Setup ---
+TMPDIR_BASE="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_BASE"; }
+trap cleanup EXIT
+
+REPO_SLUG="test-repo"
+
+# Build a minimal raw staging entry (valid SubagentStop payload written by capture hook)
+make_entry() {
+  local session_id="$1"
+  local agent_id="$2"
+  local agent_type="${3:-bitsmith}"
+  local ts
+  ts="2026-04-22T00:00:00Z"
+  printf '{"session_id":"%s","agent_id":"%s","agent_type":"%s","hook_event_name":"SubagentStop","_captured_at":"%s","last_assistant_message":"done"}\n' \
+    "$session_id" "$agent_id" "$agent_type" "$ts"
+}
+
+# Run the enrich hook with given stdin, using a custom HOME so log paths are isolated.
+# The hook uses git rev-parse for REPO_SLUG, so we must cd into a fake git repo whose
+# basename matches REPO_SLUG. Stdin is passed via a temp file to avoid read -r -t 2 timeout issues.
+run_enrich() {
+  local stdin_data="$1"
+  local fake_home="$2"
+  local repo_slug="${3:-$REPO_SLUG}"
+
+  # Create a stub git repo whose basename matches repo_slug
+  local work_dir="$TMPDIR_BASE/repos/$repo_slug"
+  mkdir -p "$work_dir"
+  if [ ! -d "$work_dir/.git" ]; then
+    git -C "$work_dir" init -q
+  fi
+
+  # Write stdin to a temp file
+  local stdin_file="$TMPDIR_BASE/stdin-$$.txt"
+  printf '%s' "$stdin_data" > "$stdin_file"
+
+  # Run the hook from within the fake git repo
+  (cd "$work_dir" && HOME="$fake_home" bash "$ENRICH_SCRIPT" < "$stdin_file") 2>/dev/null || true
+  rm -f "$stdin_file"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Missing session_id in stdin → exit 0, no files touched
+# ---------------------------------------------------------------------------
+T1_HOME="$TMPDIR_BASE/t1"
+T1_REPO="$T1_HOME/.ai-tpk/logs/$REPO_SLUG"
+mkdir -p "$T1_REPO"
+# Place a staging file that should NOT be touched
+make_entry "other-session" "other-agent" > "$T1_REPO/talekeeper-raw-other-session.jsonl"
+OTHER_MTIME_BEFORE="$(stat -f '%m' "$T1_REPO/talekeeper-raw-other-session.jsonl" 2>/dev/null || stat -c '%Y' "$T1_REPO/talekeeper-raw-other-session.jsonl" 2>/dev/null)"
+
+run_enrich '{}' "$T1_HOME"
+
+OTHER_MTIME_AFTER="$(stat -f '%m' "$T1_REPO/talekeeper-raw-other-session.jsonl" 2>/dev/null || stat -c '%Y' "$T1_REPO/talekeeper-raw-other-session.jsonl" 2>/dev/null)"
+if [ "$OTHER_MTIME_BEFORE" = "$OTHER_MTIME_AFTER" ]; then
+  pass "Test 1a: Missing session_id does not touch other session staging file"
+else
+  fail "Test 1a: Missing session_id modified other session staging file"
+fi
+
+# No chronicle should be created
+if ls "$T1_REPO"/talekeeper-*.jsonl 2>/dev/null | grep -qv 'talekeeper-raw-'; then
+  fail "Test 1b: Missing session_id created unexpected chronicle file"
+else
+  pass "Test 1b: Missing session_id created no chronicle file"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Valid session_id → reads own staging file, writes chronicle, removes staging file
+# ---------------------------------------------------------------------------
+T2_HOME="$TMPDIR_BASE/t2"
+T2_REPO="$T2_HOME/.ai-tpk/logs/$REPO_SLUG"
+mkdir -p "$T2_REPO"
+SESSION_A="aaaa-1111"
+make_entry "$SESSION_A" "agent-x" > "$T2_REPO/talekeeper-raw-${SESSION_A}.jsonl"
+
+run_enrich "{\"session_id\":\"${SESSION_A}\"}" "$T2_HOME"
+
+CHRONICLE="$T2_REPO/talekeeper-${SESSION_A}.jsonl"
+if [ -f "$CHRONICLE" ]; then
+  pass "Test 2a: Chronicle file created for session A"
+else
+  fail "Test 2a: Chronicle file NOT created for session A"
+fi
+
+if [ ! -f "$T2_REPO/talekeeper-raw-${SESSION_A}.jsonl" ]; then
+  pass "Test 2b: Staging file removed after successful enrich"
+else
+  fail "Test 2b: Staging file still present after enrich"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Two concurrent sessions produce isolated chronicles
+# ---------------------------------------------------------------------------
+T3_HOME="$TMPDIR_BASE/t3"
+T3_REPO="$T3_HOME/.ai-tpk/logs/$REPO_SLUG"
+mkdir -p "$T3_REPO"
+SESSION_B="bbbb-2222"
+SESSION_C="cccc-3333"
+make_entry "$SESSION_B" "agent-y" > "$T3_REPO/talekeeper-raw-${SESSION_B}.jsonl"
+make_entry "$SESSION_C" "agent-z" > "$T3_REPO/talekeeper-raw-${SESSION_C}.jsonl"
+
+run_enrich "{\"session_id\":\"${SESSION_B}\"}" "$T3_HOME"
+
+CHRONICLE_B="$T3_REPO/talekeeper-${SESSION_B}.jsonl"
+CHRONICLE_C="$T3_REPO/talekeeper-${SESSION_C}.jsonl"
+STAGING_C="$T3_REPO/talekeeper-raw-${SESSION_C}.jsonl"
+
+if [ -f "$CHRONICLE_B" ]; then
+  pass "Test 3a: Session B chronicle created"
+else
+  fail "Test 3a: Session B chronicle NOT created"
+fi
+
+if [ ! -f "$CHRONICLE_C" ]; then
+  pass "Test 3b: Session C chronicle NOT touched (isolation)"
+else
+  fail "Test 3b: Session C chronicle was created (isolation violated)"
+fi
+
+if [ -f "$STAGING_C" ]; then
+  pass "Test 3c: Session C staging file untouched (isolation)"
+else
+  fail "Test 3c: Session C staging file was removed (isolation violated)"
+fi
+
+# Verify session B's chronicle contains only session B rows
+if [ -f "$CHRONICLE_B" ]; then
+  SESSION_IDS_IN_B=$(jq -r '.session_id' "$CHRONICLE_B" 2>/dev/null | sort -u)
+  if [ "$SESSION_IDS_IN_B" = "$SESSION_B" ]; then
+    pass "Test 3d: Session B chronicle contains only session B rows"
+  else
+    fail "Test 3d: Session B chronicle contains unexpected session IDs: $SESSION_IDS_IN_B"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Per-session token summary cache written
+# ---------------------------------------------------------------------------
+T4_HOME="$TMPDIR_BASE/t4"
+T4_REPO="$T4_HOME/.ai-tpk/logs/$REPO_SLUG"
+mkdir -p "$T4_REPO"
+SESSION_D="dddd-4444"
+make_entry "$SESSION_D" "agent-w" > "$T4_REPO/talekeeper-raw-${SESSION_D}.jsonl"
+
+run_enrich "{\"session_id\":\"${SESSION_D}\"}" "$T4_HOME"
+
+PER_SESSION_CACHE="$T4_REPO/latest-token-summary-${SESSION_D}.txt"
+SHARED_CACHE="$T4_REPO/latest-token-summary.txt"
+
+if [ -f "$PER_SESSION_CACHE" ]; then
+  pass "Test 4a: Per-session token summary cache written"
+else
+  fail "Test 4a: Per-session token summary cache NOT written"
+fi
+
+if [ -f "$SHARED_CACHE" ]; then
+  pass "Test 4b: Shared token summary cache written (backward compat)"
+else
+  fail "Test 4b: Shared token summary cache NOT written"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Staging file missing for this session → exit 0 (no chronicle created)
+# ---------------------------------------------------------------------------
+T5_HOME="$TMPDIR_BASE/t5"
+T5_REPO="$T5_HOME/.ai-tpk/logs/$REPO_SLUG"
+mkdir -p "$T5_REPO"
+SESSION_E="eeee-5555"
+# Do NOT create a staging file for session E
+
+run_enrich "{\"session_id\":\"${SESSION_E}\"}" "$T5_HOME"
+
+if ! ls "$T5_REPO"/talekeeper-*.jsonl 2>/dev/null | grep -qv 'talekeeper-raw-'; then
+  pass "Test 5: Missing staging file for session → no chronicle created, exit 0"
+else
+  fail "Test 5: Missing staging file for session created unexpected chronicle"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/claude/scripts/talekeeper-index.sh
+++ b/claude/scripts/talekeeper-index.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# talekeeper-index.sh — optional SQLite indexer for Talekeeper session chronicles
+# Usage: talekeeper-index.sh [--quiet|--verbose|--help]
+#
+# Reads all talekeeper-*.jsonl chronicle files (excluding staging files) from
+# TALEKEEPER_LOGS_ROOT (default: ~/.ai-tpk/logs) and upserts their rows into
+# a SQLite database at TALEKEEPER_DB (default: ~/.ai-tpk/tokens.db).
+#
+# Exits 0 silently when sqlite3 or jq is not in PATH — the indexer is a no-op
+# when its optional dependencies are absent.
+#
+# Exits 1 with a stderr message if sqlite3 returns non-zero (e.g., SQLITE_BUSY
+# after the busy_timeout has elapsed). This is intentional: the indexer is
+# user-invoked, so surfacing the failure is the correct behaviour. The script's
+# set -euo pipefail already enforces this; do not soften it.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Dependency guards — silent no-op when optional tools are absent.
+# These must be the first two substantive lines so the script exits 0
+# before touching any paths or printing anything.
+# ---------------------------------------------------------------------------
+command -v sqlite3 >/dev/null 2>&1 || { exit 0; }
+command -v jq >/dev/null 2>&1 || { exit 0; }
+
+# ---------------------------------------------------------------------------
+# Environment variable overrides — first-class variables, not buried in tests.
+# Both exist so test fixtures can isolate the indexer from production data.
+# ---------------------------------------------------------------------------
+DB_PATH="${TALEKEEPER_DB:-$HOME/.ai-tpk/tokens.db}"
+LOGS_ROOT="${TALEKEEPER_LOGS_ROOT:-$HOME/.ai-tpk/logs}"
+mkdir -p "$(dirname "$DB_PATH")" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+VERBOSE=0
+
+show_help() {
+  printf '%s\n' \
+    'Usage: talekeeper-index.sh [--quiet] [--verbose] [--help]' \
+    '' \
+    'Index Talekeeper session chronicles into a SQLite token-events database.' \
+    '' \
+    'Options:' \
+    '  --quiet    (default) Print only a single summary line on completion.' \
+    '  --verbose  Print one line per file processed.' \
+    '  --help     Show this help and exit.' \
+    '' \
+    'Environment:' \
+    '  TALEKEEPER_DB        Override the database path (default: ~/.ai-tpk/tokens.db)' \
+    '  TALEKEEPER_LOGS_ROOT Override the logs root path (default: ~/.ai-tpk/logs)' \
+    '' \
+    'Behaviour:' \
+    '  - Exits 0 silently when sqlite3 or jq is not in PATH.' \
+    '  - Reads chronicle files under TALEKEEPER_LOGS_ROOT/*/*, excluding staging' \
+    '    files matching talekeeper-raw-*.jsonl.' \
+    '  - Uses each row'\''s own session_id field as the natural key (not the' \
+    '    filename), so legacy mixed-session chronicle files index correctly.' \
+    '  - INSERT OR REPLACE keyed on (session_id, agent_id, timestamp) for idempotency.' \
+    '  - Sets PRAGMA busy_timeout = 5000 so concurrent indexer runs serialise' \
+    '    rather than fail with SQLITE_BUSY.' \
+    '  - Exits 1 with a stderr message if sqlite3 exits non-zero.'
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --verbose) VERBOSE=1 ;;
+    --quiet)   VERBOSE=0 ;;
+    --help|-h) show_help; exit 0 ;;
+    *)
+      printf 'talekeeper-index.sh: unknown flag: %s\n' "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Orphaned temp file cleanup — runs before indexing.
+# This cleanup was deliberately moved out of the enrich hook (to avoid running
+# on every Stop event). On a system where the indexer is never run, orphaned
+# files accumulate harmlessly until the next invocation.
+# ---------------------------------------------------------------------------
+find "$LOGS_ROOT" -mindepth 2 -maxdepth 2 -type f -name 'talekeeper-*.jsonl.tmp.*' -mmin +60 -delete 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Early exit when the logs root does not exist — nothing to index.
+# ---------------------------------------------------------------------------
+if [[ ! -d "$LOGS_ROOT" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Schema initialisation — idempotent via IF NOT EXISTS.
+#
+# SCHEMA-ANCHOR: talekeeper.token_events.v1
+# If you change this schema, update src/installer/token-db.ts (same anchor).
+#
+# PRAGMA busy_timeout = 5000 ensures concurrent indexer invocations serialise
+# rather than fail immediately with SQLITE_BUSY.
+# ---------------------------------------------------------------------------
+sqlite3 "$DB_PATH" <<'SCHEMA_SQL' >/dev/null
+PRAGMA busy_timeout = 5000;
+CREATE TABLE IF NOT EXISTS token_events (
+  session_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  repo_slug TEXT NOT NULL,
+  agent_type TEXT,
+  event_type TEXT,
+  verdict TEXT,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+  indexed_at TEXT NOT NULL,
+  PRIMARY KEY (session_id, agent_id, timestamp)
+);
+CREATE INDEX IF NOT EXISTS idx_token_events_repo_session
+  ON token_events (repo_slug, session_id);
+SCHEMA_SQL
+
+# ---------------------------------------------------------------------------
+# Index chronicle files
+# ---------------------------------------------------------------------------
+TOTAL_ROWS=0
+TOTAL_FILES=0
+
+# Temp files — cleaned up on exit.
+TSV_TMP="$(mktemp)"
+SQL_TMP="$(mktemp)"
+trap 'rm -f "$TSV_TMP" "$SQL_TMP"' EXIT
+
+while IFS= read -r -d '' file; do
+  repo_slug="$(basename "$(dirname "$file")")"
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # Stream each row through jq, produce TSV lines for sqlite3 import.
+  # Uses each row's own session_id (not the filename) as the natural key —
+  # this is what makes legacy mixed-session chronicle files index correctly.
+  if ! jq -r \
+    --arg repo "$repo_slug" \
+    --arg now "$now" \
+    'select(has("session_id") and has("agent_id") and has("timestamp"))
+    | [
+        .session_id,
+        .agent_id,
+        .timestamp,
+        $repo,
+        (.agent_type // ""),
+        (.event_type // ""),
+        (if .verdict == null then "" else .verdict end),
+        (.input_tokens // 0),
+        (.output_tokens // 0),
+        (.cache_creation_input_tokens // 0),
+        (.cache_read_input_tokens // 0),
+        $now
+      ]
+    | @tsv' \
+    "$file" >"$TSV_TMP" 2>/dev/null; then
+    [[ "$VERBOSE" -eq 1 ]] && printf 'warn: jq failed on %s, skipping\n' "$file" >&2
+    continue
+  fi
+
+  if [[ ! -s "$TSV_TMP" ]]; then
+    continue
+  fi
+
+  row_count="$(wc -l <"$TSV_TMP" | tr -d ' ')"
+
+  # Build a sqlite3 script file that uses dot-commands for TSV import.
+  # Dot-commands (.mode, .import) only work via a script file or stdin —
+  # not as a -cmd argument. We write a script to a temp file and pass it
+  # to sqlite3 via stdin redirection.
+  #
+  # Wrapped in BEGIN IMMEDIATE ... COMMIT for transactional consistency.
+  # PRAGMA busy_timeout is re-asserted so it applies to this transaction.
+  printf '%s\n' \
+    "PRAGMA busy_timeout = 5000;" \
+    "BEGIN IMMEDIATE;" \
+    "CREATE TEMP TABLE IF NOT EXISTS _stage (session_id TEXT, agent_id TEXT, timestamp TEXT, repo_slug TEXT, agent_type TEXT, event_type TEXT, verdict TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_creation_tokens INTEGER, cache_read_tokens INTEGER, indexed_at TEXT);" \
+    "DELETE FROM _stage;" \
+    ".mode tabs" \
+    ".import $TSV_TMP _stage" \
+    "INSERT OR REPLACE INTO token_events SELECT * FROM _stage;" \
+    "DROP TABLE _stage;" \
+    "COMMIT;" \
+    >"$SQL_TMP"
+
+  sqlite3 "$DB_PATH" <"$SQL_TMP" >/dev/null
+
+  TOTAL_ROWS=$(( TOTAL_ROWS + row_count ))
+  TOTAL_FILES=$(( TOTAL_FILES + 1 ))
+
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    printf 'indexed: %s/%s (%d rows)\n' "$repo_slug" "$(basename "$file")" "$row_count"
+  fi
+
+done < <(find "$LOGS_ROOT" \
+  -mindepth 2 -maxdepth 2 \
+  -type f \
+  -name 'talekeeper-*.jsonl' \
+  -not -name 'talekeeper-raw-*.jsonl' \
+  -print0)
+
+printf 'indexed %d rows from %d files into %s\n' "$TOTAL_ROWS" "$TOTAL_FILES" "$DB_PATH"

--- a/claude/scripts/test-talekeeper-index.sh
+++ b/claude/scripts/test-talekeeper-index.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# test-talekeeper-index.sh — automated test fixture for talekeeper-index.sh
+#
+# Tests:
+#   1. A chronicle with two distinct session_ids produces 2 rows and 2
+#      distinct session_ids in token_events.
+#   2. Re-running the indexer over the same data is idempotent (row count
+#      does not change).
+#   3. Staging files (talekeeper-raw-*.jsonl) are NOT indexed.
+#   4. The indexer exits 0 silently when sqlite3 is absent (PATH restriction).
+#
+# Usage: bash claude/scripts/test-talekeeper-index.sh
+# Exit:  0 on success, 1 on any assertion failure.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve the directory containing this test script so absolute paths work
+# regardless of cwd.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INDEXER="$SCRIPT_DIR/talekeeper-index.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+pass() { printf '[PASS] %s\n' "$1"; PASS=$(( PASS + 1 )); }
+fail() { printf '[FAIL] %s\n' "$1" >&2; FAIL=$(( FAIL + 1 )); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Temp directory — cleaned up on exit
+# ---------------------------------------------------------------------------
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Create the repo-slug subdirectory (mindepth 2 requirement of the indexer)
+LOGS_DIR="$TMPDIR_ROOT/logs"
+REPO_DIR="$LOGS_DIR/test-repo"
+mkdir -p "$REPO_DIR"
+
+DB="$TMPDIR_ROOT/test.db"
+
+# ---------------------------------------------------------------------------
+# Fixture: a single chronicle file with TWO distinct session_ids
+# ---------------------------------------------------------------------------
+CHRONICLE="$REPO_DIR/talekeeper-fixture-session.jsonl"
+
+cat >"$CHRONICLE" <<'JSONL'
+{"session_id":"aaaa-1111","agent_id":"agent-001","timestamp":"2026-04-01T10:00:00Z","agent_type":"bitsmith","event_type":"SubagentStop","verdict":"","input_tokens":100,"output_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}
+{"session_id":"bbbb-2222","agent_id":"agent-002","timestamp":"2026-04-01T11:00:00Z","agent_type":"ruinor","event_type":"SubagentStop","verdict":"ACCEPT","input_tokens":50,"output_tokens":75,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}
+JSONL
+
+# Also place a staging file to verify it is excluded
+STAGING="$REPO_DIR/talekeeper-raw-cccc-3333.jsonl"
+cat >"$STAGING" <<'JSONL'
+{"session_id":"cccc-3333","agent_id":"agent-003","timestamp":"2026-04-01T12:00:00Z","agent_type":"pathfinder","event_type":"SubagentStop","verdict":"","input_tokens":999,"output_tokens":999,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}
+JSONL
+
+# ---------------------------------------------------------------------------
+# Test 1: two distinct session_ids are indexed correctly
+# ---------------------------------------------------------------------------
+TALEKEEPER_DB="$DB" TALEKEEPER_LOGS_ROOT="$LOGS_DIR" bash "$INDEXER" --quiet
+
+distinct_sessions="$(sqlite3 "$DB" "SELECT COUNT(DISTINCT session_id) FROM token_events;")"
+assert_eq "distinct session_id count == 2" "2" "$distinct_sessions"
+
+total_rows="$(sqlite3 "$DB" "SELECT COUNT(*) FROM token_events;")"
+assert_eq "total row count == 2" "2" "$total_rows"
+
+# ---------------------------------------------------------------------------
+# Test 2: idempotency — running again does not change the row count
+# ---------------------------------------------------------------------------
+TALEKEEPER_DB="$DB" TALEKEEPER_LOGS_ROOT="$LOGS_DIR" bash "$INDEXER" --quiet
+
+total_rows_after="$(sqlite3 "$DB" "SELECT COUNT(*) FROM token_events;")"
+assert_eq "row count unchanged after second run (idempotency)" "2" "$total_rows_after"
+
+# ---------------------------------------------------------------------------
+# Test 3: staging files (talekeeper-raw-*.jsonl) are NOT indexed
+# The fixture placed cccc-3333 only in a staging file; it must not appear.
+# ---------------------------------------------------------------------------
+staging_session="$(sqlite3 "$DB" "SELECT COUNT(*) FROM token_events WHERE session_id = 'cccc-3333';")"
+assert_eq "staging file session not indexed" "0" "$staging_session"
+
+# ---------------------------------------------------------------------------
+# Test 4: indexer exits 0 silently when sqlite3 is absent
+# Construct a restricted PATH that excludes sqlite3.
+# ---------------------------------------------------------------------------
+
+# Build a PATH that keeps bash, find, jq, date but removes sqlite3.
+# We do this by making a tempdir with symlinks for everything we need
+# except sqlite3.
+RESTRICTED_PATH_DIR="$TMPDIR_ROOT/restricted-bin"
+mkdir -p "$RESTRICTED_PATH_DIR"
+
+for cmd in bash find jq date wc tr mkdir printf cat rm; do
+  cmd_path="$(command -v "$cmd" 2>/dev/null || true)"
+  if [[ -n "$cmd_path" ]]; then
+    ln -sf "$cmd_path" "$RESTRICTED_PATH_DIR/$cmd"
+  fi
+done
+# Intentionally do NOT symlink sqlite3.
+
+exit_code=0
+PATH="$RESTRICTED_PATH_DIR" bash "$INDEXER" --quiet 2>/dev/null || exit_code=$?
+assert_eq "exits 0 silently when sqlite3 is absent" "0" "$exit_code"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n--- Results: %d passed, %d failed ---\n' "$PASS" "$FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/claude/scripts/token-summary.sh
+++ b/claude/scripts/token-summary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # token-summary.sh — emit formatted session token totals for a repo
-# Usage: token-summary.sh <repo-slug>
+# Usage: token-summary.sh <repo-slug> [<session-id>]
 # Output: "<N>k in / <N>k out / <N>k cache-write / <N>k cache-read"  or "unavailable"
 # Always exits 0.
 
@@ -12,10 +12,23 @@ if [[ -z "$REPO_SLUG" ]]; then
   exit 0
 fi
 
+SESSION_ID="${2:-}"
 LOG_DIR="$HOME/.ai-tpk/logs/$REPO_SLUG"
 CACHE_FILE="$LOG_DIR/latest-token-summary.txt"
 
-# Fast path: read pre-computed cache written by talekeeper-enrich.sh Stop hook
+# Fast path: prefer the per-session cache when SESSION_ID is provided;
+# fall back to the shared cache.
+if [[ -n "$SESSION_ID" ]]; then
+  SESSION_CACHE="$LOG_DIR/latest-token-summary-${SESSION_ID}.txt"
+  if [[ -s "$SESSION_CACHE" ]]; then
+    RESULT=$(cat "$SESSION_CACHE" 2>/dev/null || true)
+    if [[ -n "$RESULT" ]]; then
+      printf '%s\n' "$RESULT"
+      exit 0
+    fi
+  fi
+fi
+
 if [[ -s "$CACHE_FILE" ]]; then
   RESULT=$(cat "$CACHE_FILE" 2>/dev/null || true)
   if [[ -n "$RESULT" ]]; then
@@ -31,7 +44,7 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-LATEST=$(ls -t "$LOG_DIR"/talekeeper-*.jsonl 2>/dev/null | grep -v '/talekeeper-raw\.jsonl$' | head -n1 || true)
+LATEST=$(ls -t "$LOG_DIR"/talekeeper-*.jsonl 2>/dev/null | grep -E -v '/talekeeper-raw-[^/]*\.jsonl$' | head -n1 || true)
 if [[ -z "$LATEST" ]]; then
   printf 'unavailable\n'
   exit 0

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -123,9 +123,11 @@ Runs at the start of every Claude Code session. For resumed sessions, restores t
 
 Runs after every sub-agent completion to capture raw session event data.
 
-**Purpose:** Appends raw sub-agent completion events to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-raw.jsonl` for later enrichment. Script: `claude/hooks/talekeeper-capture.sh`.
+**Purpose:** Appends raw sub-agent completion events to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-raw-{session_id}.jsonl` for later enrichment. Script: `~/.claude/hooks/talekeeper-capture.sh`.
 
-**Non-obvious behavior:** Filters out `hook-agent-*` events — Stop hook agents are not real sub-agents and must not pollute the log. Always exits 0; logging must never block the session.
+Each session writes to its own staging file — see Constitution Principle 1 for the rationale.
+
+**Non-obvious behavior:** Filters out `hook-agent-*` events — Stop hook agents are not real sub-agents and must not pollute the log. Always exits 0; logging must never block the session. When `session_id` is absent from the SubagentStop event (or `jq` is unavailable), falls back to a unique `unknown-$(date +%s)-$$` filename so concurrent captures from unknown sessions cannot collide.
 
 #### Stop Hook - Session Enrichment
 
@@ -135,9 +137,20 @@ Note: A second Stop hook (`tab-rename-stop.sh`) also fires asynchronously for te
 
 **Session enrichment (async):**
 
-Processes the raw sub-agent event log captured during the session into a structured enriched JSONL chronicle. Script: `claude/hooks/talekeeper-enrich.sh`.
+Processes the raw sub-agent event log captured during the session into a structured enriched JSONL chronicle. Script: `~/.claude/hooks/talekeeper-enrich.sh`.
 
-**Non-obvious behaviors:** Filters out `hook-agent-*` events and `talekeeper` self-captures. Reads each agent's transcript file (`agent_transcript_path`) and sums token usage across all assistant turns. Clears the raw log on success.
+**Behavior:**
+1. Reads `session_id` from the Stop event payload on stdin (2-second timeout).
+2. If `session_id` is absent or empty, exits 0 silently — the hook **must not** scan or touch any other session's `talekeeper-raw-*.jsonl` file (Constitution Principle 1).
+3. Reads only this session's own staging file: `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-raw-{session_id}.jsonl`.
+4. Filters out `hook-agent-*` events and `talekeeper` self-captures. Reads each agent's transcript file (`agent_transcript_path`) and sums token usage across all assistant turns.
+5. Writes enriched entries to a PID-suffixed temp file, then appends the temp file to the per-session chronicle using `cat >>`. Because each session is the sole writer of its own chronicle file, plain append is safe — there is no concurrent writer to race against.
+6. Removes the per-session staging file on success. On failure (temp file empty or write error), the staging file is left in place for retry or debugging.
+7. Writes the session token summary to two cache files:
+   - `~/.ai-tpk/logs/{REPO_SLUG}/latest-token-summary-{session_id}.txt` — per-session cache.
+   - `~/.ai-tpk/logs/{REPO_SLUG}/latest-token-summary.txt` — shared, last-writer-wins convenience copy for backward compatibility with single-session consumers.
+
+**Non-obvious behaviors:** When the Stop event has no `session_id`, the hook exits 0 immediately without reading any file — this is a deliberate Constitution Principle 1 invariant. The capture hook already assigns `unknown-$(date +%s)-$$` filenames when `session_id` is missing at SubagentStop time, so a missing Stop-event `session_id` means there is no matching staging file anyway, making silent exit correct and safe.
 
 **Enriched Chronicle Schema:**
 
@@ -175,3 +188,77 @@ Runs after every Claude turn (Stop hook) to generate and store an AI-derived ter
 **Supported terminals and detection:** Same table as the SessionStart hook above.
 
 **Async and timeout:** The hook runs asynchronously with a 30-second timeout so that title generation does not block the user between turns.
+
+---
+
+### Optional SQLite Token Index
+
+`~/.claude/scripts/talekeeper-index.sh` is a user-invoked script (not a hook) that reads all Talekeeper chronicle files and upserts their rows into a queryable SQLite database. It is never run automatically from a hook — invoke it manually when you want to query historical token data.
+
+**Usage:**
+
+```
+bash ~/.claude/scripts/talekeeper-index.sh [--verbose] [--help]
+```
+
+**Database location:** `~/.ai-tpk/tokens.db`
+
+The script creates the parent directory of `TALEKEEPER_DB` automatically (`mkdir -p`) before opening the database, so custom paths via the environment override do not require the directory to exist beforehand.
+
+**Environment overrides:**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TALEKEEPER_DB` | `~/.ai-tpk/tokens.db` | Override the database path (e.g., for testing) |
+| `TALEKEEPER_LOGS_ROOT` | `~/.ai-tpk/logs` | Override the logs root path (e.g., for testing) |
+
+**Schema (`token_events` table):**
+
+```sql
+CREATE TABLE IF NOT EXISTS token_events (
+  session_id              TEXT    NOT NULL,
+  agent_id                TEXT    NOT NULL,
+  timestamp               TEXT    NOT NULL,
+  repo_slug               TEXT    NOT NULL,
+  agent_type              TEXT,
+  event_type              TEXT,
+  verdict                 TEXT,
+  input_tokens            INTEGER NOT NULL DEFAULT 0,
+  output_tokens           INTEGER NOT NULL DEFAULT 0,
+  cache_creation_tokens   INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens       INTEGER NOT NULL DEFAULT 0,
+  indexed_at              TEXT    NOT NULL,
+  PRIMARY KEY (session_id, agent_id, timestamp)
+);
+CREATE INDEX IF NOT EXISTS idx_token_events_repo_session
+  ON token_events (repo_slug, session_id);
+```
+
+**Key behaviors:**
+
+- **Silent no-op when `sqlite3` is absent:** the script exits 0 with no output when `sqlite3` is not in PATH. `jq` absence also triggers a silent exit 0. The installer prints a one-line notice if `sqlite3` is missing at install time, but the script itself is always silent in this case. When `jq` fails on a specific chronicle file during indexing, the file is skipped; in `--verbose` mode a warning is printed to stderr (`warn: jq failed on <file>, skipping`) so failures are visible without being fatal.
+- **Idempotent:** re-running over the same chronicle files produces the same database state. `INSERT OR REPLACE` keyed on `(session_id, agent_id, timestamp)` ensures no duplicate rows; `indexed_at` is updated to the latest run timestamp, which is acceptable.
+- **Concurrent-safe:** `PRAGMA busy_timeout = 5000` is set before every transaction so concurrent indexer invocations serialise rather than fail with `SQLITE_BUSY`. If `sqlite3` still exits non-zero after the timeout, the script exits 1 with a one-line stderr message — this is the correct behaviour for a user-invoked tool.
+- **Staging files excluded:** chronicle files whose basename matches `talekeeper-raw-*.jsonl` are skipped. Only fully-enriched chronicle files (`talekeeper-{session_id}.jsonl`) are indexed.
+- **Legacy mixed-session chronicles handled correctly:** each row's own `session_id` field is used as the natural key, not the chronicle filename. This means existing chronicle files that contain rows from multiple session IDs (produced before per-session staging was introduced) are indexed correctly — each row lands in `token_events` under its own `session_id`.
+- **Orphaned temp file cleanup:** the script removes any `talekeeper-*.jsonl.tmp.*` files older than 60 minutes from the logs directory. These are temp files left behind by crashed enrichment runs. This cleanup is deliberate here (not in the hook) to avoid a per-Stop filesystem walk in the hook hot path.
+
+#### `token-summary.sh` — formatted token total helper
+
+`~/.claude/scripts/token-summary.sh` is a companion script that reads session token totals and emits a single formatted line. It is called by the `/merged` command to include token usage in the post-merge summary.
+
+**Usage:**
+
+```
+bash ~/.claude/scripts/token-summary.sh <repo-slug> [<session-id>]
+```
+
+**Output format:** `<N>k in / <N>k out / <N>k cache-write / <N>k cache-read`, or `unavailable` when no data can be found. Always exits 0.
+
+**Lookup order:**
+
+1. Per-session cache: `~/.ai-tpk/logs/<repo-slug>/latest-token-summary-<session-id>.txt` (only when `session-id` is provided and non-empty).
+2. Shared cache: `~/.ai-tpk/logs/<repo-slug>/latest-token-summary.txt`.
+3. `jq` fallback: sums token fields from the most-recent enriched chronicle file in the repo's log directory (staging files excluded).
+
+Both cache files are written by the Stop hook enrichment script (`talekeeper-enrich.sh`) — see "Stop Hook - Session Enrichment" above.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,6 +22,8 @@ Run the installation script:
 
 The installer copies the whitelisted paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `hooks/`, `references/`, `scripts/`) from `claude/` into `~/.claude/` and, when present, into `~/.cursor/`. Anything else in the repo or on disk under those destinations is left untouched except where those paths are replaced (after a timestamped backup).
 
+When `sqlite3` is available in PATH, the installer also initializes the optional token tracking database at `~/.ai-tpk/tokens.db` (the `token_events` table schema). Re-running the installer with an existing database is non-destructive — `CREATE TABLE IF NOT EXISTS` leaves existing data intact. When `sqlite3` is absent, the installer prints a one-line notice and continues; the database can be created later by running `~/.claude/scripts/talekeeper-index.sh`. For the database schema, query examples, and the `talekeeper-index.sh` indexer, see [docs/HOOKS.md — Optional SQLite Token Index](/docs/HOOKS.md).
+
 The `.claude/` directory is never synced by the installer — it remains project-local.
 
 ## Development Setup

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -7,6 +7,7 @@ Install AI TPK to your home directory.
 Claude Code:
   - Whitelisted paths: settings.json, CLAUDE.md, skills/, agents/, references/
   - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
+  - Optional SQLite token DB at ~/.ai-tpk/tokens.db (when sqlite3 is available)
 
 Options:
   --help    Show this help message`;

--- a/src/installer/main.ts
+++ b/src/installer/main.ts
@@ -3,6 +3,7 @@ import { installDir } from "./fs-utils.js";
 import { installClaudeWhitelist } from "./claude.js";
 import { installMcpServers } from "./mcp.js";
 import { installLauncherScript } from "./launcher-install.js";
+import { initTokenDb, removeLegacySingletonStagingFiles } from "./token-db.js";
 import { c } from "./colors.js";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
@@ -37,6 +38,15 @@ try {
       `✓ Created artifact directories: ${aiTpkDir}/plans/, ${aiTpkDir}/lessons/`,
     ),
   );
+
+  // Optional: initialize the SQLite token DB schema when sqlite3 is available.
+  // The installer surfaces a one-line notice when sqlite3 is absent; the
+  // indexer script (talekeeper-index.sh) is fully silent in the same case.
+  initTokenDb(os.homedir(), (msg) => console.log(msg));
+
+  // Remove legacy singleton staging files left over from before per-session
+  // staging was introduced.
+  removeLegacySingletonStagingFiles(os.homedir(), (msg) => console.log(msg));
 
   console.log("");
   installMcpServers(scriptDir);

--- a/src/installer/token-db.test.ts
+++ b/src/installer/token-db.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as childProcess from "node:child_process";
+import {
+  TOKEN_DB_SCHEMA_SQL,
+  initTokenDb,
+  removeLegacySingletonStagingFiles,
+} from "./token-db.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-token-db-test-"));
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// TOKEN_DB_SCHEMA_SQL constant — schema anchor guardrail
+// ---------------------------------------------------------------------------
+
+describe("TOKEN_DB_SCHEMA_SQL", () => {
+  it("contains the schema anchor comment", () => {
+    assert.ok(
+      TOKEN_DB_SCHEMA_SQL.includes("SCHEMA-ANCHOR: talekeeper.token_events.v1"),
+      "TOKEN_DB_SCHEMA_SQL must contain the SCHEMA-ANCHOR comment so grep finds both copies",
+    );
+  });
+
+  it("contains the token_events table definition", () => {
+    assert.ok(
+      TOKEN_DB_SCHEMA_SQL.includes("CREATE TABLE IF NOT EXISTS token_events"),
+    );
+  });
+
+  it("contains the composite primary key", () => {
+    assert.ok(
+      TOKEN_DB_SCHEMA_SQL.includes(
+        "PRIMARY KEY (session_id, agent_id, timestamp)",
+      ),
+    );
+  });
+
+  it("contains the repo_session index", () => {
+    assert.ok(TOKEN_DB_SCHEMA_SQL.includes("idx_token_events_repo_session"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initTokenDb — absent sqlite3
+// Inject a fake spawnSync that simulates ENOENT (sqlite3 not found).
+// ---------------------------------------------------------------------------
+
+// Defined at module scope so the linter does not flag it as a function that
+// could be hoisted (consistent-function-scoping rule).
+function fakeSpawnSyncAbsent() {
+  return {
+    pid: null,
+    output: [],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status: null as number | null,
+    signal: null,
+    error: Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+  };
+}
+
+describe("initTokenDb — absent sqlite3", () => {
+  it("does not throw and does not create the DB file when sqlite3 is absent", () => {
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-absent-"));
+    const dbPath = path.join(fakeHome, ".ai-tpk", "tokens.db");
+
+    const logs: string[] = [];
+    assert.doesNotThrow(() =>
+      initTokenDb(fakeHome, (msg) => logs.push(msg), fakeSpawnSyncAbsent),
+    );
+
+    // DB file must not have been created
+    assert.ok(
+      !fs.existsSync(dbPath),
+      "DB file must not be created when sqlite3 is absent",
+    );
+
+    // One notice line must be logged
+    assert.strictEqual(logs.length, 1);
+    assert.ok(
+      logs[0]?.includes("sqlite3 not found"),
+      `expected 'sqlite3 not found' in log message, got: ${logs[0]}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initTokenDb — present sqlite3, successful init
+// ---------------------------------------------------------------------------
+
+describe("initTokenDb — present sqlite3, successful init", () => {
+  it("does not throw and logs success when sqlite3 is available", () => {
+    // Check whether sqlite3 is actually available on this machine.
+    const probe = childProcess.spawnSync("sqlite3", ["--version"], {
+      stdio: "ignore",
+    });
+    if (probe.status !== 0 || probe.error) {
+      // sqlite3 not available in this environment — skip with a warning.
+      console.warn(
+        "  [skip] sqlite3 not found in PATH; skipping real-binary init test",
+      );
+      return;
+    }
+
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-success-"));
+    fs.mkdirSync(path.join(fakeHome, ".ai-tpk"), { recursive: true });
+
+    const logs: string[] = [];
+    // Use the real spawnSync (no injection — tests with the real binary)
+    assert.doesNotThrow(() => initTokenDb(fakeHome, (msg) => logs.push(msg)));
+
+    assert.strictEqual(logs.length, 1);
+    assert.ok(
+      logs[0]?.includes("Initialized token DB schema"),
+      `expected success message, got: ${logs[0]}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initTokenDb — present sqlite3, non-zero exit
+// Inject a fake spawnSync: probe succeeds, schema init fails.
+// ---------------------------------------------------------------------------
+
+// Call counter lives outside the function so it can be reset per test while
+// the function itself remains at module scope (consistent-function-scoping).
+let nonZeroCallCount = 0;
+function fakeSpawnSyncNonZero() {
+  nonZeroCallCount++;
+  // First call: probe for sqlite3 — succeed
+  if (nonZeroCallCount === 1) {
+    return {
+      pid: 1,
+      output: [],
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      status: 0 as number | null,
+      signal: null,
+      error: undefined,
+    };
+  }
+  // Second call: schema init — fail
+  return {
+    pid: 1,
+    output: [],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status: 1 as number | null,
+    signal: null,
+    error: undefined,
+  };
+}
+
+describe("initTokenDb — present sqlite3, non-zero exit", () => {
+  it("does not throw and logs a warning when sqlite3 exits non-zero", () => {
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-fail-"));
+    nonZeroCallCount = 0; // reset for this test
+
+    const logs: string[] = [];
+    assert.doesNotThrow(() =>
+      initTokenDb(fakeHome, (msg) => logs.push(msg), fakeSpawnSyncNonZero),
+    );
+
+    assert.strictEqual(logs.length, 1);
+    assert.ok(
+      logs[0]?.toLowerCase().includes("warning"),
+      `expected a warning message, got: ${logs[0]}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeLegacySingletonStagingFiles
+// ---------------------------------------------------------------------------
+
+describe("removeLegacySingletonStagingFiles", () => {
+  it("removes talekeeper-raw.jsonl from each repo slug directory and logs a notice", () => {
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-legacy-"));
+    const logsDir = path.join(fakeHome, ".ai-tpk", "logs");
+    const repoDir = path.join(logsDir, "my-repo");
+    fs.mkdirSync(repoDir, { recursive: true });
+
+    const legacyFile = path.join(repoDir, "talekeeper-raw.jsonl");
+    fs.writeFileSync(legacyFile, "old staging data\n", "utf8");
+
+    const logs: string[] = [];
+    removeLegacySingletonStagingFiles(fakeHome, (msg) => logs.push(msg));
+
+    assert.ok(!fs.existsSync(legacyFile), "legacy file must be removed");
+    assert.strictEqual(logs.length, 1);
+    assert.ok(
+      logs[0]?.includes("legacy") || logs[0]?.includes("Removing"),
+      `expected legacy removal notice, got: ${logs[0]}`,
+    );
+  });
+
+  it("does not throw when the logs directory does not exist", () => {
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-no-logs-"));
+    const logs: string[] = [];
+    assert.doesNotThrow(() =>
+      removeLegacySingletonStagingFiles(fakeHome, (msg) => logs.push(msg)),
+    );
+    assert.strictEqual(logs.length, 0);
+  });
+
+  it("does not remove session-namespaced staging files", () => {
+    const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-namespaced-"));
+    const logsDir = path.join(fakeHome, ".ai-tpk", "logs");
+    const repoDir = path.join(logsDir, "my-repo");
+    fs.mkdirSync(repoDir, { recursive: true });
+
+    // Session-namespaced file — must NOT be removed
+    const namespacedFile = path.join(repoDir, "talekeeper-raw-abc123.jsonl");
+    fs.writeFileSync(namespacedFile, "per-session staging\n", "utf8");
+
+    const logs: string[] = [];
+    removeLegacySingletonStagingFiles(fakeHome, (msg) => logs.push(msg));
+
+    assert.ok(
+      fs.existsSync(namespacedFile),
+      "session-namespaced staging file must NOT be removed",
+    );
+    assert.strictEqual(logs.length, 0);
+  });
+});

--- a/src/installer/token-db.ts
+++ b/src/installer/token-db.ts
@@ -1,0 +1,120 @@
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import type { SpawnSyncOptionsWithBufferEncoding } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { c } from "./colors.js";
+
+// SCHEMA-ANCHOR: talekeeper.token_events.v1
+// If you change this schema, update claude/scripts/talekeeper-index.sh (same anchor).
+// This is a deliberate duplicate per Constitution Principle 2 — the installed indexer
+// must be self-contained without back-references to this repo. Use the grep anchor to
+// keep the two copies in sync:
+//   grep -rn 'SCHEMA-ANCHOR: talekeeper.token_events.v1' .
+export const TOKEN_DB_SCHEMA_SQL = [
+  "-- SCHEMA-ANCHOR: talekeeper.token_events.v1",
+  "PRAGMA busy_timeout = 5000;",
+  "CREATE TABLE IF NOT EXISTS token_events (",
+  "  session_id TEXT NOT NULL,",
+  "  agent_id TEXT NOT NULL,",
+  "  timestamp TEXT NOT NULL,",
+  "  repo_slug TEXT NOT NULL,",
+  "  agent_type TEXT,",
+  "  event_type TEXT,",
+  "  verdict TEXT,",
+  "  input_tokens INTEGER NOT NULL DEFAULT 0,",
+  "  output_tokens INTEGER NOT NULL DEFAULT 0,",
+  "  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,",
+  "  cache_read_tokens INTEGER NOT NULL DEFAULT 0,",
+  "  indexed_at TEXT NOT NULL,",
+  "  PRIMARY KEY (session_id, agent_id, timestamp)",
+  ");",
+  "CREATE INDEX IF NOT EXISTS idx_token_events_repo_session",
+  "  ON token_events (repo_slug, session_id);",
+].join("\n");
+
+// Minimal type matching the spawnSync signature we use.
+type SpawnSyncFn = (
+  cmd: string,
+  args: string[],
+  opts?:
+    | SpawnSyncOptionsWithBufferEncoding
+    | { input: string; stdio: ("pipe" | "ignore")[] },
+) => { status: number | null; error?: Error };
+
+export function initTokenDb(
+  homeDir: string,
+  log: (msg: string) => void,
+  // Injectable for testing; defaults to the real spawnSync.
+  spawnSyncFn: SpawnSyncFn = nodeSpawnSync as unknown as SpawnSyncFn,
+): void {
+  const dbPath = path.join(homeDir, ".ai-tpk", "tokens.db");
+
+  // Check sqlite3 availability.
+  // The indexer script is fully silent on sqlite3 absence; the installer is
+  // allowed (and expected) to surface a one-line user-facing notice during setup.
+  const probe = spawnSyncFn("sqlite3", ["--version"], {
+    stdio: "ignore",
+  } as SpawnSyncOptionsWithBufferEncoding);
+  if (probe.status !== 0 || probe.error) {
+    log(c.yellow("Skipping SQLite token DB init (sqlite3 not found in PATH)"));
+    return;
+  }
+
+  // Initialize schema (idempotent — CREATE TABLE IF NOT EXISTS).
+  const result = spawnSyncFn("sqlite3", [dbPath], {
+    input: TOKEN_DB_SCHEMA_SQL,
+    stdio: ["pipe", "ignore", "ignore"],
+  } as unknown as SpawnSyncOptionsWithBufferEncoding);
+
+  if (result.status !== 0) {
+    log(
+      c.yellow(
+        "Warning: sqlite3 schema init failed; the indexer will create the schema on first run",
+      ),
+    );
+    return;
+  }
+
+  log(c.green(`✓ Initialized token DB schema: ${dbPath}`));
+}
+
+export function removeLegacySingletonStagingFiles(
+  homeDir: string,
+  log: (msg: string) => void,
+): void {
+  // Remove legacy talekeeper-raw.jsonl files (no session-ID suffix) left over
+  // from before per-session staging was introduced. These are staging files
+  // (not chronicles), so deletion is safe — the new per-session enrich hook
+  // will never read them.
+  const logsDir = path.join(homeDir, ".ai-tpk", "logs");
+
+  let slugEntries: fs.Dirent[];
+  try {
+    slugEntries = fs.readdirSync(logsDir, { withFileTypes: true });
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return; // logs dir does not exist yet — nothing to clean
+    }
+    throw err;
+  }
+
+  for (const entry of slugEntries) {
+    if (!entry.isDirectory()) continue;
+    const legacyPath = path.join(logsDir, entry.name, "talekeeper-raw.jsonl");
+    try {
+      fs.unlinkSync(legacyPath);
+      log(c.yellow(`Removing legacy shared staging file: ${legacyPath}`));
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        continue; // file does not exist — nothing to do
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The talekeeper capture hook used a single shared staging file (`talekeeper-raw.jsonl`) for all concurrent Claude Code sessions. Because multiple sessions write to this file simultaneously and the enrich hook reads/flushes it on `Stop` events, sessions could consume each other's raw records — causing cross-session token mixing that corrupted ~67% of chronicle files (entries attributed to the wrong session).

## Approach

**Per-session staging files** — `talekeeper-raw-{session_id}.jsonl` replaces the shared singleton. Each session writes to its own file; the enrich hook reads and deletes only that session's file on `Stop`. Cross-session interference is eliminated structurally.

**Optional SQLite index** — `talekeeper-index.sh` is a new opt-in script that reads completed chronicle JSONL files and upserts rows into a local SQLite database (`~/.ai-tpk/logs/token-history.db`). This enables queryable history (e.g., tokens per project, per day, per model) without affecting the existing append-only chronicle format. The script degrades gracefully: if `sqlite3` is absent, it exits 0 with a warning.

**Node installer wiring** — `token-db.ts` exposes `initTokenDb()` to create the SQLite schema on first run. The installer calls it only when sqlite3 is available; missing binary is not treated as a fatal error.

**Backward compatibility preserved** — `latest-token-summary.txt` continues to be updated by `token-summary.sh` exactly as before. Existing chronicle JSONL files are not migrated or reformatted. Users who don't have sqlite3 see no change in behavior.

## Rollout Notes

- `sqlite3` CLI is optional; its absence produces a warning, not a failure
- Existing chronicle files are not touched; the SQLite index is populated only on demand by running `talekeeper-index.sh`
- Per-session staging files are ephemeral and cleaned up automatically by the enrich hook on `Stop`
- The shared `talekeeper-raw.jsonl` (if present from a previous install) can be safely deleted after any in-flight sessions complete

## Test Coverage

- `src/installer/token-db.test.ts` — unit tests for schema initialization and upsert idempotency
- `claude/hooks/test-talekeeper-enrich.sh` — shell integration tests for the enrich hook
- `claude/scripts/test-talekeeper-index.sh` — integration tests for the SQLite indexer

---

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>