### PR TITLE
feat(installer): add dynamic multi-account GitHub MCP support

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -26,6 +26,8 @@ The installer copies the whitelisted paths (`CLAUDE.md`, `settings.json`, `skill
 
 The `.claude/` directory is never synced by the installer — it remains project-local.
 
+**GitHub MCP setup:** To enable multi-account GitHub MCP servers, create `~/.config/github-pats.json` before (or after) running `install.sh` and set its mode to `0600`. See [docs/MCP.md § Server Roster](/docs/MCP.md#server-roster) for the file format, key naming rules, and operational details.
+
 ## Development Setup
 
 To contribute to this repository, you'll need to set up the development environment:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -11,7 +11,19 @@ Currently configured servers:
 - **Kubernetes MCP Server** (`mcp-server-kubernetes@3.4.0`) — Read-only Kubernetes cluster access via `~/.kube/config`. Skips setup gracefully if that file does not exist.
 - **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) — CloudWatch Metrics, Alarms, and Logs access via `~/.aws` credentials. Uses `src/mcp/wrappers/mcp-cloudwatch.sh` for dynamic AWS profile selection (set with `/set-aws-profile`). Requires `uvx`. Skips setup gracefully if `~/.aws/credentials` does not exist.
 - **Grafana MCP Server** (`mcp-grafana`) — Grafana dashboards, datasources, and incident access. Uses `src/mcp/wrappers/mcp-grafana.sh`, which requires `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` in the shell environment.
-- **GitHub MCP Server** (`@modelcontextprotocol/server-github`) — GitHub repository, issue, PR, and code search access. Requires `GITHUB_PERSONAL_ACCESS_TOKEN` set in `src/mcp/mcp-servers.json` before running `install.sh`. Note: the npm package was archived 2025-05-29; the Docker-based successor (`ghcr.io/github/github-mcp-server`) is not used here to avoid a Docker dependency.
+- **GitHub MCP Server** (`@modelcontextprotocol/server-github@2025.4.8`) — Multi-account GitHub repository, issue, PR, and code search access via `~/.config/github-pats.json`. Define your accounts as a flat JSON object mapping account names to PATs:
+  ```json
+  {"personal": "ghp_xxx", "work": "ghp_yyy"}
+  ```
+  **Set the file mode to `0600` immediately after creation: `chmod 600 ~/.config/github-pats.json`.** The file holds long-lived GitHub PATs in plaintext; on multi-user hosts a default umask (`022`) leaves it world-readable. The wrapper refuses to read the file at MCP-server boot if the mode is broader than `0600`, and the installer prints a warning.
+
+  Each key becomes the suffix of a registered MCP server (`github-personal`, `github-work`) and a tool namespace (`mcp__github-personal__*`, `mcp__github-work__*`). Account keys must match `^[a-zA-Z0-9_.-]+$`.
+
+  The wrapper at `~/.claude/wrappers/mcp-github.sh` selects the token at runtime via the `GITHUB_ACCOUNT` env var injected by the installer. **The PAT is not stored in `~/.claude.json`**; rotating the token in `~/.config/github-pats.json` takes effect on the next MCP server boot without re-running `install.sh`.
+
+  The wrapper invokes **`pnpx`** (pnpm's equivalent of the npm runner) because this repository uses pnpm. Users without pnpm installed must install it (<https://pnpm.io/installation>) before GitHub MCP servers can spawn. The wrapper pins `@modelcontextprotocol/server-github@2025.4.8` to protect against any future "latest" publish on the abandoned package name (archived 2025-05-29; the Docker-based successor `ghcr.io/github/github-mcp-server` is not used here to avoid a Docker dependency).
+
+  If `~/.config/github-pats.json` is missing or empty (`{}`) at install time, GitHub MCP setup is skipped with a yellow warning and installation continues. On each run, the installer also removes the legacy `github` (no suffix) registration, removes stale `github-<key>` registrations, and removes stale `mcp__github-<key>__*` allow-list entries for keys no longer present in the PATs file.
 - **GCP Observability MCP Server** (`@google-cloud/observability-mcp@0.2.3`) — Read-only access to GCP Cloud Logging, Monitoring, Trace, and Error Reporting. Requires Node.js 20+ and the gcloud CLI. Authenticate before running `install.sh`: `gcloud auth application-default login` then `gcloud auth application-default set-quota-project YOUR_PROJECT_ID`.
 
 MCP servers are available in all repositories once configured.

--- a/src/installer/mcp.test.ts
+++ b/src/installer/mcp.test.ts
@@ -10,6 +10,11 @@ import {
   computeConfigSignature,
   readStamps,
   writeStamps,
+  registerGithubAccounts,
+  removeStaleGithubRegistrations,
+  removeLegacyGithubRegistration,
+  assertWrappersDirNotWorldWritable,
+  updateGithubAllowList,
 } from "./mcp.js";
 
 // ---------------------------------------------------------------------------
@@ -537,5 +542,694 @@ describe("writeStamps", () => {
   it("does not throw when path is unwritable", () => {
     const stampsPath = path.join(tmpDir, "no", "such", "dir", "stamps.json");
     assert.doesNotThrow(() => writeStamps(stampsPath, { key: "value" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for GitHub multi-account tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a fake homedir with the necessary directory structure.
+ * Returns the path to the fake homedir.
+ */
+function makeFakeHome(): string {
+  const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-gh-"));
+  fs.mkdirSync(path.join(fakeHome, ".config"), { recursive: true });
+  fs.mkdirSync(path.join(fakeHome, ".claude", "wrappers"), { recursive: true });
+  return fakeHome;
+}
+
+/**
+ * Writes a github-pats.json to the fake home's .config directory and sets
+ * the given octal mode on it.
+ */
+function writePatsFile(
+  fakeHome: string,
+  contents: unknown,
+  mode: number = 0o600,
+): string {
+  const patsPath = path.join(fakeHome, ".config", "github-pats.json");
+  fs.writeFileSync(patsPath, JSON.stringify(contents), "utf8");
+  fs.chmodSync(patsPath, mode);
+  return patsPath;
+}
+
+/** Captured spawnSync call record. */
+interface SpawnCall {
+  cmd: string;
+  args: string[];
+}
+
+/**
+ * Replaces execFileSync with a stub that records calls and optionally
+ * throws on certain command patterns. Returns the call log and a restore fn.
+ *
+ * The stub is injected via the module-level override pattern: we monkey-patch
+ * the `child_process` module's execFileSync by temporarily replacing it on
+ * the mcp module's internal binding. Because the TypeScript source imports
+ * execFileSync as a named import at module load time, we cannot replace it
+ * after the fact. Instead, we pass a `spawnFn` override to functions that
+ * accept it (registerGithubAccounts etc. accept an optional last parameter).
+ */
+
+// ---------------------------------------------------------------------------
+// removeLegacyGithubRegistration
+// ---------------------------------------------------------------------------
+
+/** Stub that always throws — used to assert error-tolerance. */
+function alwaysThrowStub(_cmd: string, _args: string[]): void {
+  throw new Error("command failed");
+}
+
+/** No-op stub — used in tests that only check thrown errors and don't need call capture. */
+function noOpStub(_cmd: string, _args: string[]): void {
+  // intentionally empty
+}
+
+describe("removeLegacyGithubRegistration", () => {
+  it("invokes claude mcp remove -s user github exactly once", () => {
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+    };
+
+    removeLegacyGithubRegistration(stub);
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0], {
+      cmd: "claude",
+      args: ["mcp", "remove", "-s", "user", "github"],
+    });
+  });
+
+  it("does not throw when the command fails (legacy registration absent)", () => {
+    assert.doesNotThrow(() => removeLegacyGithubRegistration(alwaysThrowStub));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertWrappersDirNotWorldWritable
+// ---------------------------------------------------------------------------
+
+describe("assertWrappersDirNotWorldWritable", () => {
+  it("is silent when wrappers dir mode is 0755", () => {
+    const fakeHome = makeFakeHome();
+    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    fs.chmodSync(wrappersDir, 0o755);
+
+    const warnings: string[] = [];
+    assertWrappersDirNotWorldWritable(fakeHome, (msg) => warnings.push(msg));
+
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it("prints warning when wrappers dir mode is 0775 (group-writable)", () => {
+    const fakeHome = makeFakeHome();
+    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    fs.chmodSync(wrappersDir, 0o775);
+
+    const warnings: string[] = [];
+    assertWrappersDirNotWorldWritable(fakeHome, (msg) => warnings.push(msg));
+
+    assert.ok(warnings.length > 0, "expected at least one warning");
+    assert.ok(
+      warnings.some((w) => w.includes("wrappers")),
+      `expected 'wrappers' in warning, got: ${warnings.join(", ")}`,
+    );
+  });
+
+  it("prints warning when wrappers dir mode is 0777 (world-writable)", () => {
+    const fakeHome = makeFakeHome();
+    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    fs.chmodSync(wrappersDir, 0o777);
+
+    const warnings: string[] = [];
+    assertWrappersDirNotWorldWritable(fakeHome, (msg) => warnings.push(msg));
+
+    assert.ok(warnings.length > 0, "expected at least one warning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerGithubAccounts
+// ---------------------------------------------------------------------------
+
+describe("registerGithubAccounts", () => {
+  it("registers one server per key in sorted order with only GITHUB_ACCOUNT env, no PAT in argv", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, { work: "ghp_b", personal: "ghp_a" });
+
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+    };
+
+    const result = registerGithubAccounts(fakeHome, stub);
+
+    // Should have registered 2 accounts (each: remove + add = 2 calls per account)
+    const addCalls = calls.filter(
+      (c) => c.cmd === "claude" && c.args.includes("add"),
+    );
+    assert.strictEqual(addCalls.length, 2, "expected exactly 2 mcp add calls");
+
+    // Sorted order: personal before work
+    const firstAdd = addCalls[0]!;
+    const secondAdd = addCalls[1]!;
+    assert.ok(
+      firstAdd.args.includes("github-personal"),
+      `expected first add to be for 'personal', got: ${JSON.stringify(firstAdd.args)}`,
+    );
+    assert.ok(
+      secondAdd.args.includes("github-work"),
+      `expected second add to be for 'work', got: ${JSON.stringify(secondAdd.args)}`,
+    );
+
+    // Each add must contain -e GITHUB_ACCOUNT=<key>
+    assert.ok(
+      firstAdd.args.includes("-e") &&
+        firstAdd.args.includes("GITHUB_ACCOUNT=personal"),
+      `expected GITHUB_ACCOUNT=personal in argv: ${JSON.stringify(firstAdd.args)}`,
+    );
+    assert.ok(
+      secondAdd.args.includes("-e") &&
+        secondAdd.args.includes("GITHUB_ACCOUNT=work"),
+      `expected GITHUB_ACCOUNT=work in argv: ${JSON.stringify(secondAdd.args)}`,
+    );
+
+    // No GITHUB_PERSONAL_ACCESS_TOKEN anywhere in any call's args
+    for (const call of calls) {
+      for (const arg of call.args) {
+        assert.ok(
+          !arg.includes("GITHUB_PERSONAL_ACCESS_TOKEN"),
+          `found GITHUB_PERSONAL_ACCESS_TOKEN in argv: ${JSON.stringify(call.args)}`,
+        );
+      }
+    }
+
+    // No PAT values in any arg
+    for (const call of calls) {
+      for (const arg of call.args) {
+        assert.ok(
+          !arg.includes("ghp_a") && !arg.includes("ghp_b"),
+          `found PAT value in argv: ${JSON.stringify(call.args)}`,
+        );
+      }
+    }
+
+    // Wrapper path resolves to fakeHome/.claude/wrappers/mcp-github.sh
+    const expectedWrapperPath = path.join(
+      fakeHome,
+      ".claude",
+      "wrappers",
+      "mcp-github.sh",
+    );
+    assert.ok(
+      firstAdd.args.includes(expectedWrapperPath),
+      `expected wrapper path in add args: ${JSON.stringify(firstAdd.args)}`,
+    );
+
+    // Returns the set of registered keys
+    assert.deepStrictEqual(result, new Set(["personal", "work"]));
+  });
+
+  it("returns empty set and prints warning when github-pats.json is absent", () => {
+    const fakeHome = makeFakeHome();
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    const warnings: string[] = [];
+    const result = registerGithubAccounts(fakeHome, stub, (msg) =>
+      warnings.push(msg),
+    );
+
+    assert.deepStrictEqual(result, new Set());
+    assert.ok(
+      warnings.some((w) => w.includes("not found")),
+      `expected 'not found' warning, got: ${warnings.join(", ")}`,
+    );
+    const addCalls = calls.filter((c) => c.args.includes("add"));
+    assert.strictEqual(addCalls.length, 0);
+  });
+
+  it("returns empty set and prints warning when github-pats.json is empty object", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, {});
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    const warnings: string[] = [];
+    const result = registerGithubAccounts(fakeHome, stub, (msg) =>
+      warnings.push(msg),
+    );
+
+    assert.deepStrictEqual(result, new Set());
+    assert.ok(
+      warnings.some((w) => w.includes("empty")),
+      `expected 'empty' warning, got: ${warnings.join(", ")}`,
+    );
+    const addCalls = calls.filter((c) => c.args.includes("add"));
+    assert.strictEqual(addCalls.length, 0);
+  });
+
+  it("throws on invalid JSON and error message does not include file contents", () => {
+    const fakeHome = makeFakeHome();
+    const patsPath = path.join(fakeHome, ".config", "github-pats.json");
+    fs.writeFileSync(patsPath, "not-valid-json-{{{", "utf8");
+    fs.chmodSync(patsPath, 0o600);
+
+    assert.throws(
+      () => registerGithubAccounts(fakeHome, noOpStub),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        // Must not include file contents
+        assert.ok(
+          !err.message.includes("not-valid-json"),
+          `error message must not include file contents, got: ${err.message}`,
+        );
+        // Must include path
+        assert.ok(
+          err.message.includes("github-pats.json"),
+          `error message must include path, got: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws when PAT value is a number, error identifies key only not value", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, { personal: 123 });
+
+    assert.throws(
+      () => registerGithubAccounts(fakeHome, noOpStub),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          err.message.includes("personal"),
+          `expected key name in error: ${err.message}`,
+        );
+        assert.ok(
+          !err.message.includes("123"),
+          `must not include value '123' in error: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws when PAT value is empty string, error identifies key only", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, { personal: "" });
+
+    assert.throws(
+      () => registerGithubAccounts(fakeHome, noOpStub),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.ok(
+          err.message.includes("personal"),
+          `expected key name in error: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws when key contains invalid characters", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, { "per sonal": "ghp_x" });
+
+    assert.throws(
+      () => registerGithubAccounts(fakeHome, noOpStub),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        return true;
+      },
+    );
+  });
+
+  it("prints mode warning when github-pats.json mode is 0644 but continues to register", () => {
+    const fakeHome = makeFakeHome();
+    writePatsFile(fakeHome, { personal: "ghp_a" }, 0o644);
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    const warnings: string[] = [];
+    registerGithubAccounts(fakeHome, stub, (msg) => warnings.push(msg));
+
+    assert.ok(
+      warnings.some((w) => w.includes("644") || w.includes("0644")),
+      `expected mode warning, got: ${warnings.join(", ")}`,
+    );
+    const addCalls = calls.filter((c) => c.args.includes("add"));
+    assert.strictEqual(addCalls.length, 1, "should still register 1 account");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeStaleGithubRegistrations
+// ---------------------------------------------------------------------------
+
+describe("removeStaleGithubRegistrations", () => {
+  it("removes stale github-old but not desired github-personal or unrelated grafana", () => {
+    const fakeHome = makeFakeHome();
+    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    fs.writeFileSync(
+      claudeJsonPath,
+      JSON.stringify({
+        mcpServers: {
+          "github-old": { type: "stdio", command: "/some/wrapper" },
+          "github-personal": { type: "stdio", command: "/some/wrapper" },
+          grafana: { type: "stdio", command: "/some/wrapper" },
+        },
+      }),
+      "utf8",
+    );
+
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    removeStaleGithubRegistrations(new Set(["personal"]), fakeHome, stub);
+
+    const removeCalls = calls.filter(
+      (c) => c.cmd === "claude" && c.args.includes("remove"),
+    );
+    assert.strictEqual(removeCalls.length, 1, "expected exactly 1 remove call");
+    assert.ok(
+      removeCalls[0]!.args.includes("github-old"),
+      `expected github-old to be removed, got: ${JSON.stringify(removeCalls[0]!.args)}`,
+    );
+
+    // Assert grafana and github-personal not removed
+    for (const call of removeCalls) {
+      assert.ok(!call.args.includes("grafana"), "must not remove grafana");
+      assert.ok(
+        !call.args.includes("github-personal"),
+        "must not remove github-personal (still desired)",
+      );
+    }
+  });
+
+  it("removes stale github-my_account (underscore suffix, F-10 mirror)", () => {
+    const fakeHome = makeFakeHome();
+    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    fs.writeFileSync(
+      claudeJsonPath,
+      JSON.stringify({
+        mcpServers: {
+          "github-my_account": { type: "stdio", command: "/some/wrapper" },
+        },
+      }),
+      "utf8",
+    );
+
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    removeStaleGithubRegistrations(new Set(["personal"]), fakeHome, stub);
+
+    const removeCalls = calls.filter(
+      (c) => c.cmd === "claude" && c.args.includes("remove"),
+    );
+    assert.strictEqual(removeCalls.length, 1);
+    assert.ok(removeCalls[0]!.args.includes("github-my_account"));
+  });
+
+  it("does not remove the legacy github (no hyphen suffix) server", () => {
+    const fakeHome = makeFakeHome();
+    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    fs.writeFileSync(
+      claudeJsonPath,
+      JSON.stringify({
+        mcpServers: {
+          github: { type: "stdio", command: "/some/wrapper" },
+        },
+      }),
+      "utf8",
+    );
+
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    removeStaleGithubRegistrations(new Set(), fakeHome, stub);
+
+    const removeCalls = calls.filter(
+      (c) => c.cmd === "claude" && c.args.includes("remove"),
+    );
+    assert.strictEqual(
+      removeCalls.length,
+      0,
+      "legacy github should not be removed by removeStale (removeLegacy handles it)",
+    );
+  });
+
+  it("returns silently when ~/.claude.json is absent", () => {
+    const fakeHome = makeFakeHome();
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+
+    assert.doesNotThrow(() =>
+      removeStaleGithubRegistrations(new Set(), fakeHome, stub),
+    );
+    assert.strictEqual(calls.length, 0);
+  });
+
+  it("prints yellow warning and returns without throwing when ~/.claude.json is malformed", () => {
+    const fakeHome = makeFakeHome();
+    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    fs.writeFileSync(claudeJsonPath, "not-valid-json", "utf8");
+
+    const calls: SpawnCall[] = [];
+    const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
+    const warnings: string[] = [];
+
+    assert.doesNotThrow(() =>
+      removeStaleGithubRegistrations(new Set(), fakeHome, stub, (msg) =>
+        warnings.push(msg),
+      ),
+    );
+    assert.ok(
+      warnings.some(
+        (w) => w.includes("invalid JSON") || w.includes("claude.json"),
+      ),
+      `expected warning about invalid JSON, got: ${warnings.join(", ")}`,
+    );
+    assert.strictEqual(calls.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateGithubAllowList
+// ---------------------------------------------------------------------------
+
+describe("updateGithubAllowList", () => {
+  /** Creates a settings.json with an allowedTools array (and optional extra tools). */
+  function writeSettings(
+    fakeHome: string,
+    allowedTools: string[],
+    extra: Record<string, unknown> = {},
+  ): string {
+    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    const content = { allowedTools, ...extra };
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(content, null, 2) + "\n",
+      "utf8",
+    );
+    return settingsPath;
+  }
+
+  function readSettings(fakeHome: string): Record<string, unknown> {
+    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    return JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it("adds mcp__github-personal__* and mcp__github-work__* in sorted order", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, ["Bash(git *)"]);
+
+    updateGithubAllowList(new Set(["work", "personal"]), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    assert.ok(tools.includes("mcp__github-personal__*"));
+    assert.ok(tools.includes("mcp__github-work__*"));
+    // sorted: personal before work when appended
+    const piIdx = tools.indexOf("mcp__github-personal__*");
+    const wiIdx = tools.indexOf("mcp__github-work__*");
+    assert.ok(piIdx < wiIdx, "personal should appear before work (sorted)");
+    // Unrelated entry preserved
+    assert.ok(tools.includes("Bash(git *)"));
+  });
+
+  it("is idempotent: calling twice with same input produces byte-identical output", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, ["Bash(git *)"]);
+
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    const after1 = fs.readFileSync(settingsPath, "utf8");
+
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    const after2 = fs.readFileSync(settingsPath, "utf8");
+
+    assert.strictEqual(
+      after1,
+      after2,
+      "file must be byte-identical on second run",
+    );
+  });
+
+  it("removes stale mcp__github-old__* when key is no longer in desired set", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, ["mcp__github-old__*", "Bash(git *)"]);
+
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    assert.ok(
+      !tools.includes("mcp__github-old__*"),
+      "stale entry must be removed",
+    );
+    assert.ok(
+      tools.includes("mcp__github-personal__*"),
+      "new entry must be added",
+    );
+    assert.ok(
+      tools.includes("Bash(git *)"),
+      "unrelated entry must be preserved",
+    );
+  });
+
+  it("removes mcp__github-my_account__* (underscore in key, F-10)", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, ["mcp__github-my_account__*", "Bash(git *)"]);
+
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    assert.ok(
+      !tools.includes("mcp__github-my_account__*"),
+      "underscore-suffix stale entry must be removed",
+    );
+    assert.ok(tools.includes("mcp__github-personal__*"));
+  });
+
+  it("removes multi-character-class entries (dots, dashes, underscores) when desired set is empty", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, [
+      "mcp__github-foo.bar__*",
+      "mcp__github-foo-bar__*",
+      "mcp__github-foo_bar__*",
+      "Bash(git *)",
+    ]);
+
+    updateGithubAllowList(new Set(), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    assert.ok(!tools.includes("mcp__github-foo.bar__*"));
+    assert.ok(!tools.includes("mcp__github-foo-bar__*"));
+    assert.ok(!tools.includes("mcp__github-foo_bar__*"));
+    assert.ok(tools.includes("Bash(git *)"));
+  });
+
+  it("removes github entry when desired set is empty", () => {
+    const fakeHome = makeFakeHome();
+    writeSettings(fakeHome, ["mcp__github-foo__*", "Bash(git *)"]);
+
+    updateGithubAllowList(new Set(), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    assert.ok(!tools.includes("mcp__github-foo__*"));
+    assert.ok(tools.includes("Bash(git *)"));
+  });
+
+  it("does not reorder or modify unrelated entries", () => {
+    const fakeHome = makeFakeHome();
+    const originalTools = [
+      "Bash(git *)",
+      "mcp__grafana__search_dashboards",
+      "Write(~/.ai-tpk/**)",
+    ];
+    writeSettings(fakeHome, originalTools);
+
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+
+    const settings = readSettings(fakeHome);
+    const tools = settings["allowedTools"] as string[];
+    // Original entries preserved and in original order
+    const gitIdx = tools.indexOf("Bash(git *)");
+    const grafanaIdx = tools.indexOf("mcp__grafana__search_dashboards");
+    const writeIdx = tools.indexOf("Write(~/.ai-tpk/**)");
+    assert.ok(gitIdx < grafanaIdx, "original order preserved");
+    assert.ok(grafanaIdx < writeIdx, "original order preserved");
+  });
+
+  it("throws when settings file is malformed and does not write", () => {
+    const fakeHome = makeFakeHome();
+    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    fs.writeFileSync(settingsPath, "not-valid-json", "utf8");
+
+    assert.throws(
+      () => updateGithubAllowList(new Set(["personal"]), fakeHome),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        return true;
+      },
+    );
+
+    // File must remain unchanged
+    const onDisk = fs.readFileSync(settingsPath, "utf8");
+    assert.strictEqual(onDisk, "not-valid-json");
+  });
+
+  it("prints warning and returns when settings file does not exist", () => {
+    const fakeHome = makeFakeHome();
+    // Don't write settings file
+    const warnings: string[] = [];
+    assert.doesNotThrow(() =>
+      updateGithubAllowList(new Set(["personal"]), fakeHome, (msg) =>
+        warnings.push(msg),
+      ),
+    );
+    assert.ok(
+      warnings.some((w) => w.includes("settings.json")),
+      `expected warning about missing settings.json, got: ${warnings.join(", ")}`,
+    );
+  });
+
+  it("uses atomic temp+rename write pattern", () => {
+    const fakeHome = makeFakeHome();
+    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    writeSettings(fakeHome, ["Bash(git *)"]);
+
+    // Collect file ops by checking what files are created/modified in the .claude dir
+    // We verify by checking that no .tmp file remains after the call
+    updateGithubAllowList(new Set(["personal"]), fakeHome);
+
+    // The final file must exist and be valid JSON
+    const content = fs.readFileSync(settingsPath, "utf8");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    assert.ok(
+      Array.isArray(parsed["allowedTools"]),
+      "allowedTools must be an array",
+    );
+
+    // No temp files should remain in .claude dir
+    const claudeDir = path.join(fakeHome, ".claude");
+    const entries = fs.readdirSync(claudeDir);
+    const tempFiles = entries.filter((e) => e.includes(".tmp."));
+    assert.strictEqual(
+      tempFiles.length,
+      0,
+      `temp files must be cleaned up, found: ${tempFiles.join(", ")}`,
+    );
   });
 });

--- a/src/installer/mcp.ts
+++ b/src/installer/mcp.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -279,6 +280,456 @@ export function writeStamps(
   }
 }
 
+// ---------------------------------------------------------------------------
+// GitHub multi-account support
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the cross-platform file mode of a path as an octal string.
+ * Returns the mode string (e.g. "600", "755") or null if stat failed.
+ * Uses the same stat fallback chain as the mcp-github.sh wrapper.
+ */
+function readFileModeOctal(filePath: string): string | null {
+  try {
+    return execFileSync("stat", ["-f", "%Lp", filePath], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    try {
+      return execFileSync("stat", ["-c", "%a", filePath], {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * A spawn function type used by the GitHub registration helpers so that tests
+ * can inject a stub without needing to monkey-patch node:child_process.
+ * The function receives the command and args; return value is ignored.
+ * It MUST throw to indicate command failure.
+ */
+type SpawnFn = (cmd: string, args: string[]) => void;
+
+/**
+ * Default spawnFn that calls execFileSync with stdio: "pipe".
+ */
+function defaultSpawn(cmd: string, args: string[]): void {
+  execFileSync(cmd, args, { stdio: "pipe" });
+}
+
+/**
+ * A warn function type used by the GitHub helpers so that tests can capture
+ * warnings instead of printing them to stdout.
+ */
+type WarnFn = (msg: string) => void;
+
+function defaultWarn(msg: string): void {
+  console.log(c.yellow(msg));
+}
+
+/**
+ * Removes the legacy single-account 'github' MCP server registration (no suffix).
+ * Runs unconditionally on every install run as an upgrade migration.
+ * Uses explicit -s user scope flag for symmetry with mcp add calls (F-11).
+ * Ignores failure (the registration may not exist on a fresh install).
+ *
+ * @param spawnFn - Injectable for testing; defaults to execFileSync.
+ */
+export function removeLegacyGithubRegistration(
+  spawnFn: SpawnFn = defaultSpawn,
+): void {
+  try {
+    spawnFn("claude", ["mcp", "remove", "-s", "user", "github"]);
+    console.log(c.green("Removed legacy 'github' MCP registration"));
+  } catch {
+    // Registration was not present — that is fine
+  }
+}
+
+/**
+ * Asserts that ~/.claude/wrappers/ is not group- or world-writable (V-5).
+ * Prints a warning if the directory mode has the group-write or world-write bit set.
+ * This is a warning, not a failure — the user controls their own umask intent.
+ *
+ * @param homedir - Injectable for testing; defaults to os.homedir().
+ * @param warnFn - Injectable for testing; defaults to console.log yellow.
+ */
+export function assertWrappersDirNotWorldWritable(
+  homedir: string = os.homedir(),
+  warnFn: WarnFn = defaultWarn,
+): void {
+  const wrappersDir = path.join(homedir, ".claude", "wrappers");
+  const modeStr = readFileModeOctal(wrappersDir);
+  if (modeStr === null) {
+    // Can't stat the dir — skip silently (may not exist yet on a fresh install)
+    return;
+  }
+  const modeNum = parseInt(modeStr, 8);
+  if (isNaN(modeNum)) {
+    return;
+  }
+  // Check group-write (020) or world-write (002) bits
+  if ((modeNum & 0o022) !== 0) {
+    warnFn(
+      `Warning: ~/.claude/wrappers/ mode is ${modeStr}; should not be group- or world-writable\n` +
+        `(recommended 0755). A writable wrappers directory could allow another process to\n` +
+        `replace mcp-github.sh and exfiltrate PATs.\n` +
+        `Run: chmod 755 ~/.claude/wrappers`,
+    );
+  }
+}
+
+/**
+ * Reads and validates ~/.config/github-pats.json.
+ * Returns the validated flat object of key→PAT pairs, or null on ENOENT/empty.
+ * Throws on malformed JSON, wrong shape, or invalid entries.
+ *
+ * NOTE: does not route through buildAddArgs because buildAddArgs's wrapper-based
+ * path explicitly forbids -e flags (asserted in mcp.test.ts:222-225), and we
+ * need to pass GITHUB_ACCOUNT per server. Extending buildAddArgs to allow env
+ * on wrappers would change the contract for *all* wrapper servers. The simpler
+ * local change is for registerGithubAccounts to construct its claude mcp add
+ * argv directly.
+ *
+ * @param homedir - Injectable for testing; defaults to os.homedir().
+ * @param spawnFn - Injectable for testing; defaults to execFileSync.
+ * @param warnFn - Injectable for testing; defaults to console.log yellow.
+ * @returns Set of successfully registered account keys.
+ */
+export function registerGithubAccounts(
+  homedir: string = os.homedir(),
+  spawnFn: SpawnFn = defaultSpawn,
+  warnFn: WarnFn = defaultWarn,
+): Set<string> {
+  const patsPath = path.join(homedir, ".config", "github-pats.json");
+
+  // PATs file mode check at install time (V-1 part 2)
+  try {
+    fs.statSync(patsPath);
+    const modeStr = readFileModeOctal(patsPath);
+    if (modeStr !== null) {
+      // Normalise: strip leading zero for comparison
+      const normalised = modeStr.replace(/^0+/, "") || "0";
+      if (normalised !== "600") {
+        warnFn(
+          `Warning: ~/.config/github-pats.json mode is ${modeStr}; recommended mode is 0600.\n` +
+            `Run: chmod 600 ~/.config/github-pats.json\n` +
+            `The wrapper will refuse to read this file at MCP server boot until the mode is fixed.`,
+        );
+      }
+    }
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      warnFn(
+        "Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup",
+      );
+      return new Set();
+    }
+    throw err;
+  }
+
+  // Read the PATs file
+  let raw: string;
+  try {
+    raw = fs.readFileSync(patsPath, "utf8");
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      warnFn(
+        "Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup",
+      );
+      return new Set();
+    }
+    throw err;
+  }
+
+  // Parse JSON — error message must NOT include file contents (V-4)
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: unknown) {
+    const kind = err instanceof Error ? err.constructor.name : typeof err;
+    throw new Error(`github-pats.json: invalid JSON in ${patsPath} (${kind})`, {
+      cause: err,
+    });
+  }
+
+  // Validate shape
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`github-pats.json: ${patsPath} must be a flat JSON object`);
+  }
+
+  const d = parsed as Record<string, unknown>;
+
+  // Validate each entry — key by key (V-4: identify by key only, never value)
+  const KEY_RE = /^[a-zA-Z0-9_.-]+$/;
+  for (const [key, value] of Object.entries(d)) {
+    if (!KEY_RE.test(key)) {
+      throw new Error(
+        `github-pats.json: key '${key}' contains characters outside [a-zA-Z0-9_.-]`,
+      );
+    }
+    if (typeof value !== "string" || value === "") {
+      // SECURITY: identify the offending entry by key only, never by value (V-4)
+      throw new Error(
+        `github-pats.json: PAT for account '${key}' must be a non-empty string`,
+      );
+    }
+  }
+
+  // Empty object case
+  const sortedKeys = Object.keys(d).toSorted();
+  if (sortedKeys.length === 0) {
+    warnFn(
+      "Warning: ~/.config/github-pats.json is empty -- registering zero GitHub MCP servers",
+    );
+    return new Set();
+  }
+
+  const wrapperPath = path.join(
+    homedir,
+    ".claude",
+    "wrappers",
+    "mcp-github.sh",
+  );
+  const registered = new Set<string>();
+
+  for (const key of sortedKeys) {
+    // Best-effort remove any prior registration for this key (idempotent re-add)
+    try {
+      spawnFn("claude", ["mcp", "remove", "-s", "user", `github-${key}`]);
+    } catch {
+      // Not previously registered — fine
+    }
+
+    // Register the new server. Only GITHUB_ACCOUNT is passed as env — the PAT
+    // is never passed here (resolves from ~/.config/github-pats.json at boot time).
+    try {
+      spawnFn("claude", [
+        "mcp",
+        "add",
+        "-s",
+        "user",
+        "-t",
+        "stdio",
+        "-e",
+        `GITHUB_ACCOUNT=${key}`,
+        "--",
+        `github-${key}`,
+        wrapperPath,
+      ]);
+      console.log(c.green(`MCP server 'github-${key}' added`));
+      registered.add(key);
+    } catch {
+      // SECURITY: failure log must NOT include the PAT or any portion of
+      // github-pats.json contents (V-4)
+      console.log(c.red(`Failed to add MCP server 'github-${key}'`));
+    }
+  }
+
+  return registered;
+}
+
+/**
+ * Removes stale github-<key> MCP registrations from ~/.claude.json where
+ * <key> is no longer present in desiredKeys.
+ *
+ * Data source: ~/.claude.json direct read — NOT claude mcp list.
+ * Reads ~/.claude.json at top-level key `mcpServers` (object: server name -> config).
+ * Verified against claude --version 2.1.119 on 2026-04-23 by inspecting a live
+ * ~/.claude.json with at least one user-scope MCP server registered.
+ * If a future claude release moves user-scope MCP state to a different key, update
+ * the path and re-record the verified version above. Do NOT add a sidecar fallback
+ * (~/.claude/.mcp-github-keys.json) -- the direct-read path is the only supported
+ * mechanism (per plan F-13).
+ *
+ * @param desiredKeys - The set of account keys currently desired.
+ * @param homedir - Injectable for testing; defaults to os.homedir().
+ * @param spawnFn - Injectable for testing; defaults to execFileSync.
+ * @param warnFn - Injectable for testing; defaults to console.log yellow.
+ */
+export function removeStaleGithubRegistrations(
+  desiredKeys: Set<string>,
+  homedir: string = os.homedir(),
+  spawnFn: SpawnFn = defaultSpawn,
+  warnFn: WarnFn = defaultWarn,
+): void {
+  const claudeStorePath = path.join(homedir, ".claude.json");
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(claudeStorePath, "utf8");
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      // No Claude CLI state present — nothing to clean
+      return;
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warnFn(
+      `Warning: ~/.claude.json contains invalid JSON -- skipping stale GitHub MCP cleanup`,
+    );
+    return;
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("mcpServers" in parsed)
+  ) {
+    // No mcpServers key — nothing to clean
+    return;
+  }
+
+  const mcpServers = (parsed as Record<string, unknown>)["mcpServers"];
+  if (typeof mcpServers !== "object" || mcpServers === null) {
+    return;
+  }
+
+  // Match github-<suffix> — .+ intentionally matches underscores, dots, hyphens
+  // (same character class as key validator ^[a-zA-Z0-9_.-]+$)
+  const GITHUB_PREFIX_RE = /^github-(.+)$/;
+
+  for (const serverName of Object.keys(mcpServers as Record<string, unknown>)) {
+    const match = GITHUB_PREFIX_RE.exec(serverName);
+    if (!match) continue;
+    const suffix = match[1]!;
+    if (desiredKeys.has(suffix)) continue;
+
+    // This registration is stale — remove it
+    try {
+      spawnFn("claude", ["mcp", "remove", "-s", "user", serverName]);
+      console.log(c.green(`Removed stale MCP registration '${serverName}'`));
+    } catch {
+      // Best-effort — do not abort
+    }
+  }
+}
+
+/**
+ * Injects per-account mcp__github-<key>__* allow-list entries into the
+ * installed ~/.claude/settings.json.
+ *
+ * Constitution check (Principle 2 — Install-time Self-Containment):
+ * The file being mutated is ~/.claude/settings.json (the installed copy at
+ * the destination, NOT the source claude/settings.json). Mutations happen
+ * at install time only; the resulting ~/.claude/settings.json is fully
+ * self-contained and contains no back-references to the repo.
+ *
+ * Atomic via temp + rename. Two concurrent install.sh runs are last-writer-wins
+ * on the rename — the file will not corrupt, but one set of edits may be lost.
+ * This is acceptable because parallel installs of this repo are not a supported
+ * workflow.
+ *
+ * @param accountKeys - The set of successfully-registered account keys.
+ * @param homedir - Injectable for testing; defaults to os.homedir().
+ * @param warnFn - Injectable for testing; defaults to console.log yellow.
+ */
+export function updateGithubAllowList(
+  accountKeys: Set<string>,
+  homedir: string = os.homedir(),
+  warnFn: WarnFn = defaultWarn,
+): void {
+  const settingsPath = path.join(homedir, ".claude", "settings.json");
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(settingsPath, "utf8");
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      warnFn(
+        `Warning: ~/.claude/settings.json not found -- skipping GitHub allow-list update`,
+      );
+      return;
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: unknown) {
+    throw new Error(
+      `settings.json: invalid JSON in ${settingsPath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`settings.json: expected a JSON object in ${settingsPath}`);
+  }
+
+  const settings = parsed as Record<string, unknown>;
+  const existingTools: string[] = Array.isArray(settings["allowedTools"])
+    ? (settings["allowedTools"] as string[])
+    : [];
+
+  // Compute desired set of GitHub patterns
+  const desiredPatterns = new Set(
+    [...accountKeys].map((k) => `mcp__github-${k}__*`),
+  );
+
+  // Regex for existing GitHub allow-list entries — matches same character
+  // class as key validator ^[a-zA-Z0-9_.-]+$ so underscore/dot/hyphen keys
+  // are correctly cleaned. Must NOT use [^_]+ (would miss underscore keys, F-10).
+  const GITHUB_PATTERN_RE = /^mcp__github-[a-zA-Z0-9_.-]+__\*$/;
+
+  // Partition: keep non-github entries and desired github entries; remove stale github entries
+  const kept: string[] = [];
+  for (const tool of existingTools) {
+    if (GITHUB_PATTERN_RE.test(tool)) {
+      if (desiredPatterns.has(tool)) {
+        kept.push(tool);
+      }
+      // else: stale — drop it
+    } else {
+      kept.push(tool);
+    }
+  }
+
+  // Append any desired patterns not already present, in sorted order
+  const alreadyPresent = new Set(kept.filter((t) => GITHUB_PATTERN_RE.test(t)));
+  const toAdd = [...desiredPatterns]
+    .filter((p) => !alreadyPresent.has(p))
+    .toSorted();
+  const updatedTools = [...kept, ...toAdd];
+
+  settings["allowedTools"] = updatedTools;
+
+  // Atomic write via temp + rename
+  const tmpPath = `${settingsPath}.tmp.${process.pid}.${randomBytes(8).toString("hex")}`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+    fs.renameSync(tmpPath, settingsPath);
+  } catch (err: unknown) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
+}
+
 export function installMcpServers(repoRoot: string): void {
   // Check claude CLI availability
   try {
@@ -423,4 +874,12 @@ export function installMcpServers(repoRoot: string): void {
   }
 
   writeStamps(STAMPS_PATH, updatedStamps);
+
+  // GitHub multi-account registration sequence.
+  // Runs after wrapper-copy completes (installDir in main.ts:29 ran before us).
+  assertWrappersDirNotWorldWritable(); // V-5: warn if wrappers dir is group/world-writable
+  removeLegacyGithubRegistration(); // unconditional upgrade migration
+  const registeredKeys = registerGithubAccounts(); // may be empty
+  removeStaleGithubRegistrations(registeredKeys); // clean even when empty
+  updateGithubAllowList(registeredKeys); // clean even when empty
 }

--- a/src/mcp/mcp-servers.json
+++ b/src/mcp/mcp-servers.json
@@ -23,17 +23,6 @@
       "wrapper": "wrappers/mcp-grafana.sh"
     },
     {
-      "name": "github",
-      "scope": "user",
-      "transport": "stdio",
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": ""
-      },
-      "command": "npx",
-      "args": ["--yes", "@modelcontextprotocol/server-github"],
-      "_note": "Package archived 2025-05-29. Successor: ghcr.io/github/github-mcp-server (requires Docker). Using npm package for zero-dependency install."
-    },
-    {
       "name": "gcp-observability",
       "scope": "user",
       "transport": "stdio",

--- a/src/mcp/wrappers/mcp-github.sh
+++ b/src/mcp/wrappers/mcp-github.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SECURITY: Do not add 'set -x' (or otherwise enable bash xtrace) to this script.
+# The PAT passes through $TOKEN below and would be exposed in stderr by xtrace.
+# If you need to debug, instrument the python heredoc with explicit print statements
+# that NEVER echo the loaded dict or any individual PAT value.
+
+# Validate GITHUB_ACCOUNT is set and non-empty
+if [[ -z "${GITHUB_ACCOUNT:-}" ]]; then
+  echo "Error: GITHUB_ACCOUNT env var is not set -- this wrapper must be invoked by the installer-registered MCP server" >&2
+  exit 1
+fi
+
+# Validate GITHUB_ACCOUNT matches safe character class (mirrors cloudwatch/gcp validation pattern)
+if [[ ! "$GITHUB_ACCOUNT" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+  echo "Error: GITHUB_ACCOUNT='$GITHUB_ACCOUNT' contains characters outside [a-zA-Z0-9_.-]" >&2
+  exit 1
+fi
+
+# Validate python3 is available before any token extraction
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 not found on PATH -- the GitHub MCP wrapper requires python3 to read ~/.config/github-pats.json" >&2
+  exit 1
+fi
+
+# Validate pnpx is available before any token extraction
+if ! command -v pnpx >/dev/null 2>&1; then
+  echo "Error: pnpx not found on PATH -- this repository's wrapper uses pnpm. Install pnpm (https://pnpm.io/installation) and re-try." >&2
+  exit 1
+fi
+
+# Validate ~/.config/github-pats.json exists and is readable
+if [ ! -r "$HOME/.config/github-pats.json" ]; then
+  echo 'Error: ~/.config/github-pats.json not found or not readable. Create a flat JSON object mapping account keys to PATs, e.g. {"personal": "ghp_xxx", "work": "ghp_yyy"} and run: chmod 600 ~/.config/github-pats.json' >&2
+  exit 1
+fi
+
+# Validate ~/.config/github-pats.json mode is exactly 0600 (V-1 part 1)
+PATS_PATH="$HOME/.config/github-pats.json"
+mode=$(stat -f '%Lp' "$PATS_PATH" 2>/dev/null || stat -c '%a' "$PATS_PATH" 2>/dev/null || echo "")
+if [[ -z "$mode" ]]; then
+  echo "Error: could not stat $PATS_PATH to check file mode" >&2
+  exit 1
+fi
+# Normalise: strip ALL leading zeros; default to "0" if entirely zero.
+# Mirrors the installer's modeStr.replace(/^0+/, "") || "0" logic (F-3).
+while [[ "$mode" == 0?* ]]; do mode="${mode#0}"; done
+mode="${mode:-0}"
+if [[ "$mode" != "600" ]]; then
+  echo "Error: $PATS_PATH mode is $mode; must be 0600 (run: chmod 600 $PATS_PATH)" >&2
+  exit 1
+fi
+
+# Extract the token using explicit if!-guarded heredoc form.
+# This form is mandatory -- it propagates the python script's exit status reliably
+# even with set -euo pipefail, because command substitution failures inside
+# local/export/simple assignments do NOT trigger set -e exit; the explicit if!
+# boundary is what makes the failure abort the script.
+if ! TOKEN="$(python3 - <<'PY'
+import json, os, sys
+try:
+    with open(os.path.expanduser("~/.config/github-pats.json")) as f:
+        d = json.load(f)
+except Exception as e:
+    # SECURITY: print only the exception type, never str(e) in case json
+    # parsing surfaces file fragments containing the PAT (V-3, V-4).
+    sys.stderr.write(f'Error: failed to read ~/.config/github-pats.json ({type(e).__name__})\n')
+    sys.exit(1)
+k = os.environ["GITHUB_ACCOUNT"]
+if not isinstance(d, dict):
+    sys.stderr.write('Error: ~/.config/github-pats.json must be a JSON object\n')
+    sys.exit(1)
+if k not in d:
+    # SECURITY: it is safe to echo the requested key 'k' because it came
+    # from the GITHUB_ACCOUNT env var (already validated above), not from
+    # the PATs file. We never echo any value from the dict.
+    sys.stderr.write(f"Error: account key '{k}' not found in ~/.config/github-pats.json\n")
+    sys.exit(1)
+v = d[k]
+if not isinstance(v, str) or not v:
+    # SECURITY: identify the offending entry by key only, never by value (V-4).
+    sys.stderr.write(f"Error: PAT for account '{k}' must be a non-empty string\n")
+    sys.exit(1)
+print(v)
+PY
+)"; then
+  exit 1
+fi
+
+# Belt-and-suspenders empty-token guard (F-12)
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: extracted token is empty (this should not happen; the python heredoc validates non-empty strings)" >&2
+  exit 1
+fi
+
+echo "GitHub MCP: using account '$GITHUB_ACCOUNT'" >&2
+
+export GITHUB_PERSONAL_ACCESS_TOKEN="$TOKEN"
+# Belt-and-suspenders: exec replaces the process so $TOKEN goes away with the
+# shell anyway, but explicitly unsetting documents intent and protects against
+# any future refactor that adds work between this point and the exec call.
+unset TOKEN
+# Pinned to 2025.4.8 on 2026-04-23. Package archived 2025-05-29; any future
+# 'latest' publish would be a supply-chain anomaly we want to opt out of.
+# To bump: vet the new version, update the pin, update docs/MCP.md, and
+# update the grep assertion in Step 6 sub-step 4.
+exec pnpx @modelcontextprotocol/server-github@2025.4.8 "$@"


### PR DESCRIPTION
Replaces the single-account GitHub MCP entry with a parameterised wrapper and dynamic installer registration. The installer reads ~/.config/github-pats.json at install time and registers one github-<key> MCP server per key found, with allow-list entries injected into ~/.claude/settings.json. PATs are resolved fresh at each MCP server boot from the user-owned config file, never persisted in ~/.claude.json. The wrapper enforces 0600 permissions on the PAT file and pins the npm package version to prevent supply-chain drift from the archived @modelcontextprotocol/server-github package.