### PR TITLE
refactor(agents): remove inline verdict labels, defer to verdict-taxonomy.md

### DIFF
--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -191,7 +191,7 @@ See `claude/references/verdict-taxonomy.md`. Apply through the lens of complexit
 - Identify over-engineered steps and unnecessary complexity
 - Propose simpler alternatives that achieve core objectives
 - Challenge assumptions about what's "needed"
-- Issue verdict: ACCEPT (minimal), REVISE (too complex), REJECT (fundamentally over-engineered)
+- Issue a verdict per `claude/references/verdict-taxonomy.md`
 - Provide specific step-by-step simplification recommendations
 
 **For implementation reviews:**

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -169,7 +169,7 @@ Permitted tools include Grep for pattern detection, Bash for dependency audits, 
 
 ### Security Review Summary
 - **Artifact**: Plan file reviewed
-- **Verdict**: REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT
+- **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Risk Level**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X security gaps identified
 
@@ -192,7 +192,7 @@ Why this verdict was chosen based on identified security risks.
 
 ### Security Review Summary
 - **Scope**: Components, files, and attack surface reviewed
-- **Verdict**: REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT
+- **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Overall Risk Level**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X CRITICAL, Y HIGH, Z MEDIUM vulnerabilities
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -199,7 +199,7 @@ Structure every review as follows:
 
 ### Review Summary
 - **Artifact**: What was reviewed
-- **Verdict**: REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT
+- **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Mode**: Standard | Adversarial
 - **Findings**: X CRITICAL, Y MAJOR, Z MINOR
 - **Specialist Review Recommended**: None | Riskmancer | Windwarden | Knotcutter | Truthhammer | Multiple (comma-separated)

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -183,7 +183,7 @@ Structure every review as follows:
 
 ### Factual Validation Summary
 - **Artifact**: What was reviewed (plan file or code files)
-- **Verdict**: REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT
+- **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Confidence Level**: HIGH (multiple sources confirmed) | MEDIUM (single source confirmed) | LOW (limited verification possible)
 - **Findings**: X CRITICAL, Y HIGH, Z MEDIUM, W LOW
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -219,7 +219,7 @@ Structure every review as follows:
 
 ### Performance Review Summary
 - **Artifact**: What was reviewed (plan file or code files)
-- **Verdict**: REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT
+- **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Performance Impact**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X CRITICAL, Y HIGH, Z MEDIUM, W LOW
 


### PR DESCRIPTION
Each of the five reviewer agents (Ruinor, Riskmancer, Windwarden, Truthhammer, Knotcutter) restated the full verdict enum (`REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT`) inline in their Output Format sections despite `verdict-taxonomy.md` already being the canonical source. This creates a maintenance hazard: any taxonomy change requires updating six files instead of one. The fix removes the six inline enumerations and replaces each with a pointer to `claude/references/verdict-taxonomy.md`. As a bonus, Knotcutter's old list omitted `ACCEPT-WITH-RESERVATIONS` — this incidentally aligns it with the full 4-verdict taxonomy. Closes #206.