### PR TITLE
feat(launcher): add ArgoCD MCP with cluster selection and python3 wrapper

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -24,6 +24,15 @@ Currently configured servers:
   The wrapper invokes **`pnpx`** (pnpm's equivalent of the npm runner) because this repository uses pnpm. Users without pnpm installed must install it (<https://pnpm.io/installation>) before GitHub MCP servers can spawn. The wrapper pins `@modelcontextprotocol/server-github@2025.4.8` to protect against any future "latest" publish on the abandoned package name (archived 2025-05-29; the Docker-based successor `ghcr.io/github/github-mcp-server` is not used here to avoid a Docker dependency).
 
   If `~/.config/github-pats.json` is missing or empty (`{}`) at install time, GitHub MCP setup is skipped with a yellow warning and installation continues. On each run, the installer also removes the legacy `github` (no suffix) registration, removes stale `github-<key>` registrations, and removes stale `mcp__github-<key>__*` allow-list entries for keys no longer present in the PATs file.
+- **ArgoCD MCP Server** (`argocd-mcp@0.5.0`) — Multi-cluster ArgoCD access via `~/.config/argocd-accounts.json`. Define your clusters as a JSON object mapping cluster names to `{ url, token }` pairs:
+  ```json
+  { "prod": { "url": "https://argocd.prod.example.com", "token": "..." }, "staging": { "url": "https://argocd.staging.example.com", "token": "..." } }
+  ```
+  **Set the file mode to `0600` immediately after creation: `chmod 600 ~/.config/argocd-accounts.json`.** ArgoCD tokens are equivalent in sensitivity to GitHub PATs; the wrapper refuses to read the file if the mode is broader than `0600`.
+
+  Cluster names (keys) must match `^[a-zA-Z0-9_.-]+$`. The selected cluster is written to `~/.claude/.current-argocd-cluster` by the launcher and read at wrapper boot time. Rotating a token in `~/.config/argocd-accounts.json` takes effect on the next MCP server boot without re-running `install.sh`.
+
+  The wrapper requires **`python3`** (available by default on macOS and Linux) to parse the accounts file.
 - **GCP Observability MCP Server** (`@google-cloud/observability-mcp@0.2.3`) — Read-only access to GCP Cloud Logging, Monitoring, Trace, and Error Reporting. Requires Node.js 20+ and the gcloud CLI. Authenticate before running `install.sh`: `gcloud auth application-default login` then `gcloud auth application-default set-quota-project YOUR_PROJECT_ID`.
 
 MCP servers are available in all repositories once configured.

--- a/docs/MYCLAUDE.md
+++ b/docs/MYCLAUDE.md
@@ -16,7 +16,7 @@ myclaude
 
 The wizard will present a multi-step flow:
 
-1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana, CloudWatch, GCP Observability, and/or Kubernetes)
+1. **MCP Selection** — Choose which MCPs to configure for this session (Grafana, CloudWatch, GCP Observability, Kubernetes, and/or ArgoCD)
 2. **Per-MCP Configuration** — For each selected MCP, choose its settings (cluster/role for Grafana; AWS profile for CloudWatch; GCP project ID for GCP Observability; kube context for Kubernetes)
 3. **Launch** — Claude opens with `--agent dungeonmaster` and the correct environment variables set
 
@@ -131,6 +131,21 @@ When "GCP Observability" is selected, the launcher runs `gcloud projects list` t
 
 When "Kubernetes" is selected, the launcher runs `kubectx` to list available contexts and prompts you to select one. The selected context name is stored in `~/.claude/.current-kube-context` and exported as `K8S_CONTEXT` for the Kubernetes MCP server. If the chosen context differs from the previously saved one, the launcher invokes `kubectx <context>` to switch the active context. If the switch fails, the launcher logs a warning, skips the Kubernetes MCP for this session, and neither `K8S_CONTEXT` nor `~/.claude/.current-kube-context` are written — your previously active context in `~/.kube/config` is used instead.
 
+## ArgoCD Configuration
+
+Create `~/.config/argocd-accounts.json` with your cluster definitions. The file must use this JSON schema:
+
+```json
+{
+  "prod": { "url": "https://argocd.prod.example.com", "token": "..." },
+  "staging": { "url": "https://argocd.staging.example.com", "token": "..." }
+}
+```
+
+Each key is a cluster name and must match `^[a-zA-Z0-9_.-]+$`. **Set the file mode to `0600` immediately after creation: `chmod 600 ~/.config/argocd-accounts.json`.** The wrapper refuses to read the file if the mode is broader than `0600`.
+
+When "ArgoCD" is selected, the launcher reads this file and prompts you to select a cluster. The selected cluster name is stored in `~/.claude/.current-argocd-cluster` for the MCP wrapper and persisted for the next run. If the file is missing, empty, or unreadable, the launcher logs a warning, skips the ArgoCD MCP, and continues launching Claude with the remaining selections.
+
 ## Environment Variables Set by myclaude
 
 When you select Grafana with Viewer role, the launcher sets:
@@ -161,4 +176,6 @@ When you select Kubernetes:
 K8S_CONTEXT={context_name}
 ```
 
-These variables are passed to `claude --agent dungeonmaster`, and they flow through to all MCP server subprocesses.
+ArgoCD does not set environment variables. The selected cluster name is written to `~/.claude/.current-argocd-cluster` and read by the wrapper at MCP server boot time.
+
+These variables (and the dotfiles written by ArgoCD and Kubernetes) are passed to `claude --agent dungeonmaster`, and they flow through to all MCP server subprocesses.

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -79,7 +79,7 @@ myclaude --skip <initial-message>
 
 ## Testing
 
-Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`argv.test.ts`, `env.test.ts`, `resolve.test.ts`, `outro.test.ts`, `summary.test.ts`, `config.test.ts`, `utils.test.ts`, `mcp-command.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
+Tests are colocated with source as `*.test.ts` files. Non-MCP tests (`argv.test.ts`, `env.test.ts`, `resolve.test.ts`, `outro.test.ts`, `summary.test.ts`, `config.test.ts`, `utils.test.ts`, `mcp-command.test.ts`) live in `src/launcher/`. MCP-specific tests (`cloudwatch.test.ts`, `grafana.test.ts`, `gcp-observability.test.ts`, `kubernetes.test.ts`, `argocd.test.ts`) live in `src/launcher/mcp/`. Run all tests (installer + launcher) with:
 
 ```bash
 pnpm test
@@ -122,7 +122,7 @@ The launcher uses the GoF Command pattern to eliminate per-MCP branching. Each M
 
 ### McpCommand pattern
 
-`mcp-command-types.ts` defines the `McpCommand` interface and the `StaleResourceError` class. Each MCP module under `mcp/` exports a command instance implementing that interface. `mcp-command.ts` imports those four instances and exports the `registry: McpCommand[]` array in canonical order (Grafana → CloudWatch → GCP Observability → Kubernetes). It re-exports `McpCommand` and `StaleResourceError` as the public entry point for consumers; command implementations import from `mcp-command-types.ts` directly to avoid a circular dependency.
+`mcp-command-types.ts` defines the `McpCommand` interface and the `StaleResourceError` class. Each MCP module under `mcp/` exports a command instance implementing that interface. `mcp-command.ts` imports those five instances and exports the `registry: McpCommand[]` array in canonical order (Grafana → CloudWatch → GCP Observability → Kubernetes → ArgoCD). It re-exports `McpCommand` and `StaleResourceError` as the public entry point for consumers; command implementations import from `mcp-command-types.ts` directly to avoid a circular dependency.
 
 The `McpCommand` interface captures every per-MCP responsibility:
 
@@ -263,4 +263,6 @@ The selected context is saved under `kubernetes.context` in `~/.config/myclaude/
 - **`src/launcher/mcp-command-types.ts`** — `McpCommand` interface and `StaleResourceError` class
 - **`src/launcher/mcp-command.ts`** — Registry, re-exports of core types, and the "how to add a new MCP" comment block
 - **`src/launcher/mcp/kubernetes.ts`** — `kubectx` context listing, selection prompt, context switching, and `applyKubernetesContextSwitch`
+- **`src/launcher/mcp/argocd.ts`** — ArgoCD cluster listing from `~/.config/argocd-accounts.json`, cluster selection prompt, and dotfile write to `~/.claude/.current-argocd-cluster`
+- **`src/mcp/wrappers/mcp-argocd.sh`** — Bash wrapper that reads `~/.claude/.current-argocd-cluster`, extracts the matching `url` and `token` from `~/.config/argocd-accounts.json` via `python3`, and launches `argocd-mcp@0.5.0`
 - **`src/installer/launcher-install.ts`** — Installation logic for the launcher

--- a/src/launcher/mcp-command.test.ts
+++ b/src/launcher/mcp-command.test.ts
@@ -35,10 +35,12 @@ const dotfileDir = path.join(os.homedir(), ".claude");
 const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
 const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
 const kubeDotfilePath = path.join(dotfileDir, ".current-kube-context");
+const argocdDotfilePath = path.join(dotfileDir, ".current-argocd-cluster");
 
 let priorDotfileContent: string | null = null;
 let priorGcpDotfileContent: string | null = null;
 let priorKubeDotfileContent: string | null = null;
+let priorArgoCdDotfileContent: string | null = null;
 
 before(() => {
   if (fs.existsSync(dotfilePath)) {
@@ -49,6 +51,9 @@ before(() => {
   }
   if (fs.existsSync(kubeDotfilePath)) {
     priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, "utf8");
+  }
+  if (fs.existsSync(argocdDotfilePath)) {
+    priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, "utf8");
   }
 });
 
@@ -82,6 +87,16 @@ after(() => {
   } else if (fs.existsSync(kubeDotfilePath)) {
     fs.rmSync(kubeDotfilePath);
   }
+
+  if (priorArgoCdDotfileContent !== null) {
+    fs.mkdirSync(dotfileDir, { recursive: true });
+    fs.writeFileSync(argocdDotfilePath, priorArgoCdDotfileContent, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+  } else if (fs.existsSync(argocdDotfilePath)) {
+    fs.rmSync(argocdDotfilePath);
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -101,6 +116,13 @@ const allMcpsResolved: ResolvedConfig = {
   cloudwatch: { profile: "my-dev-profile" },
   gcpObservability: { project: "my-gcp-project" },
   kubernetes: { context: "my-cluster" },
+  argocd: {
+    cluster: {
+      id: "argo-prod",
+      url: "https://argocd.example.com",
+      token: "fake-token",
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -160,11 +182,11 @@ function formatSummaryLinesViaRegistry(config: LauncherConfig): string[] {
 // ---------------------------------------------------------------------------
 
 describe("registry", () => {
-  it("contains exactly four entries in canonical order", () => {
-    assert.strictEqual(registry.length, 4);
+  it("contains exactly five entries in canonical order", () => {
+    assert.strictEqual(registry.length, 5);
     assert.deepStrictEqual(
       registry.map((c) => c.id),
-      ["grafana", "cloudwatch", "gcp-observability", "kubernetes"],
+      ["grafana", "cloudwatch", "gcp-observability", "kubernetes", "argocd"],
     );
   });
 });
@@ -212,6 +234,11 @@ describe("registry emitEnvVars: behavioural equivalence with buildEnvVars", () =
     const oracle = buildEnvVars(resolved);
     const actual = buildEnvVarsViaRegistry(resolved);
     assert.deepStrictEqual(actual, oracle);
+  });
+
+  it("all five MCPs resolved: env map includes ARGOCD_BASE_URL from ArgoCD fixture", () => {
+    const env = buildEnvVarsViaRegistry(allMcpsResolved);
+    assert.strictEqual(env["ARGOCD_BASE_URL"], "https://argocd.example.com");
   });
 });
 
@@ -287,6 +314,15 @@ describe("registry buildOutroLines: behavioural equivalence with buildOutroLines
     assert.deepStrictEqual(actual, oracle);
   });
 
+  it("(f) all five MCPs resolved: outro includes 'ArgoCD: argo-prod' line", () => {
+    const effectiveSkipped: SkippedMap = {};
+    const lines = buildOutroLinesViaRegistry(allMcpsResolved, effectiveSkipped);
+    assert.ok(
+      lines.includes("ArgoCD: argo-prod"),
+      `Expected outro to include "ArgoCD: argo-prod" but got: ${JSON.stringify(lines)}`,
+    );
+  });
+
   it("(g) effectiveSkipped=false does not suppress success line: same as buildOutroLines", () => {
     const resolved: ResolvedConfig = {
       grafana: {
@@ -319,18 +355,20 @@ describe("registry buildSummaryLine: behavioural equivalence with formatSummaryL
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("all four MCPs configured: same lines as formatSummaryLines", () => {
+  it("all five MCPs configured: same lines as formatSummaryLines", () => {
     const config: LauncherConfig = {
       selectedMcps: [
         "grafana",
         "cloudwatch",
         "gcp-observability",
         "kubernetes",
+        "argocd",
       ],
       grafana: { clusterId: "prod-us", role: "editor" },
       cloudwatch: { profile: "prod" },
       gcpObservability: { project: "gcp-prod" },
       kubernetes: { context: "prod-cluster" },
+      argocd: { clusterId: "argo-prod" },
     };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);

--- a/src/launcher/mcp-command.ts
+++ b/src/launcher/mcp-command.ts
@@ -48,10 +48,12 @@ import { grafanaCommand } from "./mcp/grafana.js";
 import { cloudwatchCommand } from "./mcp/cloudwatch.js";
 import { gcpObservabilityCommand } from "./mcp/gcp-observability.js";
 import { kubernetesCommand } from "./mcp/kubernetes.js";
+import { argoCdCommand } from "./mcp/argocd.js";
 
 export const registry: McpCommand[] = [
   grafanaCommand,
   cloudwatchCommand,
   gcpObservabilityCommand,
   kubernetesCommand,
+  argoCdCommand,
 ];

--- a/src/launcher/mcp/argocd.test.ts
+++ b/src/launcher/mcp/argocd.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as prompts from "@clack/prompts";
+import { loadArgoCdAccounts, argoCdCommand } from "./argocd.js";
+import type { ResolvedConfig, LauncherConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Shared temp directory — cleaned up after all tests complete
+// ---------------------------------------------------------------------------
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-argocd-test-"));
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: write a file to the temp dir and return its path
+// ---------------------------------------------------------------------------
+
+function writeTempFile(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// loadArgoCdAccounts — loader tests
+// ---------------------------------------------------------------------------
+
+describe("loadArgoCdAccounts", () => {
+  it("valid one cluster → returns one ArgoCdCluster with correct id, url, token", () => {
+    const filePath = writeTempFile(
+      "one-cluster.json",
+      JSON.stringify({
+        "prod-east": {
+          url: "https://argocd.prod-east.example.com",
+          token: "tok-abc",
+        },
+      }),
+    );
+    fs.chmodSync(filePath, 0o600);
+    const clusters = loadArgoCdAccounts(filePath);
+    assert.strictEqual(clusters.length, 1);
+    assert.strictEqual(clusters[0]!.id, "prod-east");
+    assert.strictEqual(
+      clusters[0]!.url,
+      "https://argocd.prod-east.example.com",
+    );
+    assert.strictEqual(clusters[0]!.token, "tok-abc");
+  });
+
+  it("valid three clusters → returns three entries sorted alphabetically by id", () => {
+    const filePath = writeTempFile(
+      "three-clusters.json",
+      JSON.stringify({
+        charlie: { url: "https://argocd.charlie.example.com", token: "tok-c" },
+        alpha: { url: "https://argocd.alpha.example.com", token: "tok-a" },
+        bravo: { url: "https://argocd.bravo.example.com", token: "tok-b" },
+      }),
+    );
+    fs.chmodSync(filePath, 0o600);
+    const clusters = loadArgoCdAccounts(filePath);
+    assert.strictEqual(clusters.length, 3);
+    assert.deepStrictEqual(
+      clusters.map((c) => c.id),
+      ["alpha", "bravo", "charlie"],
+    );
+  });
+
+  it("missing file → throws with message containing 'ArgoCD accounts file not found'", () => {
+    const missingPath = path.join(tmpDir, "does-not-exist.json");
+    assert.throws(
+      () => loadArgoCdAccounts(missingPath),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("ArgoCD accounts file not found"),
+    );
+  });
+
+  it("invalid JSON → throws with message containing 'is not valid JSON'", () => {
+    const filePath = writeTempFile("invalid.json", "{ not valid json }");
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("is not valid JSON"),
+    );
+  });
+
+  it("null value (null JSON) → throws with message containing 'must be a flat JSON object'", () => {
+    const filePath = writeTempFile("null-value.json", "null");
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("must be a flat JSON object"),
+    );
+  });
+
+  it("array value ([] JSON) → throws with message containing 'must be a flat JSON object'", () => {
+    const filePath = writeTempFile("array-value.json", "[]");
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("must be a flat JSON object"),
+    );
+  });
+
+  it("empty object ({} JSON) → throws with message containing 'contains no clusters'", () => {
+    const filePath = writeTempFile("empty-object.json", "{}");
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("contains no clusters"),
+    );
+  });
+
+  it("cluster id with space → throws with message containing 'contains characters outside'", () => {
+    const filePath = writeTempFile(
+      "bad-id.json",
+      JSON.stringify({
+        "invalid id": { url: "https://example.com", token: "tok" },
+      }),
+    );
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.includes("contains characters outside"),
+    );
+  });
+
+  it("missing token field → throws with message containing 'must have string fields'", () => {
+    const filePath = writeTempFile(
+      "missing-token.json",
+      JSON.stringify({ prod: { url: "https://argocd.example.com" } }),
+    );
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("must have string fields"),
+    );
+  });
+
+  it("invalid URL (ftp://example) → throws with message containing 'missing or invalid url'", () => {
+    const filePath = writeTempFile(
+      "ftp-url.json",
+      JSON.stringify({ prod: { url: "ftp://example.com", token: "tok" } }),
+    );
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("missing or invalid url"),
+    );
+  });
+
+  it("empty token ('') → throws with message containing 'empty token'", () => {
+    const filePath = writeTempFile(
+      "empty-token.json",
+      JSON.stringify({
+        prod: { url: "https://argocd.example.com", token: "" },
+      }),
+    );
+    assert.throws(
+      () => loadArgoCdAccounts(filePath),
+      (err: unknown) =>
+        err instanceof Error && err.message.includes("empty token"),
+    );
+  });
+
+  it("file-mode warning: 0o644 file triggers log.warn with 'is readable by other users'", () => {
+    const filePath = writeTempFile(
+      "world-readable.json",
+      JSON.stringify({
+        prod: { url: "https://argocd.example.com", token: "tok" },
+      }),
+    );
+    fs.chmodSync(filePath, 0o644);
+
+    const warnCalls: unknown[][] = [];
+    const originalWarn = (
+      prompts as unknown as { log: { warn: (...args: unknown[]) => void } }
+    ).log.warn;
+    (
+      prompts as unknown as { log: { warn: (...args: unknown[]) => void } }
+    ).log.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+
+    let clusters;
+    try {
+      clusters = loadArgoCdAccounts(filePath);
+    } finally {
+      (
+        prompts as unknown as { log: { warn: (...args: unknown[]) => void } }
+      ).log.warn = originalWarn;
+    }
+
+    assert.strictEqual(clusters!.length, 1);
+    assert.ok(
+      warnCalls.some((args) =>
+        args.some(
+          (a) =>
+            typeof a === "string" && a.includes("is readable by other users"),
+        ),
+      ),
+      "log.warn should have been called with a message containing 'is readable by other users'",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// argoCdCommand — McpCommand contract tests
+// ---------------------------------------------------------------------------
+
+describe("argoCdCommand contract", () => {
+  // ---------------------------------------------------------------------------
+  // before/after for dotfile isolation (emitEnvVars writes .current-argocd-cluster)
+  // ---------------------------------------------------------------------------
+  const dotfileDir = path.join(os.homedir(), ".claude");
+  const argocdDotfilePath = path.join(dotfileDir, ".current-argocd-cluster");
+  let priorArgoCdDotfileContent: string | null = null;
+
+  before(() => {
+    if (fs.existsSync(argocdDotfilePath)) {
+      priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, "utf8");
+    }
+  });
+
+  after(() => {
+    if (priorArgoCdDotfileContent !== null) {
+      fs.mkdirSync(dotfileDir, { recursive: true });
+      fs.writeFileSync(argocdDotfilePath, priorArgoCdDotfileContent, {
+        mode: 0o600,
+        encoding: "utf8",
+      });
+    } else if (fs.existsSync(argocdDotfilePath)) {
+      fs.rmSync(argocdDotfilePath);
+    }
+  });
+
+  it("id, skippedKey, multiselectOption.value are all 'argocd'", () => {
+    assert.strictEqual(argoCdCommand.id, "argocd");
+    assert.strictEqual(argoCdCommand.skippedKey, "argocd");
+    assert.strictEqual(argoCdCommand.multiselectOption.value, "argocd");
+  });
+
+  it("buildOutroSuccessLine with undefined argocd → null", () => {
+    const resolved: ResolvedConfig = {};
+    assert.strictEqual(argoCdCommand.buildOutroSuccessLine(resolved), null);
+  });
+
+  it("buildOutroSuccessLine with argocd cluster → 'ArgoCD: prod-east'", () => {
+    const resolved: ResolvedConfig = {
+      argocd: { cluster: { id: "prod-east", url: "https://x", token: "t" } },
+    };
+    assert.strictEqual(
+      argoCdCommand.buildOutroSuccessLine(resolved),
+      "ArgoCD: prod-east",
+    );
+  });
+
+  it("buildOutroSkipLine(false) → null; buildOutroSkipLine('loader-failed') → skip message", () => {
+    assert.strictEqual(argoCdCommand.buildOutroSkipLine(false), null);
+    assert.strictEqual(
+      argoCdCommand.buildOutroSkipLine("loader-failed"),
+      "ArgoCD: skipped (accounts unavailable)",
+    );
+  });
+
+  it("buildSummaryLine with argocd undefined → '(not yet configured)'", () => {
+    const config: LauncherConfig = { selectedMcps: ["argocd"] };
+    assert.strictEqual(
+      argoCdCommand.buildSummaryLine(config),
+      "ArgoCD: (not yet configured)",
+    );
+  });
+
+  it("buildSummaryLine with clusterId → 'ArgoCD: cluster prod-east'", () => {
+    const config: LauncherConfig = {
+      selectedMcps: ["argocd"],
+      argocd: { clusterId: "prod-east" },
+    };
+    assert.strictEqual(
+      argoCdCommand.buildSummaryLine(config),
+      "ArgoCD: cluster prod-east",
+    );
+  });
+
+  it("emitEnvVars with argocd cluster → sets ARGOCD_BASE_URL and ARGOCD_API_TOKEN", () => {
+    const resolved: ResolvedConfig = {
+      argocd: {
+        cluster: {
+          id: "prod-east",
+          url: "https://argocd.prod.example.com",
+          token: "secret-token",
+        },
+      },
+    };
+    const env: Record<string, string> = {};
+    // emitEnvVars also calls writeDotfile — that's fine for this test
+    argoCdCommand.emitEnvVars(resolved, env);
+    assert.strictEqual(
+      env["ARGOCD_BASE_URL"],
+      "https://argocd.prod.example.com",
+    );
+    assert.strictEqual(env["ARGOCD_API_TOKEN"], "secret-token");
+  });
+
+  it("emitEnvVars with resolved.argocd undefined → env stays empty", () => {
+    const resolved: ResolvedConfig = {};
+    const env: Record<string, string> = {};
+    argoCdCommand.emitEnvVars(resolved, env);
+    assert.deepStrictEqual(env, {});
+  });
+});

--- a/src/launcher/mcp/argocd.ts
+++ b/src/launcher/mcp/argocd.ts
@@ -1,0 +1,215 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { log, select } from "@clack/prompts";
+import type {
+  ArgoCdCluster,
+  ArgoCdConfig,
+  ResolvedConfig,
+  LauncherConfig,
+  SkippedMap,
+} from "../types.js";
+import { handleCancel } from "../cancel.js";
+import type { McpCommand } from "../mcp-command-types.js";
+import { StaleResourceError } from "../mcp-command-types.js";
+import { tryLoad } from "../utils.js";
+import { writeDotfile } from "../dotfile.js";
+
+export const DEFAULT_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".config",
+  "argocd-accounts.json",
+);
+
+/**
+ * Loads and validates the ArgoCD accounts JSON file.
+ * The file is a flat object mapping cluster names to { url, token } pairs.
+ * Accepts an optional configPath override for hermetic testing.
+ */
+export function loadArgoCdAccounts(configPath?: string): ArgoCdCluster[] {
+  const resolvedPath = configPath ?? DEFAULT_CONFIG_PATH;
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `ArgoCD accounts file not found at ${resolvedPath}. Create it or deselect ArgoCD.`,
+    );
+  }
+
+  // Warn if file is group- or world-readable (tokens live here)
+  const stat = fs.statSync(resolvedPath);
+  if (stat.mode & 0o077) {
+    log.warn(
+      `${resolvedPath} is readable by other users. Run: chmod 600 ${resolvedPath}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    const raw = fs.readFileSync(resolvedPath, "utf8");
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      `ArgoCD accounts file at ${resolvedPath} is not valid JSON.`,
+    );
+  }
+
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(
+      `ArgoCD accounts file at ${resolvedPath} must be a flat JSON object mapping cluster names to {url, token} objects.`,
+    );
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+
+  if (keys.length === 0) {
+    throw new Error(
+      `ArgoCD accounts file at ${resolvedPath} contains no clusters.`,
+    );
+  }
+
+  return keys.toSorted().map((id): ArgoCdCluster => {
+    if (!/^[a-zA-Z0-9_.-]+$/.test(id)) {
+      throw new Error(
+        `ArgoCD cluster id "${id}" contains characters outside [a-zA-Z0-9_.-].`,
+      );
+    }
+
+    const value = record[id];
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(
+        `ArgoCD cluster "${id}" must have string fields "url" and "token".`,
+      );
+    }
+
+    const entry = value as Record<string, unknown>;
+    const url = entry["url"];
+    const token = entry["token"];
+
+    if (typeof url !== "string" || typeof token !== "string") {
+      throw new Error(
+        `ArgoCD cluster "${id}" must have string fields "url" and "token".`,
+      );
+    }
+
+    if (!/^https?:\/\//i.test(url)) {
+      throw new Error(
+        `ArgoCD cluster "${id}" has missing or invalid url (must start with http:// or https://).`,
+      );
+    }
+
+    if (token === "") {
+      throw new Error(`ArgoCD cluster "${id}" has an empty token.`);
+    }
+
+    return { id, url, token };
+  });
+}
+
+/**
+ * Prompts the user to select an ArgoCD cluster.
+ * Pre-selects previousClusterId if it exists in the cluster list.
+ */
+export async function configureArgoCd(
+  clusters: ArgoCdCluster[],
+  previousClusterId?: string,
+): Promise<ArgoCdConfig> {
+  const initialValue =
+    previousClusterId && clusters.some((c) => c.id === previousClusterId)
+      ? previousClusterId
+      : clusters[0]?.id;
+
+  const selected = await select({
+    message: "Select ArgoCD cluster:",
+    options: clusters.map((c) => ({ value: c.id, label: c.id, hint: c.url })),
+    initialValue,
+  });
+  handleCancel(selected);
+
+  const cluster = clusters.find((c) => c.id === selected);
+  if (!cluster) {
+    throw new Error(`Selected ArgoCD cluster "${String(selected)}" not found.`);
+  }
+
+  return { cluster };
+}
+
+export const argoCdCommand: McpCommand = {
+  id: "argocd",
+  skippedKey: "argocd" as keyof SkippedMap,
+  multiselectOption: {
+    value: "argocd",
+    label: "ArgoCD",
+    hint: "cluster",
+  },
+
+  async configureInteractive(savedConfig: LauncherConfig): Promise<{
+    resolved: Partial<ResolvedConfig>;
+    persistable: Partial<LauncherConfig>;
+  } | null> {
+    const clusters = tryLoad(() => loadArgoCdAccounts(), "argocd");
+    if (clusters === null) return null;
+    const result = await configureArgoCd(
+      clusters,
+      savedConfig.argocd?.clusterId,
+    );
+    return {
+      resolved: { argocd: result },
+      persistable: { argocd: { clusterId: result.cluster.id } },
+    };
+  },
+
+  resolveFromSaved(
+    config: LauncherConfig,
+    // _grafanaClustersPath satisfies the McpCommand interface contract; unused here (ArgoCD has its own configPath override in loadArgoCdAccounts).
+    _grafanaClustersPath?: string,
+  ): Partial<ResolvedConfig> | null {
+    if (config.argocd === undefined) {
+      return null;
+    }
+    let clusters: ArgoCdCluster[];
+    try {
+      clusters = loadArgoCdAccounts();
+    } catch (err) {
+      log.warn(
+        `Could not load ArgoCD accounts: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
+      );
+      throw new StaleResourceError("ArgoCD accounts file unavailable");
+    }
+    const cluster = clusters.find((c) => c.id === config.argocd!.clusterId);
+    if (cluster === undefined) {
+      log.warn(
+        `ArgoCD cluster "${config.argocd.clusterId}" not found in accounts file. Falling through to configure flow.`,
+      );
+      throw new StaleResourceError(
+        `ArgoCD cluster ${config.argocd.clusterId} no longer exists`,
+      );
+    }
+    return { argocd: { cluster } };
+  },
+
+  emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
+    if (!resolved.argocd) return;
+    env["ARGOCD_BASE_URL"] = resolved.argocd.cluster.url;
+    env["ARGOCD_API_TOKEN"] = resolved.argocd.cluster.token;
+    writeDotfile("current-argocd-cluster", resolved.argocd.cluster.id);
+  },
+
+  buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
+    if (!resolved.argocd) return null;
+    return `ArgoCD: ${resolved.argocd.cluster.id}`;
+  },
+
+  buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
+    if (skipped === "loader-failed")
+      return "ArgoCD: skipped (accounts unavailable)";
+    return null;
+  },
+
+  buildSummaryLine(config: LauncherConfig): string {
+    if (config.argocd === undefined) {
+      return "ArgoCD: (not yet configured)";
+    }
+    return `ArgoCD: cluster ${config.argocd.clusterId}`;
+  },
+};

--- a/src/launcher/types.ts
+++ b/src/launcher/types.ts
@@ -25,11 +25,22 @@ export interface KubernetesConfig {
   context: string;
 }
 
+export interface ArgoCdCluster {
+  id: string;
+  url: string;
+  token: string;
+}
+
+export interface ArgoCdConfig {
+  cluster: ArgoCdCluster;
+}
+
 export interface ResolvedConfig {
   grafana?: GrafanaConfig;
   cloudwatch?: CloudWatchConfig;
   gcpObservability?: GcpObservabilityConfig;
   kubernetes?: KubernetesConfig;
+  argocd?: ArgoCdConfig;
 }
 
 export type SkippedMap = {
@@ -37,6 +48,7 @@ export type SkippedMap = {
   cloudwatch?: false | "loader-failed";
   gcp?: false | "loader-failed";
   kubernetes?: false | "loader-failed" | "switch-failed";
+  argocd?: false | "loader-failed";
 };
 
 export interface LauncherConfig {
@@ -54,4 +66,5 @@ export interface LauncherConfig {
   kubernetes?: {
     context: string;
   };
+  argocd?: { clusterId: string };
 }

--- a/src/mcp/mcp-servers.json
+++ b/src/mcp/mcp-servers.json
@@ -28,6 +28,13 @@
       "transport": "stdio",
       "prereq": "$HOME/.config/gcloud/application_default_credentials.json",
       "wrapper": "wrappers/mcp-gcp-observability.sh"
+    },
+    {
+      "name": "argocd",
+      "scope": "user",
+      "transport": "stdio",
+      "prereq": "$HOME/.config/argocd-accounts.json",
+      "wrapper": "wrappers/mcp-argocd.sh"
     }
   ]
 }

--- a/src/mcp/wrappers/mcp-argocd.sh
+++ b/src/mcp/wrappers/mcp-argocd.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTFILE="$HOME/.claude/.current-argocd-cluster"
+export ACCOUNTS_FILE="$HOME/.config/argocd-accounts.json"
+
+# --- Require dotfile ---
+if [[ ! -f "$DOTFILE" ]] || [[ ! -s "$DOTFILE" ]]; then
+  printf 'Error: no ArgoCD cluster selected.\n' >&2
+  printf 'Run: myclaude (and select ArgoCD)\n' >&2
+  printf 'Or: echo "my-cluster" > %s\n' "$DOTFILE" >&2
+  exit 1
+fi
+
+# --- Read and trim cluster id ---
+IFS= read -r ARGOCD_CLUSTER_ID < "$DOTFILE"
+ARGOCD_CLUSTER_ID="${ARGOCD_CLUSTER_ID#"${ARGOCD_CLUSTER_ID%%[! $'\t']*}"}"
+ARGOCD_CLUSTER_ID="${ARGOCD_CLUSTER_ID%"${ARGOCD_CLUSTER_ID##*[! $'\t']}"}"
+export ARGOCD_CLUSTER_ID
+
+# --- Validate cluster id ---
+if [[ ! "$ARGOCD_CLUSTER_ID" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+  printf 'Error: invalid ArgoCD cluster id "%s" -- must match [a-zA-Z0-9_.-]+\n' "$ARGOCD_CLUSTER_ID" >&2
+  exit 1
+fi
+
+# --- Require accounts file ---
+if [[ ! -f "$ACCOUNTS_FILE" ]]; then
+  printf 'Error: ArgoCD accounts file not found at %s.\n' "$ACCOUNTS_FILE" >&2
+  printf 'Create it: echo '"'"'{}'"'"' > %s && chmod 600 %s\n' "$ACCOUNTS_FILE" "$ACCOUNTS_FILE" >&2
+  exit 1
+fi
+
+# --- Enforce mode 0600 on accounts file (mirrors mcp-github.sh:39-53) ---
+# ArgoCD tokens are equivalent in sensitivity to GitHub PATs; we adopt the strict
+# GitHub posture rather than the legacy Grafana advisory-only posture.
+mode=$(stat -f '%Lp' "$ACCOUNTS_FILE" 2>/dev/null || stat -c '%a' "$ACCOUNTS_FILE" 2>/dev/null || echo "")
+if [[ -z "$mode" ]]; then
+  echo "Error: could not stat $ACCOUNTS_FILE to check file mode" >&2
+  exit 1
+fi
+while [[ "$mode" == 0?* ]]; do mode="${mode#0}"; done
+mode="${mode:-0}"
+if [[ "$mode" != "600" ]]; then
+  echo "Error: $ACCOUNTS_FILE mode is $mode; must be 0600 (run: chmod 600 $ACCOUNTS_FILE)" >&2
+  exit 1
+fi
+
+# --- Require python3 ---
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 not found on PATH -- the ArgoCD MCP wrapper requires python3 to read $ACCOUNTS_FILE" >&2
+  exit 1
+fi
+
+# --- Extract URL and token with python3 ---
+# Use `if !` form to bypass set -e cleanly (no set +e/set -e toggle dance).
+# The python heredoc reads the accounts file, looks up the cluster by id,
+# and extracts url and token. It exits non-zero on any missing or null/empty value.
+if ! read -r ARGOCD_BASE_URL ARGOCD_API_TOKEN < <(python3 - <<'PY'
+import json, os, sys
+accounts_file = os.environ["ACCOUNTS_FILE"]
+cluster_id = os.environ["ARGOCD_CLUSTER_ID"]
+try:
+    with open(accounts_file) as f:
+        d = json.load(f)
+except Exception as e:
+    sys.stderr.write(f'Error: failed to read {accounts_file} ({type(e).__name__})\n')
+    sys.exit(1)
+if not isinstance(d, dict) or cluster_id not in d:
+    sys.stderr.write(f'Error: ArgoCD cluster "{cluster_id}" not found in {accounts_file}, or its url/token is missing.\n')
+    sys.exit(1)
+entry = d[cluster_id]
+if not isinstance(entry, dict):
+    sys.stderr.write(f'Error: ArgoCD cluster "{cluster_id}" not found in {accounts_file}, or its url/token is missing.\n')
+    sys.exit(1)
+url = entry.get("url")
+token = entry.get("token")
+if not url or not token:
+    sys.stderr.write(f'Error: ArgoCD cluster "{cluster_id}" not found in {accounts_file}, or its url/token is missing.\n')
+    sys.exit(1)
+print(url, token)
+PY
+); then
+  exit 1
+fi
+
+# Belt-and-suspenders: catch null/empty values output by python (should not happen; python validates above)
+if [[ -z "$ARGOCD_BASE_URL" || -z "$ARGOCD_API_TOKEN" ]]; then
+  printf 'Error: ArgoCD cluster "%s" not found in %s, or its url/token is missing.\n' "$ARGOCD_CLUSTER_ID" "$ACCOUNTS_FILE" >&2
+  exit 1
+fi
+
+# --- Validate URL shape ---
+if [[ ! "$ARGOCD_BASE_URL" =~ ^https?:// ]]; then
+  printf 'Error: ArgoCD url for cluster "%s" must start with http:// or https://\n' "$ARGOCD_CLUSTER_ID" >&2
+  exit 1
+fi
+
+# --- Export and exec ---
+export ARGOCD_BASE_URL ARGOCD_API_TOKEN
+echo "ArgoCD MCP: cluster '$ARGOCD_CLUSTER_ID' (${ARGOCD_BASE_URL})" >&2
+exec npx --yes argocd-mcp@0.5.0 stdio "$@"


### PR DESCRIPTION
Adds ArgoCD as a fifth MCP to the myclaude launcher, following the established McpCommand registry pattern. Users select a cluster from `~/.config/argocd-accounts.json` during `myclaude` startup; the choice is persisted and replayed on subsequent launches. The wrapper uses a python3 heredoc for JSON extraction (no new system dependencies beyond python3, which ships on macOS/Linux) and enforces mode 0600 on the accounts file at boot time, matching the security posture of the GitHub PAT wrapper.