### PR TITLE
chore: add .vscode/ settings and extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "timonwong.shellcheck",
+    "DavidAnson.vscode-markdownlint",
+    "streetsidesoftware.code-spell-checker",
+    "oxc.oxc-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "typescript.format.enable": false,
+  "javascript.format.enable": false,
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  }
+}


### PR DESCRIPTION
No .vscode/ directory existed, leaving VS Code contributors without inline shellcheck, markdownlint, cspell, or oxfmt feedback and without format-on-save alignment to the project's oxfmt config.

Adds extensions.json recommending shellcheck, markdownlint, cspell, and the oxc extension (which provides both oxlint diagnostics and oxfmt formatting). Adds settings.json enabling format-on-save for TypeScript/JavaScript file types only via oxc.oxc-vscode, with VS Code's built-in TS/JS formatter disabled to prevent races. Saving a .ts/.tsx/.js/.jsx file in VS Code now produces output identical to pnpm run format.

Closes #292