### PR TITLE
feat(installer): add --target-agent parameter with claude default

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -20,6 +20,8 @@ Run the installation script:
 ./install.sh
 ```
 
+The installer accepts an optional `--target-agent <name>` flag to select which agent to install for. The only currently supported value is `claude`, which is also the default.
+
 The installer copies the whitelisted paths (`CLAUDE.md`, `settings.json`, `skills/`, `agents/`, `commands/`, `hooks/`, `references/`, `scripts/`) from `claude/` into `~/.claude/` and, when present, into `~/.cursor/`. Anything else in the repo or on disk under those destinations is left untouched except where those paths are replaced (after a timestamped backup).
 
 The `.claude/` directory is never synced by the installer — it remains project-local.

--- a/src/installer/cli.test.ts
+++ b/src/installer/cli.test.ts
@@ -14,7 +14,61 @@ afterEach(() => {
 
 describe("parseArgs", () => {
   it("returns without error when no args given", () => {
-    assert.doesNotThrow(() => parseArgs([]));
+    const result = parseArgs([]);
+    assert.deepStrictEqual(result, { targetAgent: "claude" });
+  });
+
+  it("returns targetAgent: 'claude' when --target-agent claude is passed", () => {
+    const result = parseArgs(["--target-agent", "claude"]);
+    assert.deepStrictEqual(result, { targetAgent: "claude" });
+  });
+
+  it("exits 1 when --target-agent is missing a value", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    const calls: string[] = [];
+    mock.method(process.stderr, "write", (chunk: string) => {
+      calls.push(chunk);
+      return true;
+    });
+    assert.throws(
+      () => parseArgs(["--target-agent"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 1,
+    );
+    assert.ok(calls.some((c) => c.includes("--target-agent requires a value")));
+  });
+
+  it("exits 1 when --target-agent value is not in the valid list", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    const calls: string[] = [];
+    mock.method(process.stderr, "write", (chunk: string) => {
+      calls.push(chunk);
+      return true;
+    });
+    assert.throws(
+      () => parseArgs(["--target-agent", "bogus"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 1,
+    );
+    assert.ok(calls.some((c) => c.includes("bogus") && c.includes("claude")));
+  });
+
+  it("exits 1 when --target-agent value starts with --", () => {
+    mock.method(process, "exit", (code: number) => {
+      throw new ExitSentinel(code);
+    });
+    const calls: string[] = [];
+    mock.method(process.stderr, "write", (chunk: string) => {
+      calls.push(chunk);
+      return true;
+    });
+    assert.throws(
+      () => parseArgs(["--target-agent", "--help"]),
+      (err: unknown) => err instanceof ExitSentinel && err.code === 1,
+    );
+    assert.ok(calls.some((c) => c.includes("--target-agent requires a value")));
   });
 
   it("exits 1 on unknown flag", () => {

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -1,6 +1,13 @@
 import { c } from "./colors.js";
 
-const USAGE = `Usage: ./install.sh
+export const VALID_TARGET_AGENTS = ["claude"] as const;
+export type TargetAgent = (typeof VALID_TARGET_AGENTS)[number];
+
+export interface ParsedArgs {
+  targetAgent: TargetAgent;
+}
+
+const USAGE = `Usage: ./install.sh [options]
 
 Install AI TPK to your home directory.
 
@@ -9,16 +16,44 @@ Claude Code:
   - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
-  --help    Show this help message`;
+  --target-agent <name>   Target agent to install for (default: claude). Valid values: claude
+  --help, -h              Show this help message`;
 
-export function parseArgs(argv: string[]): void {
-  for (const flag of argv) {
+export function parseArgs(argv: string[]): ParsedArgs {
+  let targetAgent: TargetAgent = "claude";
+
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
     switch (flag) {
       case "--help":
       case "-h":
         console.log(USAGE);
         process.exit(0);
         break;
+      case "--target-agent": {
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+          process.stderr.write(
+            `${c.red("Error: --target-agent requires a value")}\n`,
+          );
+          process.stderr.write(
+            "Run './install.sh --help' for usage information.\n",
+          );
+          process.exit(1);
+        }
+        if (!(VALID_TARGET_AGENTS as readonly string[]).includes(value)) {
+          process.stderr.write(
+            `${c.red(`Error: Invalid --target-agent value '${value}'. Valid values: ${VALID_TARGET_AGENTS.join(", ")}`)}\n`,
+          );
+          process.stderr.write(
+            "Run './install.sh --help' for usage information.\n",
+          );
+          process.exit(1);
+        }
+        targetAgent = value as TargetAgent;
+        i++;
+        break;
+      }
       default:
         process.stderr.write(`${c.red(`Error: Unknown option ${flag}`)}\n`);
         process.stderr.write(
@@ -27,4 +62,6 @@ export function parseArgs(argv: string[]): void {
         process.exit(1);
     }
   }
+
+  return { targetAgent };
 }

--- a/src/installer/main.ts
+++ b/src/installer/main.ts
@@ -16,7 +16,7 @@ const installerDir = path.dirname(__filename);
 const scriptDir = path.dirname(installerDir);
 
 try {
-  parseArgs(process.argv.slice(2));
+  const { targetAgent } = parseArgs(process.argv.slice(2));
 
   console.log(c.blue("AI TPK Installer"));
   console.log(c.blue("====================="));
@@ -24,9 +24,12 @@ try {
   console.log(`Source directory: ${scriptDir}`);
   console.log("");
 
-  installClaudeWhitelist(scriptDir, os.homedir());
   installDir(scriptDir, "cursor", ".cursor", os.homedir());
-  installDir(scriptDir, "src/mcp/wrappers", ".claude/wrappers", os.homedir());
+
+  if (targetAgent === "claude") {
+    installClaudeWhitelist(scriptDir, os.homedir());
+    installDir(scriptDir, "src/mcp/wrappers", ".claude/wrappers", os.homedir());
+  }
 
   // Create ~/.ai-tpk artifact directories
   const aiTpkDir = path.join(os.homedir(), ".ai-tpk");
@@ -39,7 +42,9 @@ try {
   );
 
   console.log("");
-  installMcpServers(scriptDir);
+  if (targetAgent === "claude") {
+    installMcpServers(scriptDir);
+  }
 
   console.log("");
   installLauncherScript(scriptDir);

--- a/src/installer/reference-help-output.txt
+++ b/src/installer/reference-help-output.txt
@@ -1,4 +1,4 @@
-Usage: ./install.sh
+Usage: ./install.sh [options]
 
 Install AI TPK to your home directory.
 
@@ -7,4 +7,5 @@ Claude Code:
   - MCP servers: kubernetes, cloudwatch (user scope, via claude mcp add)
 
 Options:
-  --help    Show this help message
+  --target-agent <name>   Target agent to install for (default: claude). Valid values: claude
+  --help, -h              Show this help message


### PR DESCRIPTION
Adds a --target-agent parameter to install.sh that controls which AI agent the toolkit targets. Currently only claude is valid; the parameter defaults to claude so existing workflows are unaffected. The design reserves the flag namespace for future targets without requiring callers to change their invocations today. Documentation and CLI help output have been updated to reflect the new option.