### PR TITLE
feat(launcher): add --skip flag to bypass interactive wizard

### DIFF
--- a/docs/MYCLAUDE.md
+++ b/docs/MYCLAUDE.md
@@ -22,6 +22,31 @@ The wizard will present a multi-step flow:
 
 **Persistence:** Your last-used selections are saved to `~/.config/myclaude/config.json` and pre-fill the wizard on your next run. You can accept them with Enter or change them.
 
+### `--skip`: launch immediately with saved config
+
+Pass `--skip` to bypass the interactive summary screen and launch Claude immediately using whatever is currently saved in `~/.config/myclaude/config.json`:
+
+```bash
+myclaude --skip
+```
+
+This is useful for scripts, hot-key launches, and users who never want to see the summary screen.
+
+**Strict failure behaviour** — `--skip` never falls back to the interactive flow. Instead it exits non-zero with a clear error message in two cases:
+
+- **No saved config:** If `~/.config/myclaude/config.json` contains no MCP selections, the launcher prints to stderr and exits with code 1:
+  ```
+  No saved config found — run myclaude without --skip first to configure.
+  ```
+- **Stale saved config:** If the saved config cannot be resolved (e.g. the saved Grafana cluster ID no longer exists in `~/.config/grafana-clusters.yaml`), the launcher prints to stderr and exits with code 1:
+  ```
+  Saved config could not be resolved (e.g. Grafana cluster is no longer valid) — re-run myclaude without --skip to reconfigure.
+  ```
+
+In both cases, run `myclaude` without `--skip` to (re)configure.
+
+**Unknown flags** are rejected with exit code 2. Any token other than `--skip` prints `Unknown flag: <flag>. Usage: myclaude [--skip]` to stderr and exits immediately.
+
 ## Grafana Configuration
 
 Create `~/.config/grafana-clusters.yaml` with your cluster definitions. The file must use this YAML schema:

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -52,9 +52,11 @@ myclaude
 
 If the saved Grafana cluster ID no longer exists in `~/.config/grafana-clusters.yaml`, the launch path is skipped and the configure flow starts automatically with a warning.
 
+**`--skip` flag:** Pass `--skip` on the command line to bypass the summary screen entirely and launch Claude immediately with the saved config. The flag is parsed by `argv.ts` before `loadConfig` is called. If the saved config is unusable, the launcher exits non-zero with one of two stderr messages (no saved config, or stale/unresolvable config) — it never falls back to the interactive flow. Any unknown flag causes exit code 2. Example: `pnpm exec tsx src/launcher/main.ts --skip`.
+
 ## Testing
 
-Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`env.test.ts`, `resolve.test.ts`, `outro.test.ts`, `summary.test.ts`, `config.test.ts`, `utils.test.ts`, `mcp-command.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
+Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`argv.test.ts`, `env.test.ts`, `resolve.test.ts`, `outro.test.ts`, `summary.test.ts`, `config.test.ts`, `utils.test.ts`, `mcp-command.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
 
 ```bash
 pnpm test
@@ -116,16 +118,16 @@ The `McpCommand` interface captures every per-MCP responsibility:
 
 ### Orchestration files
 
-| File         | Responsibility                                                                                                                                                                                     |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main.ts`    | Entry point. Configure flow iterates `registry` to call `configureInteractive` for each selected MCP. Calls `applyKubernetesContextSwitch` explicitly after `saveConfig` and before `buildEnvVars` |
-| `resolve.ts` | `buildResolvedFromSaved` — iterates `config.selectedMcps`, calls `cmd.resolveFromSaved`, catches `StaleResourceError`                                                                              |
-| `env.ts`     | `buildEnvVars` — iterates `registry`, calls `cmd.emitEnvVars`                                                                                                                                      |
-| `outro.ts`   | `buildOutroLines` — two registry passes: success lines first, then skip lines, both in registry order                                                                                              |
-| `summary.ts` | `formatSummaryLines` + `promptSummaryAction` — looks up each selected MCP in the registry by id                                                                                                    |
-| `prompts.ts` | `selectMcps` — derives multiselect options from `registry.map(c => c.multiselectOption)`                                                                                                           |
-| `config.ts`  | Persistence: load/save `~/.config/myclaude/config.json`                                                                                                                                            |
-| `types.ts`   | All shared TypeScript types (`ResolvedConfig`, `LauncherConfig`, `SkippedMap`, per-MCP config interfaces)                                                                                          |
+| File         | Responsibility                                                                                                                                                                                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.ts`    | Entry point. Parses argv via `argv.ts` and short-circuits to a saved-config launch when `--skip` is present. Configure flow iterates `registry` to call `configureInteractive` for each selected MCP. Calls `applyKubernetesContextSwitch` explicitly after `saveConfig` and before `buildEnvVars` |
+| `resolve.ts` | `buildResolvedFromSaved` — iterates `config.selectedMcps`, calls `cmd.resolveFromSaved`, catches `StaleResourceError`                                                                                                                                                                              |
+| `env.ts`     | `buildEnvVars` — iterates `registry`, calls `cmd.emitEnvVars`                                                                                                                                                                                                                                      |
+| `outro.ts`   | `buildOutroLines` — two registry passes: success lines first, then skip lines, both in registry order                                                                                                                                                                                              |
+| `summary.ts` | `formatSummaryLines` + `promptSummaryAction` — looks up each selected MCP in the registry by id                                                                                                                                                                                                    |
+| `prompts.ts` | `selectMcps` — derives multiselect options from `registry.map(c => c.multiselectOption)`                                                                                                                                                                                                           |
+| `config.ts`  | Persistence: load/save `~/.config/myclaude/config.json`                                                                                                                                                                                                                                            |
+| `types.ts`   | All shared TypeScript types (`ResolvedConfig`, `LauncherConfig`, `SkippedMap`, per-MCP config interfaces)                                                                                                                                                                                          |
 
 ### Shared helpers
 
@@ -229,6 +231,7 @@ The selected context is saved under `kubernetes.context` in `~/.config/myclaude/
 
 ## See Also
 
+- **`src/launcher/argv.ts`** — Argv parser used by `main.ts`; exports `parseArgs` and `UnknownFlagError`
 - **`src/mcp/wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
 - **`src/mcp/wrappers/mcp-gcp-observability.sh`** — Bash wrapper that resolves the GCP project from the dotfile and launches the Observability MCP server
 - **`src/launcher/mcp-command-types.ts`** — `McpCommand` interface and `StaleResourceError` class

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs, UnknownFlagError } from "./argv.js";
+
+describe("parseArgs", () => {
+  it("returns { skip: false } for an empty argv", () => {
+    const result = parseArgs([]);
+    assert.deepStrictEqual(result, { skip: false });
+  });
+
+  it("returns { skip: true } for ['--skip']", () => {
+    const result = parseArgs(["--skip"]);
+    assert.deepStrictEqual(result, { skip: true });
+  });
+
+  it("returns { skip: true } for duplicate ['--skip', '--skip'] (idempotent)", () => {
+    const result = parseArgs(["--skip", "--skip"]);
+    assert.deepStrictEqual(result, { skip: true });
+  });
+
+  it("throws UnknownFlagError for an unknown flag, message contains the flag and usage hint", () => {
+    assert.throws(
+      () => parseArgs(["--unknown"]),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof UnknownFlagError,
+          "should be UnknownFlagError",
+        );
+        assert.ok(
+          (err as UnknownFlagError).message.includes("--unknown"),
+          "message should contain the offending flag",
+        );
+        assert.ok(
+          (err as UnknownFlagError).message.includes(
+            "Usage: myclaude [--skip]",
+          ),
+          "message should contain the usage hint",
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws UnknownFlagError for ['--skip', 'extra'] — positional after valid flag", () => {
+    assert.throws(
+      () => parseArgs(["--skip", "extra"]),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof UnknownFlagError,
+          "should be UnknownFlagError",
+        );
+        assert.ok(
+          (err as UnknownFlagError).message.includes("extra"),
+          "message should contain 'extra'",
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws UnknownFlagError for a bare positional argument", () => {
+    assert.throws(
+      () => parseArgs(["positional"]),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof UnknownFlagError,
+          "should be UnknownFlagError",
+        );
+        return true;
+      },
+    );
+  });
+});

--- a/src/launcher/argv.ts
+++ b/src/launcher/argv.ts
@@ -1,0 +1,27 @@
+// Duplicates are tolerated — the flag is idempotent and treating --skip --skip as a usage error would surprise users.
+
+export class UnknownFlagError extends Error {
+  constructor(flag: string) {
+    super(`Unknown flag: ${flag}. Usage: myclaude [--skip]`);
+    this.name = "UnknownFlagError";
+  }
+}
+
+/**
+ * Parse the arguments passed to the myclaude launcher.
+ *
+ * @param argv - the array to parse (pass `process.argv.slice(2)`; never the full argv)
+ * @returns `{ skip: true }` when `--skip` is present, `{ skip: false }` otherwise
+ * @throws {UnknownFlagError} for any token that is not `--skip`
+ */
+export function parseArgs(argv: string[]): { skip: boolean } {
+  let skip = false;
+  for (const token of argv) {
+    if (token === "--skip") {
+      skip = true;
+    } else {
+      throw new UnknownFlagError(token);
+    }
+  }
+  return { skip };
+}

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -8,6 +8,7 @@ import { promptSummaryAction } from "./summary.js";
 import { buildResolvedFromSaved } from "./resolve.js";
 import { registry } from "./mcp-command.js";
 import { applyKubernetesContextSwitch } from "./mcp/kubernetes.js";
+import { parseArgs, UnknownFlagError } from "./argv.js";
 import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
 
 function launchClaude(
@@ -45,10 +46,43 @@ function launchClaude(
   process.exit(result.status ?? 1);
 }
 
+function runSkipLaunch(savedConfig: LauncherConfig): never {
+  if (savedConfig.selectedMcps.length === 0) {
+    console.error(
+      "No saved config found — run myclaude without --skip first to configure.",
+    );
+    process.exit(1);
+  }
+  const resolved = buildResolvedFromSaved(savedConfig);
+  if (resolved === null) {
+    console.error(
+      "Saved config could not be resolved (e.g. Grafana cluster is no longer valid) — re-run myclaude without --skip to reconfigure.",
+    );
+    process.exit(1);
+  }
+  // Direct launch: no config was modified, so do NOT call saveConfig.
+  launchClaude(resolved, savedConfig);
+}
+
 async function main(): Promise<void> {
   intro("myclaude — Session Launcher");
 
+  let skip = false;
+  try {
+    ({ skip } = parseArgs(process.argv.slice(2)));
+  } catch (err) {
+    if (err instanceof UnknownFlagError) {
+      console.error(err.message);
+      process.exit(2);
+    }
+    throw err;
+  }
+
   const savedConfig = loadConfig();
+
+  if (skip) {
+    runSkipLaunch(savedConfig);
+  }
 
   // Summary screen: show current config and let user choose to launch or configure
   const hasExistingConfig = savedConfig.selectedMcps.length > 0;


### PR DESCRIPTION
Adds `--skip` to the `myclaude` launcher to bypass the interactive MCP-selection wizard when a saved config already exists at `~/.config/myclaude/config.json`. This removes friction for repeat launches and enables non-interactive invocation from scripts or shell aliases.

Failure semantics are strict: exits non-zero with a clear error message if no saved config exists or if the saved config is unresolvable (e.g., a stale Grafana cluster ID), rather than silently falling back to the interactive flow.