### PR TITLE
refactor(commands): replace inline standalone-Bash rule with bash-style.md reference

### DIFF
--- a/.claude/commands/build-and-install.md
+++ b/.claude/commands/build-and-install.md
@@ -3,7 +3,7 @@ description: Rebuild dist/installer.js, reinstall all project artifacts to ~/.cl
 ---
 
 You are rebuilding and reinstalling all project artifacts. Follow every step below in order.
-Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+All Bash commands must follow `~/.claude/references/bash-style.md`.
 
 ## Step 1 — Resolve repo root
 

--- a/claude/commands/address-pr-comments.md
+++ b/claude/commands/address-pr-comments.md
@@ -5,8 +5,8 @@ description: Address unresolved inline PR review comments -- fetch, reason, prop
 You are addressing unresolved inline review comments on a GitHub pull request. For each
 unresolved thread you will display the reviewer's context, read the current file state,
 reason about the comment, categorize it, draft a reply, and present it for approval before
-posting. Follow every step below in order. Run each command as a standalone call -- do not
-chain commands with `&&`, `;`, or `|`.
+posting. Follow every step below in order. All Bash commands must follow
+`~/.claude/references/bash-style.md`.
 
 ## Step 1 -- Parse arguments and generate session timestamp
 

--- a/claude/commands/clean-ai-tpk-artifacts.md
+++ b/claude/commands/clean-ai-tpk-artifacts.md
@@ -3,7 +3,7 @@ description: Delete plan and lesson files older than N days from ~/.ai-tpk/ for 
 ---
 
 You are cleaning up stale artifact files from `~/.ai-tpk/`. Follow every step below in order.
-Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+All Bash commands must follow `~/.claude/references/bash-style.md`.
 
 **Note for DM:** Steps that perform write operations (file deletions) must be delegated to
 Bitsmith per the DM delegation policy. Those steps are marked below.

--- a/claude/commands/clean-the-desk.md
+++ b/claude/commands/clean-the-desk.md
@@ -3,7 +3,7 @@ description: Delete local branches whose PRs have been merged, and remove their 
 ---
 
 You are cleaning up stale local branches and their associated worktrees. Follow every step below
-in order. Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+in order. All Bash commands must follow `~/.claude/references/bash-style.md`.
 
 **Note for DM:** Steps that perform write operations (file edits, destructive git commands) must
 be delegated to Bitsmith per the DM delegation policy. Those steps are marked below.

--- a/claude/commands/merge-pr.md
+++ b/claude/commands/merge-pr.md
@@ -3,8 +3,8 @@ description: Sync the current PR branch with main, wait for CI checks, squash-me
 ---
 
 You are squash-merging the current PR branch after ensuring it is in sync with `main` and all
-required CI checks have passed. Follow every step below in order. Run each command as a
-standalone call — do not chain commands with `&&`, `;`, or `|`.
+required CI checks have passed. Follow every step below in order. All Bash commands must follow
+`~/.claude/references/bash-style.md`.
 
 **Note for DM:** Steps that perform write operations (destructive git commands, merge operations)
 must be delegated to Bitsmith per the DM delegation policy. Those steps are marked below.

--- a/claude/commands/merged.md
+++ b/claude/commands/merged.md
@@ -4,8 +4,8 @@ description: Clean up the worktree and local branch for a PR that has been merge
 
 You are cleaning up after a merged pull request. This command discovers which worktree and
 branch to remove, then performs the cleanup (prompting only when multiple candidates are
-found). Follow every step below
-in order. Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+found). Follow every step below in order. All Bash commands must follow
+`~/.claude/references/bash-style.md`.
 
 **Note for DM:** Steps that perform write operations (destructive git commands) must be
 delegated to Bitsmith per the DM delegation policy. Those steps are marked below.

--- a/claude/commands/resolve-conflicts.md
+++ b/claude/commands/resolve-conflicts.md
@@ -4,7 +4,7 @@ description: Resolve merge conflicts during an in-progress rebase
 
 You are resolving merge conflicts during a rebase that has stopped due to conflicts. This
 command handles conflict detection, file-by-file resolution, staging, and `rebase --continue`
-cycling. Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+cycling. All Bash commands must follow `~/.claude/references/bash-style.md`.
 
 **Note for DM:** This command performs write operations (file edits, git staging, rebase
 continuation). When invoked standalone, delegate execution to Bitsmith per the DM delegation

--- a/claude/commands/review-pr.md
+++ b/claude/commands/review-pr.md
@@ -3,7 +3,7 @@ description: Run the local Ruinor + specialist review pipeline against a GitHub 
 ---
 
 You are running the local review pipeline against a GitHub pull request. Follow every step below in
-order. Run each command as a standalone call — do not chain commands with `&&`, `;`, or `|`.
+order. All Bash commands must follow `~/.claude/references/bash-style.md`.
 
 **Conventions:**
 - This command does NOT post anything to GitHub. v1 is review-only; posting is deferred to a future `/review-pr-post` command.

--- a/claude/commands/sync-pr.md
+++ b/claude/commands/sync-pr.md
@@ -3,8 +3,8 @@ description: Rebase the current PR branch onto main and force-push to keep the P
 ---
 
 You are rebasing the current PR branch onto the latest `main` and force-pushing to keep the PR
-in sync. Follow every step below in order. Run each command as a standalone call — do not chain
-commands with `&&`, `;`, or `|`.
+in sync. Follow every step below in order. All Bash commands must follow
+`~/.claude/references/bash-style.md`.
 
 **Note for DM:** Steps that perform write operations (file edits, destructive git commands) must
 be delegated to Bitsmith per the DM delegation policy. Those steps are marked below.


### PR DESCRIPTION
Fixes a DRY violation (#205) where the standalone-Bash-call rule was restated verbatim inside nine command files. Each restatement is replaced with a single reference line pointing to `~/.claude/references/bash-style.md`, making `bash-style.md` the single source of truth for this constraint.

`review-pr.md` was brought into scope because it contained the rule but was not listed in the original issue (it was added in #274 after #205 was filed). Five files from the issue were left untouched — they did not contain the rule.

Closes #205