### PR TITLE
refactor(verdict-taxonomy): consolidate severity scales into shared reference

### DIFF
--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -183,7 +183,9 @@ Flag patterns that don't meet their fitness criteria as speculative complexity.
 
 ## Verdict and Severity Reference
 
-See `claude/references/verdict-taxonomy.md`. Apply through the lens of complexity review.
+See `claude/references/verdict-taxonomy.md` for verdict definitions and the two severity scales.
+
+Knotcutter uses **Scale B (CRITICAL / HIGH / MEDIUM / LOW)** for complexity review. Apply through the lens of complexity review.
 
 ## Output Standards
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -225,7 +225,9 @@ Why this verdict was chosen based on security posture.
 
 ## Verdict and Severity Reference
 
-See `claude/references/verdict-taxonomy.md`. Apply through the lens of security review.
+See `claude/references/verdict-taxonomy.md` for verdict definitions and the two severity scales.
+
+Riskmancer uses **Scale B (CRITICAL / HIGH / MEDIUM / LOW)** for security review, aligned with external CVE and security-advisory severities. Apply through the lens of security review.
 
 ## Success Criteria
 

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -238,7 +238,9 @@ Brief explanation of why this verdict was chosen.
 
 ## Verdict and Severity Reference
 
-See `claude/references/verdict-taxonomy.md`. Apply through the lens of quality and correctness review.
+See `claude/references/verdict-taxonomy.md` for verdict definitions and the two severity scales.
+
+Ruinor uses **Scale A (CRITICAL / MAJOR / MINOR)** for baseline quality and correctness reviews. Apply through the lens of quality and correctness review.
 
 ## Critical Constraints
 

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -153,15 +153,16 @@ Every Truthhammer review must include the following footer disclaimer verbatim:
 
 **Graceful degradation**: If WebSearch or WebFetch tools are unavailable in the current environment, mark all claims as UNVERIFIABLE and issue ACCEPT-WITH-RESERVATIONS with a clear note that web verification was unavailable. Do not fail entirely — surface what was found and flag the limitation.
 
-## Claim Severity Levels
+## Claim Severity Application
 
-**CRITICAL** - A CONTRADICTED claim that will cause runtime failure if the plan or code is executed as written. The external system will reject, error on, or behave fundamentally differently than the claim asserts. Blocks progress.
+Truthhammer uses Scale B (CRITICAL / HIGH / MEDIUM / LOW) as defined in `claude/references/verdict-taxonomy.md`. The shared file defines what each level means. The mapping below specifies how Truthhammer's claim classifications (CONTRADICTED / UNVERIFIABLE) translate into Scale B severity in this domain.
 
-**HIGH** - A CONTRADICTED claim with a workaround, or partial incorrectness that degrades behavior without complete failure. Requires revision.
+- **CONTRADICTED claim that will cause runtime failure** → CRITICAL
+- **CONTRADICTED claim with a workaround, or partial incorrectness that degrades behavior** → HIGH
+- **UNVERIFIABLE claim in a critical code path** → MEDIUM
+- **UNVERIFIABLE claim in a non-critical context** → LOW (worth verifying before production, but not blocking)
 
-**MEDIUM** - An UNVERIFIABLE claim in a critical code path. Cannot be confirmed against official docs, and the path is important enough that an incorrect assumption would cause significant problems.
-
-**LOW** - An UNVERIFIABLE claim in a non-critical context. Could be wrong without catastrophic consequences, but should be verified before production.
+See `claude/references/verdict-taxonomy.md` for the level definitions and the rationale for using Scale B (CVE/security-scoring alignment).
 
 ## Tool Usage
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -184,9 +184,13 @@ Flag designs that trade infrastructure cost for developer convenience:
 
 ## Verdict and Severity Reference
 
-See `claude/references/verdict-taxonomy.md`. Apply through the lens of performance review.
+See `claude/references/verdict-taxonomy.md` for verdict definitions and the two severity scales.
 
-### Performance-Specific Severity Examples
+Windwarden uses **Scale B (CRITICAL / HIGH / MEDIUM / LOW)** for performance review. Apply through the lens of performance review.
+
+### Domain-Specific Severity Application — Performance Examples
+
+Windwarden uses Scale B (CRITICAL / HIGH / MEDIUM / LOW) as defined in `claude/references/verdict-taxonomy.md`. The examples below illustrate what each level looks like in the performance domain — they are *examples of application*, not redefinitions of what the levels mean.
 
 **CRITICAL:**
 - Unbounded loops over large datasets

--- a/claude/references/verdict-taxonomy.md
+++ b/claude/references/verdict-taxonomy.md
@@ -37,6 +37,8 @@ All MAJOR findings require concrete evidence: `file:line` citations for code, ba
 
 Used by specialist reviewers (Riskmancer, Windwarden, Knotcutter, Truthhammer) for domain-specific analysis.
 
+**Why Scale B uses CRITICAL / HIGH / MEDIUM / LOW.** This four-level scale aligns with the conventions used by external CVE and security-scoring systems (CVSS qualitative ratings, GitHub Security Advisory severities, vendor advisories). Specialist reviewers — and Truthhammer in particular when classifying claims that intersect with security or external-system risk — adopt this scale so that their findings can be cross-referenced with external advisory severities without translation. Ruinor's Scale A is intentionally distinct because its findings cover plan-and-code quality concerns that have no external-rating analogue.
+
 **CRITICAL** — Blocks production. A flaw that will cause system failure, security breach, runtime error, or complete unacceptability under expected conditions.
 
 **HIGH** — Requires immediate attention before deployment. Significant degradation or risk under normal conditions.

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -404,7 +404,7 @@ See `claude/agents/dungeonmaster.md` for the orchestrator implementation and `cl
 
 **Unchanged:**
 - Review verdict taxonomy (REJECT/REVISE/ACCEPT-WITH-RESERVATIONS/ACCEPT)
-- Severity levels (CRITICAL/MAJOR/MINOR)
+- Severity scales — Scale A (CRITICAL/MAJOR/MINOR, Ruinor) and Scale B (CRITICAL/HIGH/MEDIUM/LOW, specialist reviewers); both defined in `claude/references/verdict-taxonomy.md`
 - Review quality standards and investigation protocols
 - Plan and implementation review gates still exist
 - Revision loops still iterate until all reviewers accept


### PR DESCRIPTION
Fixes #207 — a DRY violation where two incompatible severity scales (Scale A and Scale B) were defined inline across five reviewer agent files instead of being consolidated in the shared verdict-taxonomy.md reference.

The inline redefinitions created an inconsistency risk: any future update to the canonical scales required hunting down and updating five separate files, with no guarantee of consistency. This PR lifts the authoritative definitions into verdict-taxonomy.md and reduces each agent file to a thin application or illustration layer.

Changes:
- verdict-taxonomy.md: Added CVE/security rationale under Scale B; made Truthhammer's scale choice explicit
- truthhammer.md: Replaced inline 'Claim Severity Levels' redefinition with a thin 'Claim Severity Application' mapping
- windwarden.md: Reframed 'Performance-Specific Severity Examples' as domain illustrations (not definitions); added Scale B clarification
- ruinor.md, riskmancer.md, knotcutter.md: Added scale-naming clarifications (Scale A / Scale B)
- docs/adrs/REVIEW_WORKFLOW.md: Updated Migration Notes to correctly name both severity scales