### PR TITLE
feat(launcher): forward initial-message arg to claude spawn

### DIFF
--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -26,6 +26,14 @@ After installation via `./install.sh`, the launcher is available as:
 myclaude
 ```
 
+To launch Claude with an initial prompt (bypasses the wizard):
+
+```bash
+myclaude --skip "/feature-issue 42"
+```
+
+Launches Claude with the given string as its first prompt. Requires `--skip` (the wizard cannot also forward an initial message).
+
 ## Startup Behavior
 
 **First run** (no saved config): the wizard goes straight to MCP selection. Choices are saved to `~/.config/myclaude/config.json` after you complete the flow.
@@ -53,6 +61,21 @@ myclaude
 If the saved Grafana cluster ID no longer exists in `~/.config/grafana-clusters.yaml`, the launch path is skipped and the configure flow starts automatically with a warning.
 
 **`--skip` flag:** Pass `--skip` on the command line to bypass the summary screen entirely and launch Claude immediately with the saved config. The flag is parsed by `argv.ts` before `loadConfig` is called. If the saved config is unusable, the launcher exits non-zero with one of two stderr messages (no saved config, or stale/unresolvable config) — it never falls back to the interactive flow. Any unknown flag causes exit code 2. Example: `pnpm exec tsx src/launcher/main.ts --skip`.
+
+## Initial Message Forwarding
+
+Pass an initial message as a positional argument to forward it verbatim to `claude` as its first prompt:
+
+```bash
+myclaude --skip <initial-message>
+```
+
+**Rules:**
+
+- `--skip` is required when supplying an initial message. If an initial message is given without `--skip`, the launcher writes `Initial message requires --skip. Usage: myclaude --skip <initial-message>` to stderr and exits with code `2`. No wizard banner is printed.
+- Only one positional argument is allowed. If two or more are supplied, the launcher writes `Too many positional arguments. Only one initial message is allowed. Usage: myclaude [--skip] [<initial-message>]` to stderr and exits with code `2`. No wizard banner is printed.
+- Any token starting with `-` other than `--skip` (including single-dash tokens like `-h` and the bare `-`) is rejected as an unknown flag. It is never captured as the initial message.
+- The message is passed verbatim to `claude` — quoting at the shell level controls whether spaces become one argument or many. The launcher performs no further tokenisation.
 
 ## Testing
 
@@ -118,16 +141,18 @@ The `McpCommand` interface captures every per-MCP responsibility:
 
 ### Orchestration files
 
-| File         | Responsibility                                                                                                                                                                                                                                                                                     |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main.ts`    | Entry point. Parses argv via `argv.ts` and short-circuits to a saved-config launch when `--skip` is present. Configure flow iterates `registry` to call `configureInteractive` for each selected MCP. Calls `applyKubernetesContextSwitch` explicitly after `saveConfig` and before `buildEnvVars` |
-| `resolve.ts` | `buildResolvedFromSaved` — iterates `config.selectedMcps`, calls `cmd.resolveFromSaved`, catches `StaleResourceError`                                                                                                                                                                              |
-| `env.ts`     | `buildEnvVars` — iterates `registry`, calls `cmd.emitEnvVars`                                                                                                                                                                                                                                      |
-| `outro.ts`   | `buildOutroLines` — two registry passes: success lines first, then skip lines, both in registry order                                                                                                                                                                                              |
-| `summary.ts` | `formatSummaryLines` + `promptSummaryAction` — looks up each selected MCP in the registry by id                                                                                                                                                                                                    |
-| `prompts.ts` | `selectMcps` — derives multiselect options from `registry.map(c => c.multiselectOption)`                                                                                                                                                                                                           |
-| `config.ts`  | Persistence: load/save `~/.config/myclaude/config.json`                                                                                                                                                                                                                                            |
-| `types.ts`   | All shared TypeScript types (`ResolvedConfig`, `LauncherConfig`, `SkippedMap`, per-MCP config interfaces)                                                                                                                                                                                          |
+| File             | Responsibility                                                                                                                                                                                                                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.ts`        | Entry point. Parses argv via `argv.ts` and short-circuits to a saved-config launch when `--skip` is present. Configure flow iterates `registry` to call `configureInteractive` for each selected MCP. Calls `applyKubernetesContextSwitch` explicitly after `saveConfig` and before `buildEnvVars` |
+| `argv.ts`        | `parseArgs(argv)` — pure lexical parser; returns `{ skip, initialMessage }`. Throws `UnknownFlagError` for unknown flags and `TooManyPositionalsError` for more than one positional.                                                                                                               |
+| `claude-args.ts` | `buildClaudeArgs(initialMessage)` — pure helper that produces the `claude` spawn argv. Single source of truth for the spawn-arg shape; called from `launchClaude` in `main.ts`.                                                                                                                    |
+| `resolve.ts`     | `buildResolvedFromSaved` — iterates `config.selectedMcps`, calls `cmd.resolveFromSaved`, catches `StaleResourceError`                                                                                                                                                                              |
+| `env.ts`         | `buildEnvVars` — iterates `registry`, calls `cmd.emitEnvVars`                                                                                                                                                                                                                                      |
+| `outro.ts`       | `buildOutroLines` — two registry passes: success lines first, then skip lines, both in registry order                                                                                                                                                                                              |
+| `summary.ts`     | `formatSummaryLines` + `promptSummaryAction` — looks up each selected MCP in the registry by id                                                                                                                                                                                                    |
+| `prompts.ts`     | `selectMcps` — derives multiselect options from `registry.map(c => c.multiselectOption)`                                                                                                                                                                                                           |
+| `config.ts`      | Persistence: load/save `~/.config/myclaude/config.json`                                                                                                                                                                                                                                            |
+| `types.ts`       | All shared TypeScript types (`ResolvedConfig`, `LauncherConfig`, `SkippedMap`, per-MCP config interfaces)                                                                                                                                                                                          |
 
 ### Shared helpers
 
@@ -231,7 +256,8 @@ The selected context is saved under `kubernetes.context` in `~/.config/myclaude/
 
 ## See Also
 
-- **`src/launcher/argv.ts`** — Argv parser used by `main.ts`; exports `parseArgs` and `UnknownFlagError`
+- **`src/launcher/argv.ts`** — Argv parser used by `main.ts`; exports `parseArgs`, `UnknownFlagError`, and `TooManyPositionalsError`
+- **`src/launcher/claude-args.ts`** — `buildClaudeArgs` helper that produces the `claude` spawn argv from the optional initial message; used by `launchClaude` in `main.ts`.
 - **`src/mcp/wrappers/mcp-grafana.sh`** — Bash wrapper that translates `GRAFANA_DISABLE_WRITE=true` to `--disable-write`
 - **`src/mcp/wrappers/mcp-gcp-observability.sh`** — Bash wrapper that resolves the GCP project from the dotfile and launches the Observability MCP server
 - **`src/launcher/mcp-command-types.ts`** — `McpCommand` interface and `StaleResourceError` class

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -1,21 +1,25 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseArgs, UnknownFlagError } from "./argv.js";
+import {
+  parseArgs,
+  UnknownFlagError,
+  TooManyPositionalsError,
+} from "./argv.js";
 
 describe("parseArgs", () => {
-  it("returns { skip: false } for an empty argv", () => {
+  it("returns { skip: false, initialMessage: undefined } for an empty argv", () => {
     const result = parseArgs([]);
-    assert.deepStrictEqual(result, { skip: false });
+    assert.deepStrictEqual(result, { skip: false, initialMessage: undefined });
   });
 
-  it("returns { skip: true } for ['--skip']", () => {
+  it("returns { skip: true, initialMessage: undefined } for ['--skip']", () => {
     const result = parseArgs(["--skip"]);
-    assert.deepStrictEqual(result, { skip: true });
+    assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
   });
 
-  it("returns { skip: true } for duplicate ['--skip', '--skip'] (idempotent)", () => {
+  it("returns { skip: true, initialMessage: undefined } for duplicate ['--skip', '--skip'] (idempotent)", () => {
     const result = parseArgs(["--skip", "--skip"]);
-    assert.deepStrictEqual(result, { skip: true });
+    assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
   });
 
   it("throws UnknownFlagError for an unknown flag, message contains the flag and usage hint", () => {
@@ -41,26 +45,82 @@ describe("parseArgs", () => {
     );
   });
 
-  it("throws UnknownFlagError for ['--skip', 'extra'] — positional after valid flag", () => {
+  it("captures initial message after --skip: parseArgs(['--skip', '/feature-issue 42']) returns { skip: true, initialMessage: '/feature-issue 42' }", () => {
+    const result = parseArgs(["--skip", "/feature-issue 42"]);
+    assert.deepStrictEqual(result, {
+      skip: true,
+      initialMessage: "/feature-issue 42",
+    });
+  });
+
+  it("captures initial message before --skip: parseArgs(['/cmd', '--skip']) returns { skip: true, initialMessage: '/cmd' }", () => {
+    const result = parseArgs(["/cmd", "--skip"]);
+    assert.deepStrictEqual(result, { skip: true, initialMessage: "/cmd" });
+  });
+
+  it("captures initial message without --skip: parseArgs(['/cmd']) returns { skip: false, initialMessage: '/cmd' }", () => {
+    const result = parseArgs(["/cmd"]);
+    assert.deepStrictEqual(result, { skip: false, initialMessage: "/cmd" });
+  });
+
+  it("throws TooManyPositionalsError when two positionals are supplied", () => {
     assert.throws(
-      () => parseArgs(["--skip", "extra"]),
+      () => parseArgs(["--skip", "a", "b"]),
       (err: unknown) => {
         assert.ok(
-          err instanceof UnknownFlagError,
-          "should be UnknownFlagError",
+          err instanceof TooManyPositionalsError,
+          "should be TooManyPositionalsError",
         );
         assert.ok(
-          (err as UnknownFlagError).message.includes("extra"),
-          "message should contain 'extra'",
+          (err as TooManyPositionalsError).message.includes(
+            "Too many positional arguments",
+          ),
+          "message should mention too many positional arguments",
+        );
+        assert.ok(
+          (err as TooManyPositionalsError).message.includes(
+            "Usage: myclaude [--skip]",
+          ),
+          "message should contain the usage hint",
         );
         return true;
       },
     );
   });
 
-  it("throws UnknownFlagError for a bare positional argument", () => {
+  it("still throws UnknownFlagError for an unknown flag in the presence of a positional", () => {
     assert.throws(
-      () => parseArgs(["positional"]),
+      () => parseArgs(["--unknown", "/cmd"]),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof UnknownFlagError,
+          "should be UnknownFlagError (not TooManyPositionalsError)",
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws UnknownFlagError for a single-dash flag after --skip", () => {
+    assert.throws(
+      () => parseArgs(["--skip", "-h"]),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof UnknownFlagError,
+          "should be UnknownFlagError",
+        );
+        assert.ok(
+          (err as UnknownFlagError).message.includes("-h"),
+          "message should contain the offending flag",
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws UnknownFlagError for a bare single dash", () => {
+    assert.throws(
+      () => parseArgs(["-"]),
       (err: unknown) => {
         assert.ok(
           err instanceof UnknownFlagError,

--- a/src/launcher/argv.ts
+++ b/src/launcher/argv.ts
@@ -1,9 +1,31 @@
-// Duplicates are tolerated — the flag is idempotent and treating --skip --skip as a usage error would surprise users.
+// Parses the argv array passed to the myclaude launcher.
+//
+// Rules:
+//   - The literal token `--skip` sets the skip flag (idempotent; duplicates are tolerated).
+//   - Any other token that starts with `-` (one or two dashes — covers `--unknown`, `-x`, `-h`,
+//     the bare `-`, etc.) throws UnknownFlagError.
+//   - Any token that does NOT start with `-` is captured as the positional initial message
+//     (first occurrence only).
+//   - A second non-flag token throws TooManyPositionalsError.
+//
+// The no-`--skip` rejection (initial message present but skip is false) is NOT enforced here.
+// The parser is purely lexical; that semantic check is main.ts's responsibility.
 
 export class UnknownFlagError extends Error {
   constructor(flag: string) {
-    super(`Unknown flag: ${flag}. Usage: myclaude [--skip]`);
+    super(
+      `Unknown flag: ${flag}. Usage: myclaude [--skip] [<initial-message>]`,
+    );
     this.name = "UnknownFlagError";
+  }
+}
+
+export class TooManyPositionalsError extends Error {
+  constructor() {
+    super(
+      "Too many positional arguments. Only one initial message is allowed. Usage: myclaude [--skip] [<initial-message>]",
+    );
+    this.name = "TooManyPositionalsError";
   }
 }
 
@@ -11,17 +33,28 @@ export class UnknownFlagError extends Error {
  * Parse the arguments passed to the myclaude launcher.
  *
  * @param argv - the array to parse (pass `process.argv.slice(2)`; never the full argv)
- * @returns `{ skip: true }` when `--skip` is present, `{ skip: false }` otherwise
- * @throws {UnknownFlagError} for any token that is not `--skip`
+ * @returns `{ skip, initialMessage }` where `skip` is true when `--skip` is present and
+ *   `initialMessage` is the single optional positional arg (or `undefined` if not supplied)
+ * @throws {UnknownFlagError} for any token starting with `-` other than `--skip`
+ *   (covers single-dash flags like `-h`, the bare `-`, and double-dash flags like `--unknown`)
+ * @throws {TooManyPositionalsError} when more than one positional (non-flag) token is supplied
  */
-export function parseArgs(argv: string[]): { skip: boolean } {
+export function parseArgs(argv: string[]): {
+  skip: boolean;
+  initialMessage: string | undefined;
+} {
   let skip = false;
+  let initialMessage: string | undefined = undefined;
   for (const token of argv) {
     if (token === "--skip") {
       skip = true;
-    } else {
+    } else if (token.startsWith("-")) {
       throw new UnknownFlagError(token);
+    } else if (initialMessage !== undefined) {
+      throw new TooManyPositionalsError();
+    } else {
+      initialMessage = token;
     }
   }
-  return { skip };
+  return { skip, initialMessage };
 }

--- a/src/launcher/claude-args.ts
+++ b/src/launcher/claude-args.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the argv array passed to `spawnSync("claude", ...)`.
+ *
+ * This helper is the single source of truth for the `claude` spawn-arg shape.
+ * No shell tokenisation or escaping occurs at this layer — `spawnSync` passes
+ * argv elements directly to the child process without shell interpretation.
+ *
+ * @param initialMessage - the optional initial message to forward to claude as
+ *   a third positional arg. When `undefined`, the args are identical to the
+ *   baseline `["--agent", "dungeonmaster"]`.
+ * @returns the complete argv array to pass to `spawnSync("claude", ...)`
+ */
+export function buildClaudeArgs(initialMessage: string | undefined): string[] {
+  if (initialMessage === undefined) {
+    return ["--agent", "dungeonmaster"];
+  }
+  return ["--agent", "dungeonmaster", initialMessage];
+}

--- a/src/launcher/main.test.ts
+++ b/src/launcher/main.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildClaudeArgs } from "./claude-args.js";
+
+describe("buildClaudeArgs", () => {
+  it("returns ['--agent', 'dungeonmaster'] when initialMessage is undefined", () => {
+    const result = buildClaudeArgs(undefined);
+    assert.deepStrictEqual(result, ["--agent", "dungeonmaster"]);
+  });
+
+  it("appends the message as a third element and preserves internal spaces as a single argv element", () => {
+    const result = buildClaudeArgs("/feature-issue 42");
+    assert.deepStrictEqual(result, [
+      "--agent",
+      "dungeonmaster",
+      "/feature-issue 42",
+    ]);
+  });
+
+  it("returns ['--agent', 'dungeonmaster', ''] for an empty string (present but empty message forwarded verbatim)", () => {
+    const result = buildClaudeArgs("");
+    assert.deepStrictEqual(result, ["--agent", "dungeonmaster", ""]);
+  });
+});

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -8,13 +8,19 @@ import { promptSummaryAction } from "./summary.js";
 import { buildResolvedFromSaved } from "./resolve.js";
 import { registry } from "./mcp-command.js";
 import { applyKubernetesContextSwitch } from "./mcp/kubernetes.js";
-import { parseArgs, UnknownFlagError } from "./argv.js";
+import {
+  parseArgs,
+  UnknownFlagError,
+  TooManyPositionalsError,
+} from "./argv.js";
+import { buildClaudeArgs } from "./claude-args.js";
 import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
 
 function launchClaude(
   resolved: ResolvedConfig,
   savedConfig: LauncherConfig,
   skipped: SkippedMap = {},
+  initialMessage: string | undefined = undefined,
 ): never {
   // Switch Kubernetes context AFTER config is persisted (avoids inconsistency if switchContext fails)
   const { effectiveSkipped, outroResolved } = applyKubernetesContextSwitch(
@@ -39,14 +45,18 @@ function launchClaude(
 
   // Launch Claude with merged env vars
   const env = { ...process.env, ...envVars };
-  const result = spawnSync("claude", ["--agent", "dungeonmaster"], {
+  const claudeArgs = buildClaudeArgs(initialMessage);
+  const result = spawnSync("claude", claudeArgs, {
     stdio: "inherit",
     env,
   });
   process.exit(result.status ?? 1);
 }
 
-function runSkipLaunch(savedConfig: LauncherConfig): never {
+function runSkipLaunch(
+  savedConfig: LauncherConfig,
+  initialMessage: string | undefined,
+): never {
   if (savedConfig.selectedMcps.length === 0) {
     console.error(
       "No saved config found — run myclaude without --skip first to configure.",
@@ -61,27 +71,39 @@ function runSkipLaunch(savedConfig: LauncherConfig): never {
     process.exit(1);
   }
   // Direct launch: no config was modified, so do NOT call saveConfig.
-  launchClaude(resolved, savedConfig);
+  launchClaude(resolved, savedConfig, undefined, initialMessage);
 }
 
 async function main(): Promise<void> {
-  intro("myclaude — Session Launcher");
-
   let skip = false;
+  let initialMessage: string | undefined = undefined;
   try {
-    ({ skip } = parseArgs(process.argv.slice(2)));
+    ({ skip, initialMessage } = parseArgs(process.argv.slice(2)));
   } catch (err) {
     if (err instanceof UnknownFlagError) {
+      console.error(err.message);
+      process.exit(2);
+    }
+    if (err instanceof TooManyPositionalsError) {
       console.error(err.message);
       process.exit(2);
     }
     throw err;
   }
 
+  if (initialMessage !== undefined && !skip) {
+    console.error(
+      "Initial message requires --skip. Usage: myclaude --skip <initial-message>",
+    );
+    process.exit(2);
+  }
+
+  intro("myclaude — Session Launcher");
+
   const savedConfig = loadConfig();
 
   if (skip) {
-    runSkipLaunch(savedConfig);
+    runSkipLaunch(savedConfig, initialMessage);
   }
 
   // Summary screen: show current config and let user choose to launch or configure


### PR DESCRIPTION
Adds a positional initial-message argument to myclaude, forwarding it verbatim to claude at spawn time. This enables terminal invocations like `myclaude --skip "/feature-issue 42"` without opening the interactive wizard. Hard-errors with exit 2 when an initial message is given without --skip. Broadens argv.ts flag-detection to reject single-dash tokens (e.g. -h) as unknown flags rather than silently treating them as positionals. Builds on the recently merged --skip PR.