### PR TITLE
refactor(worktree-protocol): establish canonical context block template

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -401,7 +401,7 @@ When not triggered: skip directly to the Intake Gate.
 
 **Tracebloom delegation template:**
 
-(The first four lines of the template below are the Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
+(The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
 ~~~
 WORKING_DIRECTORY: {REPO_ROOT}
@@ -423,7 +423,7 @@ Investigate the reported symptom. Produce a Diagnostic Report with all 5 require
 
 **Diagnostic Report handoff to Pathfinder template:**
 
-(The first four lines of the template below are the Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
+(The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
 ~~~
 WORKING_DIRECTORY: {WORKTREE_PATH}
@@ -442,7 +442,7 @@ The following Diagnostic Report was produced by Tracebloom after investigating a
 
 **Diagnostic Report handoff to Bitsmith (trivial-fix branch) template:**
 
-(The first four lines of the template below are the Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
+(The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
 When invoking Bitsmith with this template, pass `model: haiku` as the per-invocation model parameter on the Agent tool call. The trivial-fix branch is the one delegation path where the DM has independent confirmation — from Tracebloom's `Recommended next action` field — that the work fits the Trivial tier. For all other Bitsmith delegation call sites, omit the per-invocation model parameter entirely and let Bitsmith's frontmatter (`model: inherit`) and her Phase 1 self-classification govern.
 
@@ -492,7 +492,7 @@ On round 6 (after 5 questions): append "You have reached the maximum number of q
 
 **Pathfinder handoff template (when brief is ready):**
 
-(The first three lines of the template below are a partial Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
+(The first three lines of the template below are a partial Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. The trailing scope sentence is intentionally omitted in this template. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
 ```
 WORKING_DIRECTORY: ...
@@ -564,7 +564,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
    **Revision delegation template** (use this every time DM re-delegates to Pathfinder from Phase 2 step 4, including subsequent revision rounds after repeated REVISE/REJECT verdicts — every iteration of the review-revise loop uses this same template with updated feedback):
 
-   (The Worktree Context Block lines below — `WORKING_DIRECTORY`, `WORKTREE_BRANCH`, `REPO_SLUG`, and the trailing scope sentence — follow the format defined in `claude/references/worktree-protocol.md`. `REVISION_MODE` and `USER_FLAGS` are revision-specific additions.)
+   (The four canonical Worktree Context Block lines below — `WORKING_DIRECTORY`, `WORKTREE_BRANCH`, `REPO_SLUG`, and the trailing scope sentence — are defined in `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template. `REVISION_MODE` and `USER_FLAGS` are revision-specific additions. Per the format-change protocol defined in that subsection, do not edit the canonical lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
    ```
    REVISION_MODE: true

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -157,7 +157,7 @@ Please confirm the scope above and, if multiple options were presented, select y
 
 **Pathfinder re-invocation template (after scope confirmation):**
 
-(The first four lines of the template below are the Worktree Context Block — see `claude/references/worktree-protocol.md` for the canonical format definition.)
+(The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
 ````
 WORKING_DIRECTORY: {WORKTREE_PATH}

--- a/claude/references/worktree-protocol.md
+++ b/claude/references/worktree-protocol.md
@@ -8,7 +8,11 @@ When a delegation prompt contains a `WORKING_DIRECTORY:` context line, agents mu
 
 ## The WORKING_DIRECTORY Context Block
 
-When the Dungeon Master activates a session worktree, it prepends the following block to delegation prompts:
+When the Dungeon Master activates a session worktree, it prepends the following block to delegation prompts. The canonical format for this block is defined in the `### Canonical Worktree Context Block Template` subsection below.
+
+### Canonical Worktree Context Block Template
+
+This is the canonical template referenced by every consumer-side delegation prompt. When a delegation prompt includes a Worktree Context Block, the four lines below define the required format:
 
 ```
 WORKING_DIRECTORY: /absolute/path/to/.worktrees/dm-slug
@@ -18,6 +22,8 @@ All file operations and Bash commands must use this directory as the working roo
 ```
 
 Bitsmith delegations may include an additional `SKIP_TREE_AUDIT: true` line outside this canonical block — see `claude/agents/bitsmith.md` § Working-Tree Audit for the audit semantics and `claude/agents/dungeonmaster.md` § SKIP_TREE_AUDIT Choice Rule for when DM emits it.
+
+**Format-change protocol:** If this format changes, update this subsection first, then run `grep -rn 'All file operations and Bash commands must use this directory as the working root' claude/`. *(Note: the grep will also surface two in-file occurrences that are not consumer sites: the canonical block in this `### Canonical Worktree Context Block Template` subsection itself (which you just updated — it is the source of truth, not a consumer site), and the protocol sentence above that quotes the marker phrase verbatim. Both should be ignored. Every other hit from this file's `claude/` tree is an external consumer site to update in lockstep.)* Then update each consumer site in lockstep. Consumer sites currently live in `claude/agents/dungeonmaster.md` (4 full templates + 1 partial template) and `claude/agents/pathfinder.md` (1 template).
 
 This block signals that all work for this task must be scoped to the specified directory. It is not a suggestion — it is a hard scope boundary.
 

--- a/docs/WORKTREE_ISOLATION.md
+++ b/docs/WORKTREE_ISOLATION.md
@@ -132,7 +132,7 @@ When a DungeonMaster session has an active worktree, Pathfinder, Bitsmith, Quill
 ```
 WORKING_DIRECTORY: /absolute/path/to/.worktrees/feat-add-oauth-login
 WORKTREE_BRANCH: feat/add-oauth-login
-REPO_SLUG: my-repo
+REPO_SLUG: my-project
 All file operations and Bash commands must use this directory as the working root.
 ```
 


### PR DESCRIPTION
Resolves the MEDIUM-severity DRY violation in Issue #203: the 4-line Worktree Context Block format was reproduced verbatim across 6 agent template sites in `dungeonmaster.md` and `pathfinder.md`. This PR establishes a single canonical subsection (`### Canonical Worktree Context Block Template`) in `worktree-protocol.md` with an explicit format-change protocol, removes the in-file duplicate block, and strengthens the parenthetical pointer comment at each of the 7 consumer sites to name the canonical source and the grep-based maintenance workflow. All existing literal block contents and fence delimiters are preserved unchanged — this is a documentation tightening only, with zero runtime behavior change.

Closes #203