### PR TITLE
feat(launcher): clear terminal before launching Claude

### DIFF
--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -29,6 +29,11 @@ function launchClaude(
     lines.push("No MCPs configured — launching Claude with current env.");
   }
 
+  // Clear terminal so the Claude session starts on a clean screen.
+  // The return value is intentionally ignored: if `clear` is missing from PATH
+  // or exits non-zero, the launch must still proceed.
+  // stderr is suppressed to silence noise from a potentially misconfigured binary.
+  spawnSync("clear", [], { stdio: ["inherit", "inherit", "ignore"] });
   outro(`Launching: ${lines.join(" · ")}`);
 
   // Launch Claude with merged env vars


### PR DESCRIPTION
When launching Claude from the launcher, residual terminal output from previous commands cluttered the screen, making the Claude session harder to read from the start. This adds a clear-terminal step immediately before the Claude process is spawned, so every session begins with a clean slate. The change is isolated to the launcher entry point and has no effect on install or other flows.