### PR TITLE
feat(bitsmith): add model: inherit for caller-specified model tier

### DIFF
--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -2,7 +2,7 @@
 name: bitsmith
 color: green
 description: "Precision code executor focused on minimal diffs, LSP-clean changes, and pattern-matching the existing codebase. Escalates to Dungeon Master after 3 failed attempts."
-model: claude-sonnet-4-6
+model: inherit
 effort: medium
 permissionMode: acceptEdits
 level: 2
@@ -103,11 +103,19 @@ Bitsmith works in a strict sequence. She does not skip steps. Skipping steps is 
 
 Before touching a single file, assess the complexity of the work:
 
-- **Trivial** — A single, obvious change in a known location. One strike of the hammer.
-- **Scoped** — Multiple changes across a bounded set of files. Planned, sequential work.
-- **Complex** — Changes that touch many systems, require deep pattern discovery, or have unclear boundaries.
+- **Trivial** — A single, obvious change in a known location. One strike of the hammer. Recommended tier: `haiku` (pattern is clear, exploration cost is negligible).
+- **Scoped** — Multiple changes across a bounded set of files. Planned, sequential work. Recommended tier: `sonnet` (default; matches Bitsmith's historical baseline for bounded multi-file work).
+- **Complex** — Changes that touch many systems, require deep pattern discovery, or have unclear boundaries. Recommended tier: `opus` (the kind of work that benefits from the strongest model).
 
 Classification determines how much exploration is needed before striking.
+
+**Model-tier recommendation and tier-mismatch handling.** Bitsmith records the recommended tier as part of her internal classification result. She then infers her active tier (best-effort) by inspecting the DM's delegation prompt for a per-invocation `model:` parameter; if no such parameter is present she assumes inheritance from the parent session. If the active tier is lower than the recommended tier, she notes the mismatch but proceeds — the classifier is advisory, not gate-keeping. The DM, not Bitsmith, decides whether to re-delegate at a higher tier.
+
+On a *failed* completion where a tier mismatch was detected, the mismatch is recorded in the escalation report's sixth field (see "How to Escalate" below).
+
+On a *successful* completion where a tier mismatch was detected, she emits a one-line note at the end of her completion summary: `⚠️ Phase 1 classified this task as [Complex|Scoped]; active tier is [haiku|sonnet] (mismatch).` This surfaces silent degradation without blocking completion.
+
+See `claude/references/agent-model-policy.md` for the full model-resolution chain, the rationale for `model: inherit`, and the alias-only constraint on per-invocation overrides.
 
 ### Phase 2: Identify Target Files
 
@@ -215,6 +223,7 @@ Three failed attempts is the limit. On the third failure, Bitsmith sets down her
 - Implementation that causes new test failures or LSP errors that cannot be resolved
 - A change that is correct in isolation but breaks the surrounding system in ways she cannot untangle
 - Discovery that the plan's assumptions do not match the actual codebase
+- The work appears to require a higher model tier than the one currently in effect (e.g., classifier recommended opus but Bitsmith is running under haiku and cannot resolve a complex pattern after three attempts).
 
 ### When to Escalate Immediately (Without Waiting for Three Attempts)
 
@@ -224,13 +233,14 @@ Three failed attempts is the limit. On the third failure, Bitsmith sets down her
 
 ### How to Escalate
 
-Surface a structured failure report to the Dungeon Master. The report must contain all five of the following fields:
+Surface a structured failure report to the Dungeon Master. The report must contain all six of the following fields:
 
 1. **Task reference** — the plan step being executed when the failure occurred
 2. **Attempts summary** — each attempt and its outcome, briefly
 3. **Failure diagnosis** — what failed and why
 4. **Codebase discoveries** — what was found in the actual codebase that the plan did not account for
 5. **Recommended action** — Bitsmith's assessment of the appropriate next step (replan, adjust scope, or other)
+6. **Model tier in effect** — the model alias under which this failure occurred (haiku / sonnet / opus), and whether this matches the Phase 1 classifier's recommendation. Distinguishes degraded-tier failures from genuine implementation problems.
 
 After surfacing the report, Bitsmith halts and waits for the Dungeon Master to decide next steps.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -444,6 +444,10 @@ The following Diagnostic Report was produced by Tracebloom after investigating a
 
 (The first four lines of the template below are the Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
 
+When invoking Bitsmith with this template, pass `model: haiku` as the per-invocation model parameter on the Agent tool call. The trivial-fix branch is the one delegation path where the DM has independent confirmation — from Tracebloom's `Recommended next action` field — that the work fits the Trivial tier. For all other Bitsmith delegation call sites, omit the per-invocation model parameter entirely and let Bitsmith's frontmatter (`model: inherit`) and her Phase 1 self-classification govern.
+
+Use only the aliases `haiku`, `sonnet`, `opus` as the per-invocation model value — full model IDs (e.g., `claude-haiku-4-5`) are not accepted by the per-invocation parameter.
+
 ~~~
 WORKING_DIRECTORY: {WORKTREE_PATH}
 WORKTREE_BRANCH: {WORKTREE_BRANCH}
@@ -621,7 +625,7 @@ This is a read-only Bash usage authorized by DM's read-only scope (see "What the
 
     a. **Log the escalation** — include the escalation in session tracking for the completion summary.
 
-    b. **Assess the failure report** — evaluate all five fields from Bitsmith's structured report: Task reference (which plan step failed), Attempts summary (what was tried and how each attempt ended), Failure diagnosis (what failed and why), Codebase discoveries (what the plan did not account for), and Recommended action (Bitsmith's suggested next step).
+    b. **Assess the failure report** — evaluate all six fields from Bitsmith's structured report: Task reference (which plan step failed), Attempts summary (what was tried and how each attempt ended), Failure diagnosis (what failed and why), Codebase discoveries (what the plan did not account for), Recommended action (Bitsmith's suggested next step), and Model tier in effect (the model alias — `haiku`, `sonnet`, or `opus` — Bitsmith was running under; if this signals a degraded tier, prefer `Replan` (which lets Pathfinder re-scope and re-route Phase 3 with the tier context in mind) over `Abort` as the first response).
 
     c. **Decide one of four actions:**
        - **Replan:** Delegate to Pathfinder with the full failure report as context, requesting a revised plan for the failed step(s). The revised plan re-enters Phase 2 (Plan Review) before re-entering Phase 3.

--- a/claude/references/agent-model-policy.md
+++ b/claude/references/agent-model-policy.md
@@ -1,0 +1,58 @@
+# Agent Model Policy — Reference
+
+This file documents how model selection works across the agent system: the resolution chain, why Bitsmith uses `model: inherit`, why other agents remain pinned, and the discipline governing per-invocation overrides.
+
+## 1. Resolution Chain
+
+When an agent is invoked, the model is resolved in priority order:
+
+1. **Per-invocation `model` parameter** (highest priority) — passed directly on the Agent tool call at the time of invocation. Accepts aliases only: `haiku`, `sonnet`, `opus`. Full model IDs (e.g., `claude-haiku-4-5`) are not accepted here. Example: passing `model: haiku` on the Agent call forces that invocation to use Haiku regardless of the agent's frontmatter.
+
+2. **Agent frontmatter `model:` value** — set in the agent's YAML front matter. This is the default for most agents. Example: `model: claude-opus-4-7` in `ruinor.md` pins every Ruinor invocation to Opus unless priority #1 overrides it. The special value `model: inherit` at this layer skips this priority and falls through to priority #3.
+
+3. **Session-level model** (lowest priority) — the model active in the parent session. When an agent declares `model: inherit`, it runs under whatever model the invoking session is using, unless priority #1 provides an override.
+
+The alias-only constraint at priority #1 is enforced by the Agent tool itself. Always use `haiku`, `sonnet`, or `opus` — never a full model ID — when specifying a per-invocation override.
+
+## 2. Why Bitsmith Uses `model: inherit`
+
+Bitsmith is the forge executor. Her task spectrum spans more than any other agent's: she fixes a one-line typo on the trivial-fix branch and she implements complex multi-file refactors driven by Pathfinder plans. Pinning her to a single tier would either waste Haiku's cost advantage on trivial work or deny Opus's depth to genuinely complex implementations.
+
+`model: inherit` makes her default tier whatever the DM session is running — appropriate for the bulk of Scoped work — while leaving two clean levers open:
+
+- **Per-invocation override at the DM call site** — the DM can pass `model: haiku` when Tracebloom has already confirmed Trivial tier (see Section 4).
+- **Bitsmith's own Phase 1 classifier** — she records a recommended tier and surfaces any mismatch (see `claude/agents/bitsmith.md`, Phase 1 section) so the DM can decide whether to re-delegate.
+
+No other agent has this breadth of task scope, so `model: inherit` is not a default for the system — it is a deliberate choice for Bitsmith specifically.
+
+## 3. Why Other Agents Remain Pinned
+
+Agents whose role has a stable tier expectation keep a hardcoded `model:` value. Their work does not benefit from per-invocation tier flexibility because their task type is uniform: planning always warrants deep reasoning (Opus), narration is lightweight (Haiku), and advisory/intake/review tasks fit a consistent Sonnet baseline.
+
+Propagating `model: inherit` to additional agents requires a deliberate decision. Do not add it as a default.
+
+Current pinning across all 14 agents (post-change):
+
+**Opus (4):** Pathfinder, Ruinor, Riskmancer, Knotcutter.
+
+**Sonnet (8):** Dungeon Master, Tracebloom, Askmaw, Quill, Reisannin, Truthhammer, Windwarden, Everwise.
+
+**Haiku (1):** Talekeeper.
+
+**Inherit (1):** Bitsmith.
+
+Total: 4 + 8 + 1 + 1 = 14 agents.
+
+Pre-change: 13 pinned (Bitsmith at Sonnet) + 0 inherit. Post-change: 13 pinned + 1 inherit (Bitsmith). Net change: one agent moves from Sonnet-pinned to inherit.
+
+## 4. Per-Invocation Override Discipline
+
+The only documented call site for a per-invocation `model:` parameter is the trivial-fix delegation to Bitsmith in `claude/agents/dungeonmaster.md`. At that call site the DM passes `model: haiku` because Tracebloom's `Recommended next action` field provides independent confirmation that the work is Trivial tier — the DM does not need to rely solely on Bitsmith's self-classification.
+
+Any future call site that wants to use a per-invocation model override must:
+
+1. Update this reference file to enumerate the new call site, the tier used, and the justification.
+2. State the justification inline at the call site (as DM's trivial-fix block does).
+3. Honor the alias-only constraint: `haiku`, `sonnet`, or `opus` only — no full model IDs.
+
+This discipline keeps per-invocation overrides auditable. An override without a corresponding entry here is a policy violation.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -14,7 +14,7 @@
 | **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | Mandatory baseline |
 | **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | Specialist (opt-in) |
 | **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | Specialist (opt-in) |
-| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | claude-sonnet-4-6 | N/A |
+| **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | inherit | N/A |
 | **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
 | **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | N/A |
 | **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | N/A |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -35,6 +35,8 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`quill-documentation-style.md`** — Documentation style guide used by Quill when authoring and updating documentation.
 
+- **`agent-model-policy.md`** — Documents the three-priority model resolution chain, why Bitsmith uses `model: inherit` while all other 13 agents remain pinned, the exhaustive per-tier pinning enumeration (Opus=4, Sonnet=8, Haiku=1, Inherit=1), the alias-only constraint on per-invocation overrides, and the discipline for adding future override call sites.
+
 - **`specialist-triggering.md`** — Canonical keyword list for the Dungeon Master's heuristic-fallback specialist-routing logic. Covers four keyword categories (security, performance, complexity, factual validation) and their corresponding specialist suggestions. DM consults this only when no user flag is present and Ruinor has not recommended specialists. Also documents why Truthhammer's keyword set is intentionally narrow. See [docs/adrs/REVIEW_WORKFLOW.md](/docs/adrs/REVIEW_WORKFLOW.md) for the broader specialist-triggering decision model.
 
 - **`conflict-resolution-rebase.md`** — Canonical algorithm for resolving merge conflicts during a `git rebase`. Covers conflict detection, per-file resolution strategy (preserving the incoming branch's intent), round-limit guardrails, abort conditions, and the rebase-continue loop. Consumed by the `open-pull-request` skill (sub-step 6c) and the `/resolve-conflicts` command as thin pointers to this single authoritative source.


### PR DESCRIPTION
Bitsmith ran on a hardcoded model tier regardless of task complexity, preventing cost optimization on trivial work. Setting `model: inherit` in its frontmatter unlocks the full resolution chain, letting the DM pass `model: haiku` at the trivial-fix delegation call site. Bitsmith's Phase 1 classifier now emits a per-tier recommendation and surfaces mismatches on both successful completions and escalation reports. A new `claude/references/agent-model-policy.md` documents the resolution chain, the symmetry policy for all 14 agents, and the alias-only constraint on per-invocation overrides.