### PR TITLE
feat(scripts): add batch-open-issues.sh for per-issue tab fan-out

### DIFF
--- a/claude/scripts/batch-open-issues.sh
+++ b/claude/scripts/batch-open-issues.sh
@@ -13,8 +13,15 @@ set -euo pipefail
 # Exit codes:
 #   0 — success (all tabs spawned)
 #   2 — missing/invalid args, or required lib not found
-#   3 — unsupported terminal (cmux, Ghostty, or no recognized terminal)
+#   3 — unsupported terminal (standalone Ghostty, or no recognized terminal)
 #   4 — one or more tabs failed to spawn (partial success)
+#
+# Supported terminals:
+#   tmux   — new window via `tmux new-window -c "$PWD"`
+#   iTerm2 — new tab via AppleScript (inherits current session CWD)
+#   cmux   — new workspace via `cmux new-workspace --cwd "$PWD" --name "issue-<n>" --command "<cmd>"`
+#            cmux binary is located via $PATH first, falling back to
+#            /Applications/cmux.app/Contents/Resources/bin/cmux
 #
 # Dependencies:
 #   ~/.claude/hooks/lib-tab-rename.sh — sources _tab_rename_detect_terminal to
@@ -81,8 +88,8 @@ _tab_rename_detect_terminal
 
 # open_tab_for_issue <issue-number>
 # Dispatches a single tab/window spawn for the given issue number.
-# Handles ONLY the supported terminals (tmux, iterm2). The unsupported-terminal
-# cases (cmux, Ghostty-via-cmux, empty $TERMINAL) are handled by the pre-loop
+# Handles ONLY the supported terminals (tmux, iterm2, cmux). The unsupported-terminal
+# cases (standalone Ghostty, empty $TERMINAL) are handled by the pre-loop
 # check in the main loop and must never be reached here.
 # This function NEVER calls `exit` — it only `return`s. Returns 0 on successful
 # spawn, non-zero on spawn failure (or on the defensive default-branch case
@@ -103,6 +110,19 @@ open_tab_for_issue() {
         -e "tell current session of current tab of current window to write text \"myclaude --skip '/feature-issue ${n}'\""
       return $?
       ;;
+    cmux)
+      local cmux_bin=""
+      if command -v cmux >/dev/null 2>&1; then
+        cmux_bin="$(command -v cmux)"
+      elif [[ -x /Applications/cmux.app/Contents/Resources/bin/cmux ]]; then
+        cmux_bin="/Applications/cmux.app/Contents/Resources/bin/cmux"
+      else
+        printf 'batch-open-issues: cmux binary not found in PATH or at /Applications/cmux.app/Contents/Resources/bin/cmux — install cmux or ensure /Applications/cmux.app exists, then retry\n' >&2
+        return 1
+      fi
+      "$cmux_bin" new-workspace --cwd "$PWD" --name "issue-${n}" --command "myclaude --skip '/feature-issue ${n}'"
+      return $?
+      ;;
     *)
       # Defensive default — should be unreachable because the pre-loop check
       # exits before entering the loop for unsupported terminals.
@@ -113,12 +133,12 @@ open_tab_for_issue() {
 }
 
 # Pre-loop unsupported-terminal check — exits before any tab spawning.
-if [[ "$TERMINAL" == "cmux" ]]; then
-  if [[ "${TERM_PROGRAM:-}" == "ghostty" ]]; then
-    printf "batch-open-issues: ghostty is not supported (detected via cmux family) — open tabs manually and run \`myclaude --skip '/feature-issue <n>'\` in each\n" >&2
-  else
-    printf "batch-open-issues: cmux is not supported — open tabs manually and run \`myclaude --skip '/feature-issue <n>'\` in each\n" >&2
-  fi
+if [[ "$TERMINAL" == "cmux" && -z "${CMUX_WORKSPACE_ID:-}" ]]; then
+  # TERMINAL=cmux without CMUX_WORKSPACE_ID means lib-tab-rename detected
+  # standalone Ghostty (TERM_PROGRAM=ghostty without cmux running). cmux's
+  # new-workspace command requires a cmux instance, so this case is genuinely
+  # unsupported.
+  printf "batch-open-issues: standalone Ghostty (without cmux running) is not supported — open tabs manually and run \`myclaude --skip '/feature-issue <n>'\` in each\n" >&2
   exit 3
 elif [[ -z "$TERMINAL" ]]; then
   printf 'batch-open-issues: no supported terminal detected (TMUX, CMUX_WORKSPACE_ID, and the terminal program env var all unset or unrecognized)\n' >&2

--- a/claude/scripts/batch-open-issues.sh
+++ b/claude/scripts/batch-open-issues.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# batch-open-issues.sh
+# Spawns one new terminal tab/window per GitHub issue, each running myclaude --skip '/feature-issue <n>'
+#
+# Usage: batch-open-issues.sh <issue> [<issue> ...]
+#
+# Supported argument forms:
+#   - Bare integer:    42
+#   - Full GitHub URL: https://github.com/owner/repo/issues/42
+#                      (optional trailing /, #anchor, or ?query accepted)
+#
+# Exit codes:
+#   0 — success (all tabs spawned)
+#   2 — missing/invalid args, or required lib not found
+#   3 — unsupported terminal (cmux, Ghostty, or no recognized terminal)
+#   4 — one or more tabs failed to spawn (partial success)
+#
+# Dependencies:
+#   ~/.claude/hooks/lib-tab-rename.sh — sources _tab_rename_detect_terminal to
+#   populate $TERMINAL. Any change to that function's detection contract (the
+#   mapping of environment variables to TERMINAL values) requires
+#   updating this script in lockstep.
+#
+# myclaude contract dependency (documented, NOT probed at runtime):
+#   This script depends on the post-merge myclaude from the
+#   feat/forward-initial-command-to-claude-from-myclaude-cli PR, which extends
+#   myclaude to accept an initial-message positional argument alongside --skip.
+#   Runtime probing (e.g. myclaude --help) was deliberately removed: the
+#   post-merge myclaude has no --help handler — parseArgs rejects unknown flags
+#   by exiting non-zero — so any probe pipeline would always fail under
+#   set -euo pipefail, breaking the script on every invocation including
+#   correctly-installed environments. If running against a stale myclaude (one
+#   that predates the merged PR), the user will see N broken Claude sessions
+#   rather than one fail-fast error. Fix: re-run install.sh with an updated
+#   ai-tpk checkout.
+#
+# Spawn-vs-success caveat:
+#   Successful tab spawn does NOT guarantee myclaude started successfully inside
+#   the tab — verify tabs visually.
+#
+# iTerm2 assumption:
+#   iTerm2 new tabs inherit $PWD via 'create tab with default profile' — no
+#   explicit cd needed.
+
+if [[ $# -eq 0 ]]; then
+  printf 'Usage: batch-open-issues.sh <issue> [<issue> ...]\n' >&2
+  exit 2
+fi
+
+parse_issue_number() {
+  local arg="$1"
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$arg"
+    return 0
+  fi
+  if [[ "$arg" =~ ^https?://github\.com/[^/]+/[^/]+/issues/([0-9]+)([/#?].*)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf "batch-open-issues: cannot parse issue identifier '%s'\n" "$arg" >&2
+  return 2
+}
+
+ISSUE_NUMBERS=()
+for arg in "$@"; do
+  n=$(parse_issue_number "$arg") || exit 2
+  ISSUE_NUMBERS+=("$n")
+done
+
+LIB="${HOME}/.claude/hooks/lib-tab-rename.sh"
+if [[ ! -f "$LIB" ]]; then
+  printf 'batch-open-issues: required library not found at ~/.claude/hooks/lib-tab-rename.sh — re-run install.sh\n' >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+source "$LIB"
+
+_tab_rename_detect_terminal
+# $TERMINAL is now set to: tmux, cmux, iterm2, or ""
+
+# open_tab_for_issue <issue-number>
+# Dispatches a single tab/window spawn for the given issue number.
+# Handles ONLY the supported terminals (tmux, iterm2). The unsupported-terminal
+# cases (cmux, Ghostty-via-cmux, empty $TERMINAL) are handled by the pre-loop
+# check in the main loop and must never be reached here.
+# This function NEVER calls `exit` — it only `return`s. Returns 0 on successful
+# spawn, non-zero on spawn failure (or on the defensive default-branch case
+# below). The caller (the main loop) decides whether a single failure aborts
+# the run or accumulates into a partial-success summary. This separation is
+# required because `set -euo pipefail` would otherwise abort the loop on the
+# first failed spawn.
+open_tab_for_issue() {
+  local n="$1"
+  case "$TERMINAL" in
+    tmux)
+      tmux new-window -c "$PWD" "myclaude --skip '/feature-issue ${n}'"
+      return $?
+      ;;
+    iterm2)
+      osascript \
+        -e 'tell application "iTerm" to tell current window to create tab with default profile' \
+        -e "tell current session of current tab of current window to write text \"myclaude --skip '/feature-issue ${n}'\""
+      return $?
+      ;;
+    *)
+      # Defensive default — should be unreachable because the pre-loop check
+      # exits before entering the loop for unsupported terminals.
+      printf 'batch-open-issues: internal error — open_tab_for_issue called with unsupported TERMINAL=%s\n' "'${TERMINAL}'" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Pre-loop unsupported-terminal check — exits before any tab spawning.
+if [[ "$TERMINAL" == "cmux" ]]; then
+  if [[ "${TERM_PROGRAM:-}" == "ghostty" ]]; then
+    printf "batch-open-issues: ghostty is not supported (detected via cmux family) — open tabs manually and run \`myclaude --skip '/feature-issue <n>'\` in each\n" >&2
+  else
+    printf "batch-open-issues: cmux is not supported — open tabs manually and run \`myclaude --skip '/feature-issue <n>'\` in each\n" >&2
+  fi
+  exit 3
+elif [[ -z "$TERMINAL" ]]; then
+  printf 'batch-open-issues: no supported terminal detected (TMUX, CMUX_WORKSPACE_ID, and the terminal program env var all unset or unrecognized)\n' >&2
+  exit 3
+fi
+
+# Fan out: one tab per issue. `if ! ...` defangs set -e so a single spawn
+# failure does not abort the loop — we collect all failures and report them.
+failures=()
+successes=()
+for n in "${ISSUE_NUMBERS[@]}"; do
+  if ! open_tab_for_issue "$n"; then
+    printf 'batch-open-issues: failed to spawn tab for issue %s\n' "$n" >&2
+    failures+=("$n")
+  else
+    successes+=("$n")
+  fi
+done
+
+# Summary
+if [[ ${#successes[@]} -gt 0 ]]; then
+  printf 'batch-open-issues: spawned %d tab(s) for issues %s\n' "${#successes[@]}" "${successes[*]}"
+  printf 'batch-open-issues: NOTE — spawn success does not guarantee myclaude started successfully inside each tab; verify tabs visually.\n'
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  exit 4
+fi
+exit 0

--- a/docs/MYCLAUDE.md
+++ b/docs/MYCLAUDE.md
@@ -47,6 +47,35 @@ In both cases, run `myclaude` without `--skip` to (re)configure.
 
 **Unknown flags** are rejected with exit code 2. Any token other than `--skip` prints `Unknown flag: <flag>. Usage: myclaude [--skip]` to stderr and exits immediately.
 
+### `batch-open-issues.sh`: open one tab per issue
+
+`batch-open-issues.sh` is a helper script installed to `~/.claude/scripts/` that accepts one or more GitHub issue numbers (or full issue URLs) and opens one new terminal tab or window per issue, each running `myclaude --skip '/feature-issue <n>'`.
+
+**Usage:**
+
+```bash
+batch-open-issues.sh 42 123 https://github.com/owner/repo/issues/7
+```
+
+Each argument can be a bare integer (`42`) or a GitHub issue URL in the form `https://github.com/<owner>/<repo>/issues/<n>` (with an optional trailing `/`, `?query`, or `#anchor`).
+
+**Supported terminals:** tmux (new window with `-c "$PWD"`) and iTerm2 (new tab via AppleScript, inherits current session CWD). cmux and Ghostty are not supported and produce a clear error with exit code 3.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | All tabs spawned successfully |
+| 2 | Missing or unparseable arguments, or required library not found |
+| 3 | Unsupported or undetected terminal |
+| 4 | One or more tab spawns failed (partial success) |
+
+**Prerequisite:** Requires the `feat/forward-initial-command-to-claude-from-myclaude-cli` PR to be merged before use. That PR extends `myclaude` to accept an initial-message positional argument alongside `--skip`. If your installed `myclaude` predates that merge, the tabs will open but each session will fail silently — re-run `install.sh` against an updated checkout to fix.
+
+**Spawn success is not session success.** The script reports whether the tab was opened, not whether `myclaude` started correctly inside it. Verify each tab visually after launch.
+
+The script header comment is the authoritative reference for usage, exit codes, and dependencies.
+
 ## Grafana Configuration
 
 Create `~/.config/grafana-clusters.yaml` with your cluster definitions. The file must use this YAML schema:

--- a/docs/MYCLAUDE.md
+++ b/docs/MYCLAUDE.md
@@ -59,7 +59,7 @@ batch-open-issues.sh 42 123 https://github.com/owner/repo/issues/7
 
 Each argument can be a bare integer (`42`) or a GitHub issue URL in the form `https://github.com/<owner>/<repo>/issues/<n>` (with an optional trailing `/`, `?query`, or `#anchor`).
 
-**Supported terminals:** tmux (new window with `-c "$PWD"`) and iTerm2 (new tab via AppleScript, inherits current session CWD). cmux and Ghostty are not supported and produce a clear error with exit code 3.
+**Supported terminals:** tmux (new window with `-c "$PWD"`), iTerm2 (new tab via AppleScript, inherits current session CWD), and cmux (new workspace via `cmux new-workspace --cwd "$PWD" --name "issue-<n>" --command "<cmd>"`). cmux is detected via `$CMUX_WORKSPACE_ID` (set automatically inside any cmux terminal session). The cmux binary is located by searching `$PATH` first, then falling back to the bundled CLI at `/Applications/cmux.app/Contents/Resources/bin/cmux`. If neither resolves, that issue's spawn fails (recorded in the partial-failure summary) but other issues continue. Standalone Ghostty (Ghostty running without cmux) is not supported and produces exit code 3.
 
 **Exit codes:**
 
@@ -67,7 +67,7 @@ Each argument can be a bare integer (`42`) or a GitHub issue URL in the form `ht
 |------|---------|
 | 0 | All tabs spawned successfully |
 | 2 | Missing or unparseable arguments, or required library not found |
-| 3 | Unsupported or undetected terminal |
+| 3 | Unsupported terminal (standalone Ghostty) or undetected terminal |
 | 4 | One or more tab spawns failed (partial success) |
 
 **Prerequisite:** Requires the `feat/forward-initial-command-to-claude-from-myclaude-cli` PR to be merged before use. That PR extends `myclaude` to accept an initial-message positional argument alongside `--skip`. If your installed `myclaude` predates that merge, the tabs will open but each session will fail silently — re-run `install.sh` against an updated checkout to fix.


### PR DESCRIPTION
Adds a bash script that accepts a list of GitHub issue numbers or URLs and opens one new terminal tab per issue, each running `myclaude --skip '/feature-issue <n>'`. Terminal detection reuses the existing `lib-tab-rename.sh` logic — tmux and iTerm2 are supported; cmux and Ghostty produce a clear actionable error. The script is installed to `~/.claude/scripts/` via the existing `install.sh` whitelist and requires the `feat/forward-initial-command-to-claude-from-myclaude-cli` PR to be merged before use.