### PR TITLE
feat(agents): set effort levels for all agents

### DIFF
--- a/claude/agents/askmaw.md
+++ b/claude/agents/askmaw.md
@@ -3,6 +3,7 @@ name: askmaw
 color: cyan
 description: "Stateless intake and elaboration clerk. Receives an ambiguous user request plus accumulated Q&A history from DM. Returns exactly one output per invocation: either a single clarifying question (Mode A) or a completed structured brief (Mode B). Invoked by DM in a loop before Pathfinder for ambiguous requests."
 model: claude-sonnet-4-6
+effort: low
 permissionMode: acceptEdits
 tools: ""
 ---

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -3,6 +3,7 @@ name: bitsmith
 color: green
 description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to Dungeon Master after 3 failed attempts."
 model: claude-sonnet-4-6
+effort: medium
 permissionMode: acceptEdits
 level: 2
 tools: "Read, Write, Edit, Bash, Grep, Glob, Agent"

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -4,6 +4,7 @@ color: purple
 description: "Use this agent to coordinate multi-step software development work. It delegates investigation to Tracebloom for 'why is this broken?' tasks, planning to Pathfinder, runs mandatory Ruinor baseline reviews, conditionally invokes specialist reviewers (Riskmancer/Windwarden/Knotcutter/Truthhammer) based on findings or user flags, delegates implementation to Bitsmith, and validates completion against the plan."
 tools: "Task, Read, Grep, Glob, Bash"
 model: claude-sonnet-4-6
+effort: high
 ---
 
 # Dungeon Master - Orchestration Agent

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -3,6 +3,7 @@ name: everwise
 color: pink
 description: "Use this agent when the user asks for meta-analysis of agent team performance, session chronicle review, or continuous improvement analysis. Learner agent. Analyzes Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems in the agent team. Proposes structured, evidence-based configuration improvements. Never modifies production configs directly — only writes to ~/.ai-tpk/lessons/ directory."
 model: claude-sonnet-4-6
+effort: medium
 permissionMode: acceptEdits
 tools: "Read, Grep, Glob, Write"
 memory: user

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -4,6 +4,7 @@ color: yellow
 description: "Radical simplification specialist for complexity elimination reviews."
 tools: "Read, Grep, Glob, Bash"
 model: claude-opus-4-7
+effort: high
 permissionMode: auto
 level: 3
 mandatory: false

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -3,6 +3,7 @@ name: pathfinder
 color: blue
 description: "Strategic planning consultant with interview workflow"
 model: claude-opus-4-7
+effort: high
 permissionMode: acceptEdits
 level: 4
 tools: "Read, Write, Grep, Glob, Bash, Agent"

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -4,6 +4,7 @@ color: pink
 description: "Documentation specialist. Produces or updates project docs (READMEs, API specs, architecture guides, user manuals) from a session plan and a list of changed files."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
 model: claude-sonnet-4-6
+effort: low
 permissionMode: acceptEdits
 ---
 

--- a/claude/agents/reisannin.md
+++ b/claude/agents/reisannin.md
@@ -2,6 +2,7 @@
 name: reisannin
 color: purple
 model: claude-sonnet-4-6
+effort: high
 tools: "Read, Grep, Glob"
 permissionMode: acceptEdits
 description: Forward-looking agentic architecture advisor. Invoke when designing new agents, skills, harnesses, or workflow topologies — or when questioning whether to add, split, or remove them. Reasons from principles, not session data.

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -3,6 +3,7 @@ name: riskmancer
 color: orange
 description: "Security vulnerability detection specialist (OWASP, secrets, auth, crypto)."
 model: claude-opus-4-7
+effort: high
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -3,6 +3,7 @@ name: ruinor
 color: red
 description: "Mandatory baseline quality gate reviewer issuing REJECT/REVISE/ACCEPT verdicts."
 model: claude-opus-4-7
+effort: high
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash"

--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -3,6 +3,7 @@ name: tracebloom
 color: brown
 description: "Read-only investigative agent for open-ended 'why is this broken?' tasks. Produces a structured Diagnostic Report with observations, tests performed, root cause (or inconclusive), and recommended next action. Invoked before any plan or fix exists."
 model: claude-sonnet-4-6
+effort: low
 permissionMode: auto
 level: 2
 tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*, mcp__cloudwatch__*, mcp__gcp-observability__*"

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -3,6 +3,7 @@ name: truthhammer
 color: orange
 description: "Factual validation specialist verifying claims about external systems against authoritative sources."
 model: claude-sonnet-4-6
+effort: low
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, WebFetch, WebSearch"

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -3,6 +3,7 @@ name: windwarden
 color: yellow
 description: "Performance and scalability reviewer for plans and code."
 model: claude-sonnet-4-6
+effort: medium
 permissionMode: auto
 level: 3
 tools: "Read, Grep, Glob, Bash, mcp__grafana__*, mcp__kubernetes__*, mcp__cloudwatch__*, mcp__gcp-observability__*"

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,22 +2,22 @@
 
 ## Quick Reference
 
-| Agent | Purpose | Primary Use Cases | Model | Review Type |
-|-------|---------|-------------------|-------|-------------|
-| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | N/A |
-| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
-| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | N/A |
-| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | N/A |
-| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | Specialist (opt-in) |
-| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | N/A |
-| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | Specialist (opt-in) |
-| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | Mandatory baseline |
-| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | Specialist (opt-in) |
-| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | Specialist (opt-in) |
-| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | N/A |
-| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
-| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | N/A |
-| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | N/A |
+| Agent | Purpose | Primary Use Cases | Model | Effort | Review Type |
+|-------|---------|-------------------|-------|--------|-------------|
+| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | high | N/A |
+| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | low | N/A |
+| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | low | N/A |
+| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | low | N/A |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | high | Specialist (opt-in) |
+| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | high | N/A |
+| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | high | Specialist (opt-in) |
+| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | high | Mandatory baseline |
+| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | medium | Specialist (opt-in) |
+| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | low | Specialist (opt-in) |
+| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | medium | N/A |
+| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A | N/A |
+| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | medium | N/A |
+| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | high | N/A |
 
 ## When to Use Which Agent
 
@@ -309,3 +309,49 @@ Terminal tab titles are automatically managed via a SessionStart hook for resume
 Agent definitions can reference shared behavioral vocabulary defined in `claude/references/`. This eliminates duplication across multiple agents:
 
 For the authoritative catalog of shared reference files and what each one does, see [docs/SKILLS.md — References](/docs/SKILLS.md#references). Each agent definition file in [`claude/agents/`](/claude/agents/) cites the specific references it loads.
+
+## Agent Frontmatter: The `effort` Field
+
+All agent definition files (`.md` files in `claude/agents/`) use YAML frontmatter to configure the agent at runtime. The `effort` field is one of those fields.
+
+### What it does
+
+`effort` controls extended-thinking intensity for the subagent, overriding the session-level setting. It tells Claude Code how much reasoning budget to allocate when the agent runs. The field is optional; when absent, the agent inherits the session default.
+
+### Allowed values
+
+| Value | Meaning |
+|-------|---------|
+| `low` | Minimal extended thinking — suited to bounded, tool-call-driven tasks with a narrow decision surface |
+| `medium` | Moderate extended thinking — suited to structured, plan-driven execution with some judgement calls |
+| `high` | Full extended thinking — suited to planning, orchestration, adversarial review, and multi-step reasoning where errors propagate |
+| `xhigh` | Extra-high extended thinking — Opus 4.7 only; falls back to `high` on other models |
+| `max` | Maximum extended thinking — Opus 4.7, Opus 4.6, Sonnet 4.6, and Claude Mythos Preview only |
+
+None of the agents in this repository use `xhigh` or `max`. All current assignments use `low`, `medium`, or `high`, which are supported on every model in use here.
+
+### Model-compatibility constraints
+
+The `effort` API parameter is supported on: Opus 4.7, Opus 4.6, Sonnet 4.6, and Opus 4.5. It is **not supported on Haiku models**, including `claude-haiku-4-5`. When `effort` is set on an unsupported model, the field has no effect at runtime. Claude Code's documented behaviour is to silently fall back to the highest supported level at or below the requested value when a specific value is unavailable.
+
+**Talekeeper is deliberately excluded** from the `effort` field because it runs on `claude-haiku-4-5`. Adding the field to its frontmatter would be inert. (Haiku 4.5 does support extended thinking via the separate `thinking` API parameter, but that is a distinct mechanism from `effort` and is not controlled by this frontmatter field.)
+
+### Tiering rationale
+
+The effort levels assigned to agents in this repository follow an analysis by Reisannin (architecture advisor) matching cognitive load to task characteristics:
+
+- **`low`** — Askmaw, Tracebloom, Quill, Truthhammer. Stateless or lookup-bounded tasks: a single Q&A output, tool-call-driven investigation, artifact production from supplied inputs, or web-source factual lookup. Decision surface is narrow; extended thinking yields little return.
+
+- **`medium`** — Bitsmith, Windwarden, Everwise. Structured, plan-driven work with moderate judgement: executing a pre-approved plan, data-retrieval-bounded performance review, or pattern analysis over chronicle data. Some reasoning is beneficial but the task is largely constrained.
+
+- **`high`** — Dungeon Master, Pathfinder, Ruinor, Riskmancer, Knotcutter, Reisannin. High-impact decisions that propagate through the pipeline or require adversarial / multi-step reasoning. Planning errors compound downstream; routing errors are expensive mid-session; review agents must catch what others missed; security analysis requires attack-chain reasoning; complexity evaluation requires deep design judgement.
+
+### Adding a new agent
+
+When creating a new agent, place the `effort` field in the YAML frontmatter immediately after the `model:` line. Choose the tier based on the agent's decision surface:
+
+- Bounded, single-output, or lookup tasks → `low`
+- Plan-driven execution or data-bounded analysis → `medium`
+- Orchestration, planning, adversarial review, or architecture advisory → `high`
+
+If the agent uses `claude-haiku-4-5`, omit the `effort` field entirely — it has no effect on that model.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,22 +2,22 @@
 
 ## Quick Reference
 
-| Agent | Purpose | Primary Use Cases | Model | Effort | Review Type |
-|-------|---------|-------------------|-------|--------|-------------|
-| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | high | N/A |
-| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | low | N/A |
-| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | low | N/A |
-| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | low | N/A |
-| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | high | Specialist (opt-in) |
-| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | high | N/A |
-| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | high | Specialist (opt-in) |
-| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | high | Mandatory baseline |
-| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | medium | Specialist (opt-in) |
-| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | low | Specialist (opt-in) |
-| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | medium | N/A |
-| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A | N/A |
-| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | medium | N/A |
-| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | high | N/A |
+| Agent | Purpose | Primary Use Cases | Model | Review Type |
+|-------|---------|-------------------|-------|-------------|
+| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | N/A |
+| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
+| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | N/A |
+| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | N/A |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | Specialist (opt-in) |
+| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | N/A |
+| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | Specialist (opt-in) |
+| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | Mandatory baseline |
+| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | Specialist (opt-in) |
+| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | Specialist (opt-in) |
+| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | N/A |
+| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
+| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | N/A |
+| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | N/A |
 
 ## When to Use Which Agent
 
@@ -309,49 +309,3 @@ Terminal tab titles are automatically managed via a SessionStart hook for resume
 Agent definitions can reference shared behavioral vocabulary defined in `claude/references/`. This eliminates duplication across multiple agents:
 
 For the authoritative catalog of shared reference files and what each one does, see [docs/SKILLS.md — References](/docs/SKILLS.md#references). Each agent definition file in [`claude/agents/`](/claude/agents/) cites the specific references it loads.
-
-## Agent Frontmatter: The `effort` Field
-
-All agent definition files (`.md` files in `claude/agents/`) use YAML frontmatter to configure the agent at runtime. The `effort` field is one of those fields.
-
-### What it does
-
-`effort` controls extended-thinking intensity for the subagent, overriding the session-level setting. It tells Claude Code how much reasoning budget to allocate when the agent runs. The field is optional; when absent, the agent inherits the session default.
-
-### Allowed values
-
-| Value | Meaning |
-|-------|---------|
-| `low` | Minimal extended thinking — suited to bounded, tool-call-driven tasks with a narrow decision surface |
-| `medium` | Moderate extended thinking — suited to structured, plan-driven execution with some judgement calls |
-| `high` | Full extended thinking — suited to planning, orchestration, adversarial review, and multi-step reasoning where errors propagate |
-| `xhigh` | Extra-high extended thinking — Opus 4.7 only; falls back to `high` on other models |
-| `max` | Maximum extended thinking — Opus 4.7, Opus 4.6, Sonnet 4.6, and Claude Mythos Preview only |
-
-None of the agents in this repository use `xhigh` or `max`. All current assignments use `low`, `medium`, or `high`, which are supported on every model in use here.
-
-### Model-compatibility constraints
-
-The `effort` API parameter is supported on: Opus 4.7, Opus 4.6, Sonnet 4.6, and Opus 4.5. It is **not supported on Haiku models**, including `claude-haiku-4-5`. When `effort` is set on an unsupported model, the field has no effect at runtime. Claude Code's documented behaviour is to silently fall back to the highest supported level at or below the requested value when a specific value is unavailable.
-
-**Talekeeper is deliberately excluded** from the `effort` field because it runs on `claude-haiku-4-5`. Adding the field to its frontmatter would be inert. (Haiku 4.5 does support extended thinking via the separate `thinking` API parameter, but that is a distinct mechanism from `effort` and is not controlled by this frontmatter field.)
-
-### Tiering rationale
-
-The effort levels assigned to agents in this repository follow an analysis by Reisannin (architecture advisor) matching cognitive load to task characteristics:
-
-- **`low`** — Askmaw, Tracebloom, Quill, Truthhammer. Stateless or lookup-bounded tasks: a single Q&A output, tool-call-driven investigation, artifact production from supplied inputs, or web-source factual lookup. Decision surface is narrow; extended thinking yields little return.
-
-- **`medium`** — Bitsmith, Windwarden, Everwise. Structured, plan-driven work with moderate judgement: executing a pre-approved plan, data-retrieval-bounded performance review, or pattern analysis over chronicle data. Some reasoning is beneficial but the task is largely constrained.
-
-- **`high`** — Dungeon Master, Pathfinder, Ruinor, Riskmancer, Knotcutter, Reisannin. High-impact decisions that propagate through the pipeline or require adversarial / multi-step reasoning. Planning errors compound downstream; routing errors are expensive mid-session; review agents must catch what others missed; security analysis requires attack-chain reasoning; complexity evaluation requires deep design judgement.
-
-### Adding a new agent
-
-When creating a new agent, place the `effort` field in the YAML frontmatter immediately after the `model:` line. Choose the tier based on the agent's decision surface:
-
-- Bounded, single-output, or lookup tasks → `low`
-- Plan-driven execution or data-bounded analysis → `medium`
-- Orchestration, planning, adversarial review, or architecture advisory → `high`
-
-If the agent uses `claude-haiku-4-5`, omit the `effort` field entirely — it has no effect on that model.


### PR DESCRIPTION
Assigns an explicit effort field to every agent's frontmatter, letting Claude allocate its thinking budget proportionally to each agent's role complexity — lightweight intake clerks get low, deep architectural reasoners get high. This makes token spend more predictable and avoids over-thinking on simple dispatch tasks. Updates docs/AGENTS.md to document the effort field and list each agent's assigned level.