### PR TITLE
chore: add .editorconfig and standardise quote style to single quotes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
-  "singleQuote": false
+  "singleQuote": true,
+  "jsxSingleQuote": false
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -67,7 +67,7 @@ This runs all test files colocated with source under `src/installer/` and `src/l
 
 ### Code Quality: Linting and Formatting
 
-The project uses **oxlint** (TypeScript linter) and **oxfmt** (code formatter) to maintain consistent code quality.
+The project uses **oxlint** (TypeScript linter) and **oxfmt** (code formatter) to maintain consistent code quality. An `.editorconfig` file at the repo root configures indent style, line endings, charset, trailing whitespace, and final newlines for editors that support it.
 
 **pnpm scripts:**
 

--- a/src/installer/claude.test.ts
+++ b/src/installer/claude.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { installClaudeWhitelist } from "./claude.js";
-import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from "./constants.js";
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { installClaudeWhitelist } from './claude.js';
+import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from './constants.js';
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-test-'));
 
 // Build a fake source tree: tmpDir/claude/ with all whitelisted items
 function buildFakeClaudeSrc(
   base: string,
   include: string[] = [...CLAUDE_WHITELIST_FILES, ...CLAUDE_WHITELIST_DIRS],
 ) {
-  const claudeSrc = path.join(base, "claude");
+  const claudeSrc = path.join(base, 'claude');
   fs.mkdirSync(claudeSrc, { recursive: true });
   for (const name of include) {
     const p = path.join(claudeSrc, name);
@@ -30,13 +30,13 @@ after(() => {
   fs.rmSync(tmpDir, { recursive: true });
 });
 
-describe("installClaudeWhitelist", () => {
-  it("installs all whitelisted items into destRoot/.claude", () => {
-    const src = path.join(tmpDir, "full-install-src");
-    const dest = path.join(tmpDir, "full-install-dest");
+describe('installClaudeWhitelist', () => {
+  it('installs all whitelisted items into destRoot/.claude', () => {
+    const src = path.join(tmpDir, 'full-install-src');
+    const dest = path.join(tmpDir, 'full-install-dest');
     buildFakeClaudeSrc(src);
     installClaudeWhitelist(src, dest);
-    const dotClaude = path.join(dest, ".claude");
+    const dotClaude = path.join(dest, '.claude');
     for (const name of CLAUDE_WHITELIST_FILES) {
       assert.ok(
         fs.existsSync(path.join(dotClaude, name)),
@@ -51,32 +51,32 @@ describe("installClaudeWhitelist", () => {
     }
   });
 
-  it("preserves the executable bit on installed scripts", () => {
-    const src = path.join(tmpDir, "exec-bit-src");
-    const dest = path.join(tmpDir, "exec-bit-dest");
-    const claudeSrc = path.join(src, "claude");
-    const scriptsDir = path.join(claudeSrc, "scripts");
+  it('preserves the executable bit on installed scripts', () => {
+    const src = path.join(tmpDir, 'exec-bit-src');
+    const dest = path.join(tmpDir, 'exec-bit-dest');
+    const claudeSrc = path.join(src, 'claude');
+    const scriptsDir = path.join(claudeSrc, 'scripts');
     fs.mkdirSync(scriptsDir, { recursive: true });
-    const scriptFile = path.join(scriptsDir, "sample.sh");
-    fs.writeFileSync(scriptFile, "#!/bin/sh\necho hello\n");
+    const scriptFile = path.join(scriptsDir, 'sample.sh');
+    fs.writeFileSync(scriptFile, '#!/bin/sh\necho hello\n');
     fs.chmodSync(scriptFile, 0o755);
     installClaudeWhitelist(src, dest);
-    const destPath = path.join(dest, ".claude", "scripts", "sample.sh");
+    const destPath = path.join(dest, '.claude', 'scripts', 'sample.sh');
     assert.ok(
       (fs.statSync(destPath).mode & 0o100) !== 0,
-      "installed script should have owner-execute bit set",
+      'installed script should have owner-execute bit set',
     );
   });
 
-  it("skips missing items without throwing", () => {
-    const src = path.join(tmpDir, "partial-install-src");
-    const dest = path.join(tmpDir, "partial-install-dest");
+  it('skips missing items without throwing', () => {
+    const src = path.join(tmpDir, 'partial-install-src');
+    const dest = path.join(tmpDir, 'partial-install-dest');
     // Only include a subset
-    buildFakeClaudeSrc(src, ["settings.json", "skills"]);
+    buildFakeClaudeSrc(src, ['settings.json', 'skills']);
     assert.doesNotThrow(() => installClaudeWhitelist(src, dest));
-    const dotClaude = path.join(dest, ".claude");
-    assert.ok(fs.existsSync(path.join(dotClaude, "settings.json")));
-    assert.ok(fs.existsSync(path.join(dotClaude, "skills")));
-    assert.ok(!fs.existsSync(path.join(dotClaude, "CLAUDE.md")));
+    const dotClaude = path.join(dest, '.claude');
+    assert.ok(fs.existsSync(path.join(dotClaude, 'settings.json')));
+    assert.ok(fs.existsSync(path.join(dotClaude, 'skills')));
+    assert.ok(!fs.existsSync(path.join(dotClaude, 'CLAUDE.md')));
   });
 });

--- a/src/installer/claude.ts
+++ b/src/installer/claude.ts
@@ -1,34 +1,34 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { c } from "./colors.js";
-import { installPath } from "./fs-utils.js";
-import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from "./constants.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { c } from './colors.js';
+import { installPath } from './fs-utils.js';
+import { CLAUDE_WHITELIST_DIRS, CLAUDE_WHITELIST_FILES } from './constants.js';
 
 export function installClaudeWhitelist(
   scriptDir: string,
   destRoot: string = os.homedir(),
 ): void {
-  const claudeSrc = path.join(scriptDir, "claude");
+  const claudeSrc = path.join(scriptDir, 'claude');
 
   try {
     const claudeSrcStat = fs.statSync(claudeSrc);
     if (!claudeSrcStat.isDirectory()) {
-      console.log(c.yellow("Skipping claude/ (not found in repository)"));
+      console.log(c.yellow('Skipping claude/ (not found in repository)'));
       return;
     }
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
-      console.log(c.yellow("Skipping claude/ (not found in repository)"));
+      console.log(c.yellow('Skipping claude/ (not found in repository)'));
       return;
     }
     throw err;
   }
 
-  const dotClaudePath = path.join(destRoot, ".claude");
+  const dotClaudePath = path.join(destRoot, '.claude');
 
   fs.mkdirSync(dotClaudePath, { recursive: true });
 
@@ -48,7 +48,7 @@ export function installClaudeWhitelist(
     } catch (err: unknown) {
       if (
         err instanceof Error &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
       ) {
         console.log(
           c.yellow(`Skipping claude/${fileName} (not found in repository)`),
@@ -74,7 +74,7 @@ export function installClaudeWhitelist(
     } catch (err: unknown) {
       if (
         err instanceof Error &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
       ) {
         console.log(
           c.yellow(`Skipping claude/${name}/ (not found in repository)`),

--- a/src/installer/cli.test.ts
+++ b/src/installer/cli.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, afterEach, mock } from "node:test";
-import assert from "node:assert/strict";
-import { parseArgs } from "./cli.js";
+import { describe, it, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from './cli.js';
 
 class ExitSentinel extends Error {
   constructor(public readonly code: number) {
@@ -12,94 +12,94 @@ afterEach(() => {
   mock.restoreAll();
 });
 
-describe("parseArgs", () => {
-  it("returns without error when no args given", () => {
+describe('parseArgs', () => {
+  it('returns without error when no args given', () => {
     const result = parseArgs([]);
-    assert.deepStrictEqual(result, { targetAgent: "claude" });
+    assert.deepStrictEqual(result, { targetAgent: 'claude' });
   });
 
   it("returns targetAgent: 'claude' when --target-agent claude is passed", () => {
-    const result = parseArgs(["--target-agent", "claude"]);
-    assert.deepStrictEqual(result, { targetAgent: "claude" });
+    const result = parseArgs(['--target-agent', 'claude']);
+    assert.deepStrictEqual(result, { targetAgent: 'claude' });
   });
 
-  it("exits 1 when --target-agent is missing a value", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 1 when --target-agent is missing a value', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
     const calls: string[] = [];
-    mock.method(process.stderr, "write", (chunk: string) => {
+    mock.method(process.stderr, 'write', (chunk: string) => {
       calls.push(chunk);
       return true;
     });
     assert.throws(
-      () => parseArgs(["--target-agent"]),
+      () => parseArgs(['--target-agent']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 1,
     );
-    assert.ok(calls.some((c) => c.includes("--target-agent requires a value")));
+    assert.ok(calls.some((c) => c.includes('--target-agent requires a value')));
   });
 
-  it("exits 1 when --target-agent value is not in the valid list", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 1 when --target-agent value is not in the valid list', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
     const calls: string[] = [];
-    mock.method(process.stderr, "write", (chunk: string) => {
+    mock.method(process.stderr, 'write', (chunk: string) => {
       calls.push(chunk);
       return true;
     });
     assert.throws(
-      () => parseArgs(["--target-agent", "bogus"]),
+      () => parseArgs(['--target-agent', 'bogus']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 1,
     );
-    assert.ok(calls.some((c) => c.includes("bogus") && c.includes("claude")));
+    assert.ok(calls.some((c) => c.includes('bogus') && c.includes('claude')));
   });
 
-  it("exits 1 when --target-agent value starts with --", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 1 when --target-agent value starts with --', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
     const calls: string[] = [];
-    mock.method(process.stderr, "write", (chunk: string) => {
+    mock.method(process.stderr, 'write', (chunk: string) => {
       calls.push(chunk);
       return true;
     });
     assert.throws(
-      () => parseArgs(["--target-agent", "--help"]),
+      () => parseArgs(['--target-agent', '--help']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 1,
     );
-    assert.ok(calls.some((c) => c.includes("--target-agent requires a value")));
+    assert.ok(calls.some((c) => c.includes('--target-agent requires a value')));
   });
 
-  it("exits 1 on unknown flag", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 1 on unknown flag', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
     assert.throws(
-      () => parseArgs(["--bogus"]),
+      () => parseArgs(['--bogus']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 1,
     );
   });
 
-  it("exits 0 on --help", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 0 on --help', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
     // Also mock console.log to suppress output during tests
-    mock.method(console, "log", () => {});
+    mock.method(console, 'log', () => {});
     assert.throws(
-      () => parseArgs(["--help"]),
+      () => parseArgs(['--help']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 0,
     );
   });
 
-  it("exits 0 on -h alias", () => {
-    mock.method(process, "exit", (code: number) => {
+  it('exits 0 on -h alias', () => {
+    mock.method(process, 'exit', (code: number) => {
       throw new ExitSentinel(code);
     });
-    mock.method(console, "log", () => {});
+    mock.method(console, 'log', () => {});
     assert.throws(
-      () => parseArgs(["-h"]),
+      () => parseArgs(['-h']),
       (err: unknown) => err instanceof ExitSentinel && err.code === 0,
     );
   });

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -1,6 +1,6 @@
-import { c } from "./colors.js";
+import { c } from './colors.js';
 
-export const VALID_TARGET_AGENTS = ["claude"] as const;
+export const VALID_TARGET_AGENTS = ['claude'] as const;
 export type TargetAgent = (typeof VALID_TARGET_AGENTS)[number];
 
 export interface ParsedArgs {
@@ -20,21 +20,21 @@ Options:
   --help, -h              Show this help message`;
 
 export function parseArgs(argv: string[]): ParsedArgs {
-  let targetAgent: TargetAgent = "claude";
+  let targetAgent: TargetAgent = 'claude';
 
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
     switch (flag) {
-      case "--help":
-      case "-h":
+      case '--help':
+      case '-h':
         console.log(USAGE);
         process.exit(0);
         break;
-      case "--target-agent": {
+      case '--target-agent': {
         const value = argv[i + 1];
-        if (value === undefined || value.startsWith("--")) {
+        if (value === undefined || value.startsWith('--')) {
           process.stderr.write(
-            `${c.red("Error: --target-agent requires a value")}\n`,
+            `${c.red('Error: --target-agent requires a value')}\n`,
           );
           process.stderr.write(
             "Run './install.sh --help' for usage information.\n",
@@ -43,7 +43,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
         }
         if (!(VALID_TARGET_AGENTS as readonly string[]).includes(value)) {
           process.stderr.write(
-            `${c.red(`Error: Invalid --target-agent value '${value}'. Valid values: ${VALID_TARGET_AGENTS.join(", ")}`)}\n`,
+            `${c.red(`Error: Invalid --target-agent value '${value}'. Valid values: ${VALID_TARGET_AGENTS.join(', ')}`)}\n`,
           );
           process.stderr.write(
             "Run './install.sh --help' for usage information.\n",

--- a/src/installer/colors.test.ts
+++ b/src/installer/colors.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import * as childProcess from "node:child_process";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as childProcess from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // colors.ts reads NO_COLOR at module load time (const noColor = Boolean(process.env["NO_COLOR"])).
 // Testing both branches in the same process is not reliably possible.
@@ -14,35 +14,35 @@ const installerDir = path.dirname(__filename);
 
 function runColorCheck(colorName: string, noColor: boolean): string {
   const script = `
-    import { c } from "${path.join(installerDir, "colors.js")}";
+    import { c } from "${path.join(installerDir, 'colors.js')}";
     process.stdout.write(c.${colorName}("hello"));
   `;
   const env = { ...process.env };
   if (noColor) {
-    env["NO_COLOR"] = "1";
+    env['NO_COLOR'] = '1';
   } else {
-    delete env["NO_COLOR"];
+    delete env['NO_COLOR'];
   }
   return childProcess.execFileSync(
     process.execPath,
-    ["--input-type=module", "--import", "tsx/esm"],
-    { input: script, env, encoding: "utf8" },
+    ['--input-type=module', '--import', 'tsx/esm'],
+    { input: script, env, encoding: 'utf8' },
   );
 }
 
-describe("colors", () => {
-  it("wraps text in ANSI codes when NO_COLOR is unset", () => {
-    const output = runColorCheck("red", false);
-    assert.ok(output.includes("\x1b[0;31m"), "should contain red ANSI code");
-    assert.ok(output.includes("hello"));
+describe('colors', () => {
+  it('wraps text in ANSI codes when NO_COLOR is unset', () => {
+    const output = runColorCheck('red', false);
+    assert.ok(output.includes('\x1b[0;31m'), 'should contain red ANSI code');
+    assert.ok(output.includes('hello'));
   });
 
-  it("returns plain text when NO_COLOR=1", () => {
-    const output = runColorCheck("red", true);
+  it('returns plain text when NO_COLOR=1', () => {
+    const output = runColorCheck('red', true);
     assert.ok(
-      !output.includes("\x1b["),
-      "should not contain any ANSI escape codes",
+      !output.includes('\x1b['),
+      'should not contain any ANSI escape codes',
     );
-    assert.strictEqual(output, "hello");
+    assert.strictEqual(output, 'hello');
   });
 });

--- a/src/installer/colors.ts
+++ b/src/installer/colors.ts
@@ -1,4 +1,4 @@
-const noColor = Boolean(process.env["NO_COLOR"]);
+const noColor = Boolean(process.env['NO_COLOR']);
 
 function wrap(code: string, msg: string): string {
   if (noColor) return msg;
@@ -6,10 +6,10 @@ function wrap(code: string, msg: string): string {
 }
 
 export const c = {
-  red: (msg: string) => wrap("\x1b[0;31m", msg),
-  green: (msg: string) => wrap("\x1b[0;32m", msg),
-  yellow: (msg: string) => wrap("\x1b[1;33m", msg),
-  blue: (msg: string) => wrap("\x1b[0;34m", msg),
+  red: (msg: string) => wrap('\x1b[0;31m', msg),
+  green: (msg: string) => wrap('\x1b[0;32m', msg),
+  yellow: (msg: string) => wrap('\x1b[1;33m', msg),
+  blue: (msg: string) => wrap('\x1b[0;34m', msg),
 };
 
-export const nc = "\x1b[0m";
+export const nc = '\x1b[0m';

--- a/src/installer/constants.ts
+++ b/src/installer/constants.ts
@@ -1,18 +1,18 @@
 /** Sub-directories of claude/ installed into ~/.claude */
 export const CLAUDE_WHITELIST_DIRS: readonly string[] = [
-  "skills",
-  "agents",
-  "hooks",
-  "commands",
-  "references",
-  "scripts",
+  'skills',
+  'agents',
+  'hooks',
+  'commands',
+  'references',
+  'scripts',
 ];
 
 /** Standalone files of claude/ installed into ~/.claude */
 export const CLAUDE_WHITELIST_FILES: readonly string[] = [
-  "settings.json",
-  "CLAUDE.md",
+  'settings.json',
+  'CLAUDE.md',
 ];
 
 /** Minimum Node.js version required by install.sh (major.minor) */
-export const NODE_MIN_VERSION = "18.18.0";
+export const NODE_MIN_VERSION = '18.18.0';

--- a/src/installer/fs-utils.test.ts
+++ b/src/installer/fs-utils.test.ts
@@ -1,85 +1,85 @@
-import { describe, it, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { backupIfExists, installPath, installDir } from "./fs-utils.js";
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { backupIfExists, installPath, installDir } from './fs-utils.js';
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-test-'));
 
 after(() => {
   fs.rmSync(tmpDir, { recursive: true });
 });
 
-describe("backupIfExists", () => {
-  it("renames an existing file", () => {
-    const target = path.join(tmpDir, "backup-file.txt");
-    fs.writeFileSync(target, "hello");
+describe('backupIfExists', () => {
+  it('renames an existing file', () => {
+    const target = path.join(tmpDir, 'backup-file.txt');
+    fs.writeFileSync(target, 'hello');
     backupIfExists(target);
-    assert.ok(!fs.existsSync(target), "original path should be gone");
+    assert.ok(!fs.existsSync(target), 'original path should be gone');
     const backups = fs
       .readdirSync(tmpDir)
-      .filter((f) => f.startsWith("backup-file.txt.backup."));
+      .filter((f) => f.startsWith('backup-file.txt.backup.'));
     assert.strictEqual(backups.length, 1);
   });
 
-  it("renames an existing directory", () => {
-    const target = path.join(tmpDir, "backup-dir");
+  it('renames an existing directory', () => {
+    const target = path.join(tmpDir, 'backup-dir');
     fs.mkdirSync(target);
     backupIfExists(target);
     assert.ok(!fs.existsSync(target));
     const backups = fs
       .readdirSync(tmpDir)
-      .filter((f) => f.startsWith("backup-dir.backup."));
+      .filter((f) => f.startsWith('backup-dir.backup.'));
     assert.strictEqual(backups.length, 1);
   });
 
-  it("is a no-op for a non-existent path", () => {
-    const target = path.join(tmpDir, "does-not-exist");
+  it('is a no-op for a non-existent path', () => {
+    const target = path.join(tmpDir, 'does-not-exist');
     assert.doesNotThrow(() => backupIfExists(target));
     assert.ok(!fs.existsSync(target));
   });
 });
 
-describe("installPath", () => {
-  it("recursively copies a directory", () => {
-    const srcDir = path.join(tmpDir, "copy-src");
-    const destDir = path.join(tmpDir, "copy-dest");
+describe('installPath', () => {
+  it('recursively copies a directory', () => {
+    const srcDir = path.join(tmpDir, 'copy-src');
+    const destDir = path.join(tmpDir, 'copy-dest');
     fs.mkdirSync(srcDir);
-    fs.writeFileSync(path.join(srcDir, "nested.txt"), "nested");
+    fs.writeFileSync(path.join(srcDir, 'nested.txt'), 'nested');
     installPath(srcDir, destDir);
-    assert.ok(fs.existsSync(path.join(destDir, "nested.txt")));
+    assert.ok(fs.existsSync(path.join(destDir, 'nested.txt')));
   });
 
-  it("backs up existing copy on second call", () => {
-    const srcDir = path.join(tmpDir, "copy-src2");
-    const destDir = path.join(tmpDir, "copy-dest2");
+  it('backs up existing copy on second call', () => {
+    const srcDir = path.join(tmpDir, 'copy-src2');
+    const destDir = path.join(tmpDir, 'copy-dest2');
     fs.mkdirSync(srcDir);
     installPath(srcDir, destDir);
     installPath(srcDir, destDir);
     const backups = fs
       .readdirSync(tmpDir)
-      .filter((f) => f.startsWith("copy-dest2.backup."));
+      .filter((f) => f.startsWith('copy-dest2.backup.'));
     assert.strictEqual(backups.length, 1);
   });
 });
 
-describe("installDir", () => {
-  it("skips when source directory does not exist", () => {
-    const destPath = path.join(tmpDir, ".nonexistent-dest");
-    installDir(tmpDir, "nonexistent-src", ".nonexistent-dest", tmpDir);
+describe('installDir', () => {
+  it('skips when source directory does not exist', () => {
+    const destPath = path.join(tmpDir, '.nonexistent-dest');
+    installDir(tmpDir, 'nonexistent-src', '.nonexistent-dest', tmpDir);
     assert.ok(
       !fs.existsSync(destPath),
-      "dest should not be created when src is missing",
+      'dest should not be created when src is missing',
     );
   });
 
-  it("installs when source directory exists", () => {
-    const srcDir = path.join(tmpDir, "real-src");
+  it('installs when source directory exists', () => {
+    const srcDir = path.join(tmpDir, 'real-src');
     fs.mkdirSync(srcDir);
-    fs.writeFileSync(path.join(srcDir, "file.txt"), "data");
-    installDir(tmpDir, "real-src", ".real-dest", tmpDir);
-    const destPath = path.join(tmpDir, ".real-dest");
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'data');
+    installDir(tmpDir, 'real-src', '.real-dest', tmpDir);
+    const destPath = path.join(tmpDir, '.real-dest');
     assert.ok(fs.statSync(destPath).isDirectory());
   });
 });

--- a/src/installer/fs-utils.ts
+++ b/src/installer/fs-utils.ts
@@ -1,9 +1,9 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { c } from "./colors.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { c } from './colors.js';
 
-const pad = (n: number, len = 2) => String(n).padStart(len, "0");
+const pad = (n: number, len = 2) => String(n).padStart(len, '0');
 
 function timestamp(): string {
   const now = new Date();
@@ -22,7 +22,7 @@ export function backupIfExists(targetPath: string): void {
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       return;
     }
@@ -58,7 +58,7 @@ export function installDir(
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       console.log(c.yellow(`Skipping ${srcName} (not found in repository)`));
       return;

--- a/src/installer/launcher-install.test.ts
+++ b/src/installer/launcher-install.test.ts
@@ -1,41 +1,41 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { installLauncherScript } from "./launcher-install.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { installLauncherScript } from './launcher-install.js';
 
 function makeFakeRepo(
   root: string,
   { withBundle = true }: { withBundle?: boolean } = {},
 ): void {
-  const launcherDir = path.join(root, "src", "launcher");
+  const launcherDir = path.join(root, 'src', 'launcher');
   fs.mkdirSync(launcherDir, { recursive: true });
 
   const shContent =
-    ["#!/usr/bin/env bash", 'exec node "$HOME/.ai-tpk/launcher.cjs" "$@"'].join(
-      "\n",
-    ) + "\n";
-  fs.writeFileSync(path.join(launcherDir, "myclaude.sh"), shContent);
-  fs.chmodSync(path.join(launcherDir, "myclaude.sh"), 0o755);
+    ['#!/usr/bin/env bash', 'exec node "$HOME/.ai-tpk/launcher.cjs" "$@"'].join(
+      '\n',
+    ) + '\n';
+  fs.writeFileSync(path.join(launcherDir, 'myclaude.sh'), shContent);
+  fs.chmodSync(path.join(launcherDir, 'myclaude.sh'), 0o755);
 
   if (withBundle) {
-    const distDir = path.join(root, "dist");
+    const distDir = path.join(root, 'dist');
     fs.mkdirSync(distDir, { recursive: true });
     fs.writeFileSync(
-      path.join(distDir, "launcher.cjs"),
-      "// fake launcher bundle\n",
+      path.join(distDir, 'launcher.cjs'),
+      '// fake launcher bundle\n',
     );
   }
 }
 
-describe("installLauncherScript", () => {
+describe('installLauncherScript', () => {
   let fakeRepo: string;
   let fakeHome: string;
 
   before(() => {
-    fakeRepo = fs.mkdtempSync(path.join(os.tmpdir(), "launcher-test-repo-"));
-    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "launcher-test-home-"));
+    fakeRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-test-repo-'));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-test-home-'));
     makeFakeRepo(fakeRepo);
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
   });
@@ -45,25 +45,25 @@ describe("installLauncherScript", () => {
     fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 
-  it("copies dist/launcher.cjs to ~/.ai-tpk/launcher.cjs", () => {
-    const destBundle = path.join(fakeHome, ".ai-tpk", "launcher.cjs");
+  it('copies dist/launcher.cjs to ~/.ai-tpk/launcher.cjs', () => {
+    const destBundle = path.join(fakeHome, '.ai-tpk', 'launcher.cjs');
     assert.ok(fs.existsSync(destBundle));
-    const content = fs.readFileSync(destBundle, "utf8");
-    assert.ok(content.includes("fake launcher bundle"));
+    const content = fs.readFileSync(destBundle, 'utf8');
+    assert.ok(content.includes('fake launcher bundle'));
   });
 
   it("creates ~/.ai-tpk/ directory if it doesn't exist", () => {
-    const aiTpkDir = path.join(fakeHome, ".ai-tpk");
+    const aiTpkDir = path.join(fakeHome, '.ai-tpk');
     assert.ok(fs.existsSync(aiTpkDir));
     assert.ok(fs.statSync(aiTpkDir).isDirectory());
   });
 
-  it("throws if dist/launcher.cjs is missing", () => {
+  it('throws if dist/launcher.cjs is missing', () => {
     const freshRepo = fs.mkdtempSync(
-      path.join(os.tmpdir(), "launcher-test-fresh-repo-"),
+      path.join(os.tmpdir(), 'launcher-test-fresh-repo-'),
     );
     const freshHome = fs.mkdtempSync(
-      path.join(os.tmpdir(), "launcher-test-fresh-home-"),
+      path.join(os.tmpdir(), 'launcher-test-fresh-home-'),
     );
     try {
       makeFakeRepo(freshRepo, { withBundle: false });
@@ -71,53 +71,53 @@ describe("installLauncherScript", () => {
         () => installLauncherScript(freshRepo, { homeDir: freshHome }),
         /dist\/launcher\.cjs not found/,
       );
-      assert.ok(!fs.existsSync(path.join(freshHome, ".ai-tpk")));
+      assert.ok(!fs.existsSync(path.join(freshHome, '.ai-tpk')));
     } finally {
       fs.rmSync(freshRepo, { recursive: true, force: true });
       fs.rmSync(freshHome, { recursive: true, force: true });
     }
   });
 
-  it("installs ~/bin/myclaude wrapper with correct content and permissions", () => {
-    const binScript = path.join(fakeHome, "bin", "myclaude");
+  it('installs ~/bin/myclaude wrapper with correct content and permissions', () => {
+    const binScript = path.join(fakeHome, 'bin', 'myclaude');
     assert.ok(fs.existsSync(binScript));
-    const content = fs.readFileSync(binScript, "utf8");
-    assert.ok(content.startsWith("#!/usr/bin/env bash"));
-    assert.ok(content.includes(".ai-tpk/launcher.cjs"));
+    const content = fs.readFileSync(binScript, 'utf8');
+    assert.ok(content.startsWith('#!/usr/bin/env bash'));
+    assert.ok(content.includes('.ai-tpk/launcher.cjs'));
     const mode = fs.statSync(binScript).mode & 0o777;
     assert.equal(mode, 0o755);
   });
 
-  it("removes old ~/.claude/launcher/ on re-install (migration cleanup)", () => {
-    const oldLauncherDir = path.join(fakeHome, ".claude", "launcher");
+  it('removes old ~/.claude/launcher/ on re-install (migration cleanup)', () => {
+    const oldLauncherDir = path.join(fakeHome, '.claude', 'launcher');
     fs.mkdirSync(oldLauncherDir, { recursive: true });
-    fs.writeFileSync(path.join(oldLauncherDir, "main.ts"), "// old main");
+    fs.writeFileSync(path.join(oldLauncherDir, 'main.ts'), '// old main');
 
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
 
     assert.ok(!fs.existsSync(oldLauncherDir));
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
+    assert.ok(fs.existsSync(path.join(fakeHome, '.ai-tpk', 'launcher.cjs')));
   });
 
-  it("preserves unrelated ~/.ai-tpk/ files on re-install", () => {
+  it('preserves unrelated ~/.ai-tpk/ files on re-install', () => {
     fs.writeFileSync(
-      path.join(fakeHome, ".ai-tpk", "other-tool.json"),
+      path.join(fakeHome, '.ai-tpk', 'other-tool.json'),
       '{"tool":"other"}',
     );
 
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
 
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "other-tool.json")));
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
+    assert.ok(fs.existsSync(path.join(fakeHome, '.ai-tpk', 'other-tool.json')));
+    assert.ok(fs.existsSync(path.join(fakeHome, '.ai-tpk', 'launcher.cjs')));
   });
 
-  it("removes stale ~/.ai-tpk/launcher.js on re-install", () => {
-    const staleJs = path.join(fakeHome, ".ai-tpk", "launcher.js");
-    fs.writeFileSync(staleJs, "// stale bundle\n");
+  it('removes stale ~/.ai-tpk/launcher.js on re-install', () => {
+    const staleJs = path.join(fakeHome, '.ai-tpk', 'launcher.js');
+    fs.writeFileSync(staleJs, '// stale bundle\n');
 
     installLauncherScript(fakeRepo, { homeDir: fakeHome });
 
     assert.ok(!fs.existsSync(staleJs));
-    assert.ok(fs.existsSync(path.join(fakeHome, ".ai-tpk", "launcher.cjs")));
+    assert.ok(fs.existsSync(path.join(fakeHome, '.ai-tpk', 'launcher.cjs')));
   });
 });

--- a/src/installer/launcher-install.ts
+++ b/src/installer/launcher-install.ts
@@ -1,21 +1,21 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { backupIfExists } from "./fs-utils.js";
-import { c } from "./colors.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { backupIfExists } from './fs-utils.js';
+import { c } from './colors.js';
 
 export function installLauncherScript(
   repoRoot: string,
   { homeDir = os.homedir() }: { homeDir?: string } = {},
 ): void {
   // 8a. Define paths
-  const srcBundle = path.join(repoRoot, "dist", "launcher.cjs");
-  const aiTpkDir = path.join(homeDir, ".ai-tpk");
-  const destBundle = path.join(aiTpkDir, "launcher.cjs");
-  const binDir = path.join(homeDir, "bin");
-  const targetBinPath = path.join(binDir, "myclaude");
-  const srcBashScript = path.join(repoRoot, "src", "launcher", "myclaude.sh");
-  const oldLauncherDir = path.join(homeDir, ".claude", "launcher");
+  const srcBundle = path.join(repoRoot, 'dist', 'launcher.cjs');
+  const aiTpkDir = path.join(homeDir, '.ai-tpk');
+  const destBundle = path.join(aiTpkDir, 'launcher.cjs');
+  const binDir = path.join(homeDir, 'bin');
+  const targetBinPath = path.join(binDir, 'myclaude');
+  const srcBashScript = path.join(repoRoot, 'src', 'launcher', 'myclaude.sh');
+  const oldLauncherDir = path.join(homeDir, '.claude', 'launcher');
 
   // 8b. Guard: verify required source files exist before any side effects
   if (!fs.existsSync(srcBundle)) {
@@ -38,12 +38,12 @@ export function installLauncherScript(
   }
 
   // 8d2. Migrate: remove stale ~/.ai-tpk/launcher.js left by pre-rename installs
-  const staleLauncherJs = path.join(aiTpkDir, "launcher.js");
+  const staleLauncherJs = path.join(aiTpkDir, 'launcher.js');
   if (fs.existsSync(staleLauncherJs)) {
     fs.rmSync(staleLauncherJs);
     console.log(
       c.yellow(
-        "Removed stale ~/.ai-tpk/launcher.js (replaced by launcher.cjs)",
+        'Removed stale ~/.ai-tpk/launcher.js (replaced by launcher.cjs)',
       ),
     );
   }

--- a/src/installer/main.ts
+++ b/src/installer/main.ts
@@ -1,13 +1,13 @@
-import { parseArgs } from "./cli.js";
-import { installDir } from "./fs-utils.js";
-import { installClaudeWhitelist } from "./claude.js";
-import { installMcpServers } from "./mcp.js";
-import { installLauncherScript } from "./launcher-install.js";
-import { c } from "./colors.js";
-import { fileURLToPath } from "node:url";
-import * as path from "node:path";
-import * as os from "node:os";
-import * as fs from "node:fs";
+import { parseArgs } from './cli.js';
+import { installDir } from './fs-utils.js';
+import { installClaudeWhitelist } from './claude.js';
+import { installMcpServers } from './mcp.js';
+import { installLauncherScript } from './launcher-install.js';
+import { c } from './colors.js';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
 
 // scriptDir = repo root; at runtime __filename is dist/installer.js so one
 // dirname reaches dist/ and a second reaches the repo root.
@@ -18,42 +18,42 @@ const scriptDir = path.dirname(installerDir);
 try {
   const { targetAgent } = parseArgs(process.argv.slice(2));
 
-  console.log(c.blue("AI TPK Installer"));
-  console.log(c.blue("====================="));
-  console.log("");
+  console.log(c.blue('AI TPK Installer'));
+  console.log(c.blue('====================='));
+  console.log('');
   console.log(`Source directory: ${scriptDir}`);
-  console.log("");
+  console.log('');
 
-  installDir(scriptDir, "cursor", ".cursor", os.homedir());
+  installDir(scriptDir, 'cursor', '.cursor', os.homedir());
 
-  if (targetAgent === "claude") {
+  if (targetAgent === 'claude') {
     installClaudeWhitelist(scriptDir, os.homedir());
-    installDir(scriptDir, "src/mcp/wrappers", ".claude/wrappers", os.homedir());
+    installDir(scriptDir, 'src/mcp/wrappers', '.claude/wrappers', os.homedir());
   }
 
   // Create ~/.ai-tpk artifact directories
-  const aiTpkDir = path.join(os.homedir(), ".ai-tpk");
-  fs.mkdirSync(path.join(aiTpkDir, "plans"), { recursive: true });
-  fs.mkdirSync(path.join(aiTpkDir, "lessons"), { recursive: true });
+  const aiTpkDir = path.join(os.homedir(), '.ai-tpk');
+  fs.mkdirSync(path.join(aiTpkDir, 'plans'), { recursive: true });
+  fs.mkdirSync(path.join(aiTpkDir, 'lessons'), { recursive: true });
   console.log(
     c.green(
       `✓ Created artifact directories: ${aiTpkDir}/plans/, ${aiTpkDir}/lessons/`,
     ),
   );
 
-  console.log("");
-  if (targetAgent === "claude") {
+  console.log('');
+  if (targetAgent === 'claude') {
     installMcpServers(scriptDir);
   }
 
-  console.log("");
+  console.log('');
   installLauncherScript(scriptDir);
 
-  console.log("");
-  console.log(c.green("✓ Installation complete!"));
-  console.log("");
+  console.log('');
+  console.log(c.green('✓ Installation complete!'));
+  console.log('');
 
-  console.log("Your configurations have been copied from this repository.");
+  console.log('Your configurations have been copied from this repository.');
   console.log(`To update: cd ${scriptDir} && git pull && ./install.sh`);
 } catch (e: unknown) {
   const msg = e instanceof Error ? e.message : String(e);

--- a/src/installer/mcp.test.ts
+++ b/src/installer/mcp.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
   expandVars,
   loadMcpServers,
@@ -15,13 +15,13 @@ import {
   removeLegacyGithubRegistration,
   assertWrappersDirNotWorldWritable,
   updateGithubAllowList,
-} from "./mcp.js";
+} from './mcp.js';
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
 // ---------------------------------------------------------------------------
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-mcp-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-mcp-test-'));
 
 after(() => {
   fs.rmSync(tmpDir, { recursive: true });
@@ -33,12 +33,12 @@ after(() => {
 // ---------------------------------------------------------------------------
 
 function writeMcpFile(servers: unknown[]): string {
-  const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-"));
-  fs.mkdirSync(path.join(repoRoot, "src/mcp"), { recursive: true });
+  const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+  fs.mkdirSync(path.join(repoRoot, 'src/mcp'), { recursive: true });
   fs.writeFileSync(
-    path.join(repoRoot, "src/mcp/mcp-servers.json"),
+    path.join(repoRoot, 'src/mcp/mcp-servers.json'),
     JSON.stringify({ servers }),
-    "utf8",
+    'utf8',
   );
   return repoRoot;
 }
@@ -47,34 +47,34 @@ function writeMcpFile(servers: unknown[]): string {
 // expandVars
 // ---------------------------------------------------------------------------
 
-describe("expandVars", () => {
-  it("expands $HOME", () => {
+describe('expandVars', () => {
+  it('expands $HOME', () => {
     const home = os.homedir();
-    assert.strictEqual(expandVars("$HOME/.config"), `${home}/.config`);
+    assert.strictEqual(expandVars('$HOME/.config'), `${home}/.config`);
   });
 
-  it("expands ${HOME}", () => {
+  it('expands ${HOME}', () => {
     const home = os.homedir();
-    assert.strictEqual(expandVars("${HOME}/.config"), `${home}/.config`);
+    assert.strictEqual(expandVars('${HOME}/.config'), `${home}/.config`);
   });
 
-  it("expands $USER", () => {
+  it('expands $USER', () => {
     const user = os.userInfo().username;
-    assert.strictEqual(expandVars("hello-$USER"), `hello-${user}`);
+    assert.strictEqual(expandVars('hello-$USER'), `hello-${user}`);
   });
 
-  it("expands ${USER}", () => {
+  it('expands ${USER}', () => {
     const user = os.userInfo().username;
-    assert.strictEqual(expandVars("${USER}-name"), `${user}-name`);
+    assert.strictEqual(expandVars('${USER}-name'), `${user}-name`);
   });
 
-  it("does not expand arbitrary env vars like $GRAFANA_URL", () => {
-    const original = "$GRAFANA_URL";
+  it('does not expand arbitrary env vars like $GRAFANA_URL', () => {
+    const original = '$GRAFANA_URL';
     assert.strictEqual(expandVars(original), original);
   });
 
-  it("leaves a string with no vars unchanged", () => {
-    assert.strictEqual(expandVars("no-vars-here"), "no-vars-here");
+  it('leaves a string with no vars unchanged', () => {
+    assert.strictEqual(expandVars('no-vars-here'), 'no-vars-here');
   });
 });
 
@@ -82,103 +82,103 @@ describe("expandVars", () => {
 // loadMcpServers — validation
 // ---------------------------------------------------------------------------
 
-describe("loadMcpServers", () => {
-  it("returns [] when mcp-servers.json does not exist", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-empty-"));
+describe('loadMcpServers', () => {
+  it('returns [] when mcp-servers.json does not exist', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-empty-'));
     const result = loadMcpServers(repoRoot);
     assert.deepStrictEqual(result, []);
   });
 
-  it("loads a valid command-based entry (no wrapper)", () => {
+  it('loads a valid command-based entry (no wrapper)', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "kubernetes",
-        scope: "user",
-        transport: "stdio",
-        command: "kubectl",
-        args: ["mcp", "serve"],
+        name: 'kubernetes',
+        scope: 'user',
+        transport: 'stdio',
+        command: 'kubectl',
+        args: ['mcp', 'serve'],
       },
     ]);
     const servers = loadMcpServers(repoRoot);
     assert.strictEqual(servers.length, 1);
-    assert.strictEqual(servers[0]?.name, "kubernetes");
+    assert.strictEqual(servers[0]?.name, 'kubernetes');
   });
 
-  it("loads a valid wrapper-based entry (no command)", () => {
+  it('loads a valid wrapper-based entry (no command)', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "grafana",
-        scope: "user",
-        transport: "stdio",
-        wrapper: "wrappers/mcp-grafana.sh",
+        name: 'grafana',
+        scope: 'user',
+        transport: 'stdio',
+        wrapper: 'wrappers/mcp-grafana.sh',
       },
     ]);
     const servers = loadMcpServers(repoRoot);
     assert.strictEqual(servers.length, 1);
-    assert.strictEqual(servers[0]?.name, "grafana");
+    assert.strictEqual(servers[0]?.name, 'grafana');
   });
 
-  it("throws when entry has both wrapper and command", () => {
+  it('throws when entry has both wrapper and command', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "bad-server",
-        scope: "user",
-        transport: "stdio",
-        command: "some-cmd",
-        wrapper: "wrappers/some.sh",
+        name: 'bad-server',
+        scope: 'user',
+        transport: 'stdio',
+        command: 'some-cmd',
+        wrapper: 'wrappers/some.sh',
       },
     ]);
     assert.throws(
       () => loadMcpServers(repoRoot),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("must not have both"),
+        err instanceof Error && err.message.includes('must not have both'),
     );
   });
 
-  it("throws when entry has neither wrapper nor command", () => {
+  it('throws when entry has neither wrapper nor command', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "bad-server",
-        scope: "user",
-        transport: "stdio",
+        name: 'bad-server',
+        scope: 'user',
+        transport: 'stdio',
       },
     ]);
     assert.throws(
       () => loadMcpServers(repoRoot),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("must have either"),
+        err instanceof Error && err.message.includes('must have either'),
     );
   });
 
-  it("throws on invalid scope", () => {
+  it('throws on invalid scope', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "bad-scope",
-        scope: "global",
-        transport: "stdio",
-        command: "some-cmd",
+        name: 'bad-scope',
+        scope: 'global',
+        transport: 'stdio',
+        command: 'some-cmd',
       },
     ]);
     assert.throws(
       () => loadMcpServers(repoRoot),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("invalid scope"),
+        err instanceof Error && err.message.includes('invalid scope'),
     );
   });
 
-  it("throws on invalid transport", () => {
+  it('throws on invalid transport', () => {
     const repoRoot = writeMcpFile([
       {
-        name: "bad-transport",
-        scope: "user",
-        transport: "websocket",
-        command: "some-cmd",
+        name: 'bad-transport',
+        scope: 'user',
+        transport: 'websocket',
+        command: 'some-cmd',
       },
     ]);
     assert.throws(
       () => loadMcpServers(repoRoot),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("invalid transport"),
+        err instanceof Error && err.message.includes('invalid transport'),
     );
   });
 });
@@ -187,65 +187,65 @@ describe("loadMcpServers", () => {
 // buildAddArgs — wrapper-based servers
 // ---------------------------------------------------------------------------
 
-describe("buildAddArgs — wrapper-based server", () => {
-  it("returns correct args with absolute wrapper path and no -e flags when wrapper file exists", () => {
+describe('buildAddArgs — wrapper-based server', () => {
+  it('returns correct args with absolute wrapper path and no -e flags when wrapper file exists', () => {
     // Create a real wrapper file so statSync succeeds
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-wrapper-"));
-    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-wrapper-"));
-    const wrappersDir = path.join(fakeHomedir, ".claude", "wrappers");
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-wrapper-'));
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, 'home-wrapper-'));
+    const wrappersDir = path.join(fakeHomedir, '.claude', 'wrappers');
     fs.mkdirSync(wrappersDir, { recursive: true });
-    const wrapperFile = path.join(wrappersDir, "mcp-grafana.sh");
+    const wrapperFile = path.join(wrappersDir, 'mcp-grafana.sh');
     fs.writeFileSync(
       wrapperFile,
-      "#!/usr/bin/env bash\nexec uvx mcp-grafana\n",
+      '#!/usr/bin/env bash\nexec uvx mcp-grafana\n',
     );
 
     const server = {
-      name: "grafana",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      wrapper: "wrappers/mcp-grafana.sh",
+      name: 'grafana',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      wrapper: 'wrappers/mcp-grafana.sh',
     };
 
     const args = buildAddArgs(server, repoRoot, fakeHomedir);
 
     const expectedWrapperPath = path.join(
       fakeHomedir,
-      ".claude",
-      "wrappers/mcp-grafana.sh",
+      '.claude',
+      'wrappers/mcp-grafana.sh',
     );
     assert.deepStrictEqual(args, [
-      "-s",
-      "user",
-      "-t",
-      "stdio",
-      "--",
-      "grafana",
+      '-s',
+      'user',
+      '-t',
+      'stdio',
+      '--',
+      'grafana',
       expectedWrapperPath,
     ]);
 
     // Must not contain any -e flags
     assert.ok(
-      !args.includes("-e"),
-      "wrapper-based args must not contain -e flags",
+      !args.includes('-e'),
+      'wrapper-based args must not contain -e flags',
     );
   });
 
-  it("throws with descriptive error when wrapper file does not exist", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-missing-"));
-    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-missing-"));
+  it('throws with descriptive error when wrapper file does not exist', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-missing-'));
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, 'home-missing-'));
 
     const server = {
-      name: "grafana",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      wrapper: "wrappers/mcp-grafana.sh",
+      name: 'grafana',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      wrapper: 'wrappers/mcp-grafana.sh',
     };
 
     const expectedWrapperPath = path.join(
       fakeHomedir,
-      ".claude",
-      "wrappers/mcp-grafana.sh",
+      '.claude',
+      'wrappers/mcp-grafana.sh',
     );
 
     assert.throws(
@@ -253,7 +253,7 @@ describe("buildAddArgs — wrapper-based server", () => {
       (err: unknown) => {
         assert.ok(err instanceof Error);
         assert.ok(
-          err.message.includes("Wrapper script not found"),
+          err.message.includes('Wrapper script not found'),
           `expected "Wrapper script not found" in: ${err.message}`,
         );
         assert.ok(
@@ -261,7 +261,7 @@ describe("buildAddArgs — wrapper-based server", () => {
           `expected path "${expectedWrapperPath}" in: ${err.message}`,
         );
         assert.ok(
-          err.message.includes("grafana"),
+          err.message.includes('grafana'),
           `expected server name "grafana" in: ${err.message}`,
         );
         return true;
@@ -269,29 +269,29 @@ describe("buildAddArgs — wrapper-based server", () => {
     );
   });
 
-  it("resolves user-scope wrapper against homedir/.claude/ instead of repoRoot", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-user-scope-"));
-    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, "home-user-scope-"));
-    const wrappersDir = path.join(fakeHomedir, ".claude", "wrappers");
+  it('resolves user-scope wrapper against homedir/.claude/ instead of repoRoot', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-user-scope-'));
+    const fakeHomedir = fs.mkdtempSync(path.join(tmpDir, 'home-user-scope-'));
+    const wrappersDir = path.join(fakeHomedir, '.claude', 'wrappers');
     fs.mkdirSync(wrappersDir, { recursive: true });
     fs.writeFileSync(
-      path.join(wrappersDir, "mcp-test.sh"),
-      "#!/usr/bin/env bash\nexec echo test\n",
+      path.join(wrappersDir, 'mcp-test.sh'),
+      '#!/usr/bin/env bash\nexec echo test\n',
     );
 
     const server = {
-      name: "test-server",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      wrapper: "wrappers/mcp-test.sh",
+      name: 'test-server',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      wrapper: 'wrappers/mcp-test.sh',
     };
 
     const args = buildAddArgs(server, repoRoot, fakeHomedir);
 
     const expectedWrapperPath = path.join(
       fakeHomedir,
-      ".claude",
-      "wrappers/mcp-test.sh",
+      '.claude',
+      'wrappers/mcp-test.sh',
     );
     assert.ok(
       args.includes(expectedWrapperPath),
@@ -299,25 +299,25 @@ describe("buildAddArgs — wrapper-based server", () => {
     );
   });
 
-  it("resolves project-scope wrapper against repoRoot", () => {
-    const fakeRepoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-proj-scope-"));
-    const wrappersDir = path.join(fakeRepoRoot, "wrappers");
+  it('resolves project-scope wrapper against repoRoot', () => {
+    const fakeRepoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-proj-scope-'));
+    const wrappersDir = path.join(fakeRepoRoot, 'wrappers');
     fs.mkdirSync(wrappersDir);
     fs.writeFileSync(
-      path.join(wrappersDir, "some.sh"),
-      "#!/usr/bin/env bash\nexec echo some\n",
+      path.join(wrappersDir, 'some.sh'),
+      '#!/usr/bin/env bash\nexec echo some\n',
     );
 
     const server = {
-      name: "some-server",
-      scope: "project" as const,
-      transport: "stdio" as const,
-      wrapper: "wrappers/some.sh",
+      name: 'some-server',
+      scope: 'project' as const,
+      transport: 'stdio' as const,
+      wrapper: 'wrappers/some.sh',
     };
 
     const args = buildAddArgs(server, fakeRepoRoot);
 
-    const expectedWrapperPath = path.join(fakeRepoRoot, "wrappers/some.sh");
+    const expectedWrapperPath = path.join(fakeRepoRoot, 'wrappers/some.sh');
     assert.ok(
       args.includes(expectedWrapperPath),
       `expected args to contain "${expectedWrapperPath}", got: ${JSON.stringify(args)}`,
@@ -329,103 +329,103 @@ describe("buildAddArgs — wrapper-based server", () => {
 // buildAddArgs — command-based servers
 // ---------------------------------------------------------------------------
 
-describe("buildAddArgs — command-based server", () => {
-  it("returns correct args with -e flags and command", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-cmd-"));
+describe('buildAddArgs — command-based server', () => {
+  it('returns correct args with -e flags and command', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-cmd-'));
 
     const server = {
-      name: "kubernetes",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      command: "kubectl",
-      args: ["mcp", "serve"],
+      name: 'kubernetes',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      command: 'kubectl',
+      args: ['mcp', 'serve'],
       env: {
-        KUBECONFIG: "/home/user/.kube/config",
+        KUBECONFIG: '/home/user/.kube/config',
       },
     };
 
     const args = buildAddArgs(server, repoRoot);
 
     assert.deepStrictEqual(args, [
-      "-s",
-      "user",
-      "-t",
-      "stdio",
-      "-e",
-      "KUBECONFIG=/home/user/.kube/config",
-      "--",
-      "kubernetes",
-      "kubectl",
-      "mcp",
-      "serve",
+      '-s',
+      'user',
+      '-t',
+      'stdio',
+      '-e',
+      'KUBECONFIG=/home/user/.kube/config',
+      '--',
+      'kubernetes',
+      'kubectl',
+      'mcp',
+      'serve',
     ]);
   });
 
-  it("expands $HOME in env values", () => {
+  it('expands $HOME in env values', () => {
     const home = os.homedir();
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-home-"));
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-home-'));
 
     const server = {
-      name: "mytool",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      command: "mytool",
+      name: 'mytool',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      command: 'mytool',
       env: {
-        CONFIG: "$HOME/.config/mytool",
+        CONFIG: '$HOME/.config/mytool',
       },
     };
 
     const args = buildAddArgs(server, repoRoot);
 
-    const envFlag = args.find((a) => a.startsWith("CONFIG="));
-    assert.ok(envFlag !== undefined, "should have CONFIG= env flag");
+    const envFlag = args.find((a) => a.startsWith('CONFIG='));
+    assert.ok(envFlag !== undefined, 'should have CONFIG= env flag');
     assert.strictEqual(envFlag, `CONFIG=${home}/.config/mytool`);
   });
 
-  it("appends args after the command", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-args-"));
+  it('appends args after the command', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-args-'));
 
     const server = {
-      name: "cloudwatch",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      command: "uvx",
-      args: ["awslabs.cloudwatch-mcp-server@0.0.19"],
+      name: 'cloudwatch',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      command: 'uvx',
+      args: ['awslabs.cloudwatch-mcp-server@0.0.19'],
     };
 
     const args = buildAddArgs(server, repoRoot);
 
     // Command and args appear after "--"
-    const separatorIndex = args.indexOf("--");
+    const separatorIndex = args.indexOf('--');
     assert.ok(separatorIndex !== -1, 'args must contain "--" separator');
     const afterSep = args.slice(separatorIndex + 1);
     assert.deepStrictEqual(afterSep, [
-      "cloudwatch",
-      "uvx",
-      "awslabs.cloudwatch-mcp-server@0.0.19",
+      'cloudwatch',
+      'uvx',
+      'awslabs.cloudwatch-mcp-server@0.0.19',
     ]);
   });
 
-  it("handles a server with no env and no args", () => {
-    const repoRoot = fs.mkdtempSync(path.join(tmpDir, "repo-noenv-"));
+  it('handles a server with no env and no args', () => {
+    const repoRoot = fs.mkdtempSync(path.join(tmpDir, 'repo-noenv-'));
 
     const server = {
-      name: "simple",
-      scope: "project" as const,
-      transport: "sse" as const,
-      command: "simple-cmd",
+      name: 'simple',
+      scope: 'project' as const,
+      transport: 'sse' as const,
+      command: 'simple-cmd',
     };
 
     const args = buildAddArgs(server, repoRoot);
 
     assert.deepStrictEqual(args, [
-      "-s",
-      "project",
-      "-t",
-      "sse",
-      "--",
-      "simple",
-      "simple-cmd",
+      '-s',
+      'project',
+      '-t',
+      'sse',
+      '--',
+      'simple',
+      'simple-cmd',
     ]);
   });
 });
@@ -434,50 +434,50 @@ describe("buildAddArgs — command-based server", () => {
 // computeConfigSignature
 // ---------------------------------------------------------------------------
 
-describe("computeConfigSignature", () => {
+describe('computeConfigSignature', () => {
   const baseServer = {
-    name: "grafana",
-    scope: "user" as const,
-    transport: "stdio" as const,
-    wrapper: "wrappers/mcp-grafana.sh",
+    name: 'grafana',
+    scope: 'user' as const,
+    transport: 'stdio' as const,
+    wrapper: 'wrappers/mcp-grafana.sh',
   };
-  const repoRoot = "/tmp/fake-repo";
-  const fakeHomedir = "/tmp/fake-home";
+  const repoRoot = '/tmp/fake-repo';
+  const fakeHomedir = '/tmp/fake-home';
 
-  it("produces identical signatures for identical inputs", () => {
+  it('produces identical signatures for identical inputs', () => {
     const sig1 = computeConfigSignature(baseServer, repoRoot, fakeHomedir);
     const sig2 = computeConfigSignature(baseServer, repoRoot, fakeHomedir);
     assert.strictEqual(sig1, sig2);
   });
 
-  it("produces different signatures when wrapper path changes", () => {
-    const other = { ...baseServer, wrapper: "wrappers/mcp-other.sh" };
+  it('produces different signatures when wrapper path changes', () => {
+    const other = { ...baseServer, wrapper: 'wrappers/mcp-other.sh' };
     const sig1 = computeConfigSignature(baseServer, repoRoot, fakeHomedir);
     const sig2 = computeConfigSignature(other, repoRoot, fakeHomedir);
     assert.notStrictEqual(sig1, sig2);
   });
 
-  it("produces different signatures when transport changes", () => {
-    const other = { ...baseServer, transport: "sse" as const };
+  it('produces different signatures when transport changes', () => {
+    const other = { ...baseServer, transport: 'sse' as const };
     const sig1 = computeConfigSignature(baseServer, repoRoot, fakeHomedir);
     const sig2 = computeConfigSignature(other, repoRoot, fakeHomedir);
     assert.notStrictEqual(sig1, sig2);
   });
 
-  it("produces different signatures when scope changes", () => {
-    const other = { ...baseServer, scope: "project" as const };
+  it('produces different signatures when scope changes', () => {
+    const other = { ...baseServer, scope: 'project' as const };
     const sig1 = computeConfigSignature(baseServer, repoRoot, fakeHomedir);
     const sig2 = computeConfigSignature(other, repoRoot, fakeHomedir);
     assert.notStrictEqual(sig1, sig2);
   });
 
-  it("resolves user-scope wrapper against homedir", () => {
-    const localHome = "/custom/home";
+  it('resolves user-scope wrapper against homedir', () => {
+    const localHome = '/custom/home';
     const sig = computeConfigSignature(baseServer, repoRoot, localHome);
     const expectedPath = path.join(
       localHome,
-      ".claude",
-      "wrappers/mcp-grafana.sh",
+      '.claude',
+      'wrappers/mcp-grafana.sh',
     );
     assert.ok(
       sig.includes(expectedPath),
@@ -485,12 +485,12 @@ describe("computeConfigSignature", () => {
     );
   });
 
-  it("throws when server has no wrapper field", () => {
+  it('throws when server has no wrapper field', () => {
     const commandServer = {
-      name: "kubernetes",
-      scope: "user" as const,
-      transport: "stdio" as const,
-      command: "kubectl",
+      name: 'kubernetes',
+      scope: 'user' as const,
+      transport: 'stdio' as const,
+      command: 'kubectl',
     };
     assert.throws(() => computeConfigSignature(commandServer, repoRoot));
   });
@@ -500,27 +500,27 @@ describe("computeConfigSignature", () => {
 // readStamps
 // ---------------------------------------------------------------------------
 
-describe("readStamps", () => {
-  it("returns empty object when file does not exist", () => {
-    const nonexistent = path.join(tmpDir, "no-such-stamps.json");
+describe('readStamps', () => {
+  it('returns empty object when file does not exist', () => {
+    const nonexistent = path.join(tmpDir, 'no-such-stamps.json');
     const result = readStamps(nonexistent);
     assert.deepStrictEqual(result, {});
   });
 
-  it("returns parsed stamps from valid JSON file", () => {
-    const stampsPath = path.join(tmpDir, "valid-stamps.json");
+  it('returns parsed stamps from valid JSON file', () => {
+    const stampsPath = path.join(tmpDir, 'valid-stamps.json');
     const stamps = {
       grafana: '{"name":"grafana"}',
       kubernetes: '{"name":"k8s"}',
     };
-    fs.writeFileSync(stampsPath, JSON.stringify(stamps), "utf8");
+    fs.writeFileSync(stampsPath, JSON.stringify(stamps), 'utf8');
     const result = readStamps(stampsPath);
     assert.deepStrictEqual(result, stamps);
   });
 
-  it("returns empty object and does not throw on corrupted JSON", () => {
-    const stampsPath = path.join(tmpDir, "corrupt-stamps.json");
-    fs.writeFileSync(stampsPath, "not valid json {{{", "utf8");
+  it('returns empty object and does not throw on corrupted JSON', () => {
+    const stampsPath = path.join(tmpDir, 'corrupt-stamps.json');
+    fs.writeFileSync(stampsPath, 'not valid json {{{', 'utf8');
     const result = readStamps(stampsPath);
     assert.deepStrictEqual(result, {});
   });
@@ -530,18 +530,18 @@ describe("readStamps", () => {
 // writeStamps
 // ---------------------------------------------------------------------------
 
-describe("writeStamps", () => {
-  it("writes stamps to disk as pretty JSON", () => {
-    const stampsPath = path.join(tmpDir, "written-stamps.json");
-    const stamps = { grafana: "sig1", kubernetes: "sig2" };
+describe('writeStamps', () => {
+  it('writes stamps to disk as pretty JSON', () => {
+    const stampsPath = path.join(tmpDir, 'written-stamps.json');
+    const stamps = { grafana: 'sig1', kubernetes: 'sig2' };
     writeStamps(stampsPath, stamps);
-    const written = fs.readFileSync(stampsPath, "utf8");
+    const written = fs.readFileSync(stampsPath, 'utf8');
     assert.strictEqual(written, JSON.stringify(stamps, null, 2));
   });
 
-  it("does not throw when path is unwritable", () => {
-    const stampsPath = path.join(tmpDir, "no", "such", "dir", "stamps.json");
-    assert.doesNotThrow(() => writeStamps(stampsPath, { key: "value" }));
+  it('does not throw when path is unwritable', () => {
+    const stampsPath = path.join(tmpDir, 'no', 'such', 'dir', 'stamps.json');
+    assert.doesNotThrow(() => writeStamps(stampsPath, { key: 'value' }));
   });
 });
 
@@ -554,9 +554,9 @@ describe("writeStamps", () => {
  * Returns the path to the fake homedir.
  */
 function makeFakeHome(): string {
-  const fakeHome = fs.mkdtempSync(path.join(tmpDir, "home-gh-"));
-  fs.mkdirSync(path.join(fakeHome, ".config"), { recursive: true });
-  fs.mkdirSync(path.join(fakeHome, ".claude", "wrappers"), { recursive: true });
+  const fakeHome = fs.mkdtempSync(path.join(tmpDir, 'home-gh-'));
+  fs.mkdirSync(path.join(fakeHome, '.config'), { recursive: true });
+  fs.mkdirSync(path.join(fakeHome, '.claude', 'wrappers'), { recursive: true });
   return fakeHome;
 }
 
@@ -569,8 +569,8 @@ function writePatsFile(
   contents: unknown,
   mode: number = 0o600,
 ): string {
-  const patsPath = path.join(fakeHome, ".config", "github-pats.json");
-  fs.writeFileSync(patsPath, JSON.stringify(contents), "utf8");
+  const patsPath = path.join(fakeHome, '.config', 'github-pats.json');
+  fs.writeFileSync(patsPath, JSON.stringify(contents), 'utf8');
   fs.chmodSync(patsPath, mode);
   return patsPath;
 }
@@ -599,7 +599,7 @@ interface SpawnCall {
 
 /** Stub that always throws — used to assert error-tolerance. */
 function alwaysThrowStub(_cmd: string, _args: string[]): void {
-  throw new Error("command failed");
+  throw new Error('command failed');
 }
 
 /** No-op stub — used in tests that only check thrown errors and don't need call capture. */
@@ -607,8 +607,8 @@ function noOpStub(_cmd: string, _args: string[]): void {
   // intentionally empty
 }
 
-describe("removeLegacyGithubRegistration", () => {
-  it("invokes claude mcp remove -s user github exactly once", () => {
+describe('removeLegacyGithubRegistration', () => {
+  it('invokes claude mcp remove -s user github exactly once', () => {
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => {
       calls.push({ cmd, args });
@@ -618,12 +618,12 @@ describe("removeLegacyGithubRegistration", () => {
 
     assert.strictEqual(calls.length, 1);
     assert.deepStrictEqual(calls[0], {
-      cmd: "claude",
-      args: ["mcp", "remove", "-s", "user", "github"],
+      cmd: 'claude',
+      args: ['mcp', 'remove', '-s', 'user', 'github'],
     });
   });
 
-  it("does not throw when the command fails (legacy registration absent)", () => {
+  it('does not throw when the command fails (legacy registration absent)', () => {
     assert.doesNotThrow(() => removeLegacyGithubRegistration(alwaysThrowStub));
   });
 });
@@ -632,10 +632,10 @@ describe("removeLegacyGithubRegistration", () => {
 // assertWrappersDirNotWorldWritable
 // ---------------------------------------------------------------------------
 
-describe("assertWrappersDirNotWorldWritable", () => {
-  it("is silent when wrappers dir mode is 0755", () => {
+describe('assertWrappersDirNotWorldWritable', () => {
+  it('is silent when wrappers dir mode is 0755', () => {
     const fakeHome = makeFakeHome();
-    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    const wrappersDir = path.join(fakeHome, '.claude', 'wrappers');
     fs.chmodSync(wrappersDir, 0o755);
 
     const warnings: string[] = [];
@@ -644,30 +644,30 @@ describe("assertWrappersDirNotWorldWritable", () => {
     assert.strictEqual(warnings.length, 0);
   });
 
-  it("prints warning when wrappers dir mode is 0775 (group-writable)", () => {
+  it('prints warning when wrappers dir mode is 0775 (group-writable)', () => {
     const fakeHome = makeFakeHome();
-    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    const wrappersDir = path.join(fakeHome, '.claude', 'wrappers');
     fs.chmodSync(wrappersDir, 0o775);
 
     const warnings: string[] = [];
     assertWrappersDirNotWorldWritable(fakeHome, (msg) => warnings.push(msg));
 
-    assert.ok(warnings.length > 0, "expected at least one warning");
+    assert.ok(warnings.length > 0, 'expected at least one warning');
     assert.ok(
-      warnings.some((w) => w.includes("wrappers")),
-      `expected 'wrappers' in warning, got: ${warnings.join(", ")}`,
+      warnings.some((w) => w.includes('wrappers')),
+      `expected 'wrappers' in warning, got: ${warnings.join(', ')}`,
     );
   });
 
-  it("prints warning when wrappers dir mode is 0777 (world-writable)", () => {
+  it('prints warning when wrappers dir mode is 0777 (world-writable)', () => {
     const fakeHome = makeFakeHome();
-    const wrappersDir = path.join(fakeHome, ".claude", "wrappers");
+    const wrappersDir = path.join(fakeHome, '.claude', 'wrappers');
     fs.chmodSync(wrappersDir, 0o777);
 
     const warnings: string[] = [];
     assertWrappersDirNotWorldWritable(fakeHome, (msg) => warnings.push(msg));
 
-    assert.ok(warnings.length > 0, "expected at least one warning");
+    assert.ok(warnings.length > 0, 'expected at least one warning');
   });
 });
 
@@ -675,10 +675,10 @@ describe("assertWrappersDirNotWorldWritable", () => {
 // registerGithubAccounts
 // ---------------------------------------------------------------------------
 
-describe("registerGithubAccounts", () => {
-  it("registers one server per key in sorted order with only GITHUB_ACCOUNT env, no PAT in argv", () => {
+describe('registerGithubAccounts', () => {
+  it('registers one server per key in sorted order with only GITHUB_ACCOUNT env, no PAT in argv', () => {
     const fakeHome = makeFakeHome();
-    writePatsFile(fakeHome, { work: "ghp_b", personal: "ghp_a" });
+    writePatsFile(fakeHome, { work: 'ghp_b', personal: 'ghp_a' });
 
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => {
@@ -689,31 +689,31 @@ describe("registerGithubAccounts", () => {
 
     // Should have registered 2 accounts (each: remove + add = 2 calls per account)
     const addCalls = calls.filter(
-      (c) => c.cmd === "claude" && c.args.includes("add"),
+      (c) => c.cmd === 'claude' && c.args.includes('add'),
     );
-    assert.strictEqual(addCalls.length, 2, "expected exactly 2 mcp add calls");
+    assert.strictEqual(addCalls.length, 2, 'expected exactly 2 mcp add calls');
 
     // Sorted order: personal before work
     const firstAdd = addCalls[0]!;
     const secondAdd = addCalls[1]!;
     assert.ok(
-      firstAdd.args.includes("github-personal"),
+      firstAdd.args.includes('github-personal'),
       `expected first add to be for 'personal', got: ${JSON.stringify(firstAdd.args)}`,
     );
     assert.ok(
-      secondAdd.args.includes("github-work"),
+      secondAdd.args.includes('github-work'),
       `expected second add to be for 'work', got: ${JSON.stringify(secondAdd.args)}`,
     );
 
     // Each add must contain -e GITHUB_ACCOUNT=<key>
     assert.ok(
-      firstAdd.args.includes("-e") &&
-        firstAdd.args.includes("GITHUB_ACCOUNT=personal"),
+      firstAdd.args.includes('-e') &&
+        firstAdd.args.includes('GITHUB_ACCOUNT=personal'),
       `expected GITHUB_ACCOUNT=personal in argv: ${JSON.stringify(firstAdd.args)}`,
     );
     assert.ok(
-      secondAdd.args.includes("-e") &&
-        secondAdd.args.includes("GITHUB_ACCOUNT=work"),
+      secondAdd.args.includes('-e') &&
+        secondAdd.args.includes('GITHUB_ACCOUNT=work'),
       `expected GITHUB_ACCOUNT=work in argv: ${JSON.stringify(secondAdd.args)}`,
     );
 
@@ -721,7 +721,7 @@ describe("registerGithubAccounts", () => {
     for (const call of calls) {
       for (const arg of call.args) {
         assert.ok(
-          !arg.includes("GITHUB_PERSONAL_ACCESS_TOKEN"),
+          !arg.includes('GITHUB_PERSONAL_ACCESS_TOKEN'),
           `found GITHUB_PERSONAL_ACCESS_TOKEN in argv: ${JSON.stringify(call.args)}`,
         );
       }
@@ -731,7 +731,7 @@ describe("registerGithubAccounts", () => {
     for (const call of calls) {
       for (const arg of call.args) {
         assert.ok(
-          !arg.includes("ghp_a") && !arg.includes("ghp_b"),
+          !arg.includes('ghp_a') && !arg.includes('ghp_b'),
           `found PAT value in argv: ${JSON.stringify(call.args)}`,
         );
       }
@@ -740,9 +740,9 @@ describe("registerGithubAccounts", () => {
     // Wrapper path resolves to fakeHome/.claude/wrappers/mcp-github.sh
     const expectedWrapperPath = path.join(
       fakeHome,
-      ".claude",
-      "wrappers",
-      "mcp-github.sh",
+      '.claude',
+      'wrappers',
+      'mcp-github.sh',
     );
     assert.ok(
       firstAdd.args.includes(expectedWrapperPath),
@@ -750,10 +750,10 @@ describe("registerGithubAccounts", () => {
     );
 
     // Returns the set of registered keys
-    assert.deepStrictEqual(result, new Set(["personal", "work"]));
+    assert.deepStrictEqual(result, new Set(['personal', 'work']));
   });
 
-  it("returns empty set and prints warning when github-pats.json is absent", () => {
+  it('returns empty set and prints warning when github-pats.json is absent', () => {
     const fakeHome = makeFakeHome();
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
@@ -765,14 +765,14 @@ describe("registerGithubAccounts", () => {
 
     assert.deepStrictEqual(result, new Set());
     assert.ok(
-      warnings.some((w) => w.includes("not found")),
-      `expected 'not found' warning, got: ${warnings.join(", ")}`,
+      warnings.some((w) => w.includes('not found')),
+      `expected 'not found' warning, got: ${warnings.join(', ')}`,
     );
-    const addCalls = calls.filter((c) => c.args.includes("add"));
+    const addCalls = calls.filter((c) => c.args.includes('add'));
     assert.strictEqual(addCalls.length, 0);
   });
 
-  it("returns empty set and prints warning when github-pats.json is empty object", () => {
+  it('returns empty set and prints warning when github-pats.json is empty object', () => {
     const fakeHome = makeFakeHome();
     writePatsFile(fakeHome, {});
     const calls: SpawnCall[] = [];
@@ -785,17 +785,17 @@ describe("registerGithubAccounts", () => {
 
     assert.deepStrictEqual(result, new Set());
     assert.ok(
-      warnings.some((w) => w.includes("empty")),
-      `expected 'empty' warning, got: ${warnings.join(", ")}`,
+      warnings.some((w) => w.includes('empty')),
+      `expected 'empty' warning, got: ${warnings.join(', ')}`,
     );
-    const addCalls = calls.filter((c) => c.args.includes("add"));
+    const addCalls = calls.filter((c) => c.args.includes('add'));
     assert.strictEqual(addCalls.length, 0);
   });
 
-  it("throws on invalid JSON and error message does not include file contents", () => {
+  it('throws on invalid JSON and error message does not include file contents', () => {
     const fakeHome = makeFakeHome();
-    const patsPath = path.join(fakeHome, ".config", "github-pats.json");
-    fs.writeFileSync(patsPath, "not-valid-json-{{{", "utf8");
+    const patsPath = path.join(fakeHome, '.config', 'github-pats.json');
+    fs.writeFileSync(patsPath, 'not-valid-json-{{{', 'utf8');
     fs.chmodSync(patsPath, 0o600);
 
     assert.throws(
@@ -804,12 +804,12 @@ describe("registerGithubAccounts", () => {
         assert.ok(err instanceof Error);
         // Must not include file contents
         assert.ok(
-          !err.message.includes("not-valid-json"),
+          !err.message.includes('not-valid-json'),
           `error message must not include file contents, got: ${err.message}`,
         );
         // Must include path
         assert.ok(
-          err.message.includes("github-pats.json"),
+          err.message.includes('github-pats.json'),
           `error message must include path, got: ${err.message}`,
         );
         return true;
@@ -817,7 +817,7 @@ describe("registerGithubAccounts", () => {
     );
   });
 
-  it("throws when PAT value is a number, error identifies key only not value", () => {
+  it('throws when PAT value is a number, error identifies key only not value', () => {
     const fakeHome = makeFakeHome();
     writePatsFile(fakeHome, { personal: 123 });
 
@@ -826,11 +826,11 @@ describe("registerGithubAccounts", () => {
       (err: unknown) => {
         assert.ok(err instanceof Error);
         assert.ok(
-          err.message.includes("personal"),
+          err.message.includes('personal'),
           `expected key name in error: ${err.message}`,
         );
         assert.ok(
-          !err.message.includes("123"),
+          !err.message.includes('123'),
           `must not include value '123' in error: ${err.message}`,
         );
         return true;
@@ -838,16 +838,16 @@ describe("registerGithubAccounts", () => {
     );
   });
 
-  it("throws when PAT value is empty string, error identifies key only", () => {
+  it('throws when PAT value is empty string, error identifies key only', () => {
     const fakeHome = makeFakeHome();
-    writePatsFile(fakeHome, { personal: "" });
+    writePatsFile(fakeHome, { personal: '' });
 
     assert.throws(
       () => registerGithubAccounts(fakeHome, noOpStub),
       (err: unknown) => {
         assert.ok(err instanceof Error);
         assert.ok(
-          err.message.includes("personal"),
+          err.message.includes('personal'),
           `expected key name in error: ${err.message}`,
         );
         return true;
@@ -855,9 +855,9 @@ describe("registerGithubAccounts", () => {
     );
   });
 
-  it("throws when key contains invalid characters", () => {
+  it('throws when key contains invalid characters', () => {
     const fakeHome = makeFakeHome();
-    writePatsFile(fakeHome, { "per sonal": "ghp_x" });
+    writePatsFile(fakeHome, { 'per sonal': 'ghp_x' });
 
     assert.throws(
       () => registerGithubAccounts(fakeHome, noOpStub),
@@ -868,9 +868,9 @@ describe("registerGithubAccounts", () => {
     );
   });
 
-  it("prints mode warning when github-pats.json mode is 0644 but continues to register", () => {
+  it('prints mode warning when github-pats.json mode is 0644 but continues to register', () => {
     const fakeHome = makeFakeHome();
-    writePatsFile(fakeHome, { personal: "ghp_a" }, 0o644);
+    writePatsFile(fakeHome, { personal: 'ghp_a' }, 0o644);
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
 
@@ -878,11 +878,11 @@ describe("registerGithubAccounts", () => {
     registerGithubAccounts(fakeHome, stub, (msg) => warnings.push(msg));
 
     assert.ok(
-      warnings.some((w) => w.includes("644") || w.includes("0644")),
-      `expected mode warning, got: ${warnings.join(", ")}`,
+      warnings.some((w) => w.includes('644') || w.includes('0644')),
+      `expected mode warning, got: ${warnings.join(', ')}`,
     );
-    const addCalls = calls.filter((c) => c.args.includes("add"));
-    assert.strictEqual(addCalls.length, 1, "should still register 1 account");
+    const addCalls = calls.filter((c) => c.args.includes('add'));
+    assert.strictEqual(addCalls.length, 1, 'should still register 1 account');
   });
 });
 
@@ -890,82 +890,82 @@ describe("registerGithubAccounts", () => {
 // removeStaleGithubRegistrations
 // ---------------------------------------------------------------------------
 
-describe("removeStaleGithubRegistrations", () => {
-  it("removes stale github-old but not desired github-personal or unrelated grafana", () => {
+describe('removeStaleGithubRegistrations', () => {
+  it('removes stale github-old but not desired github-personal or unrelated grafana', () => {
     const fakeHome = makeFakeHome();
-    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    const claudeJsonPath = path.join(fakeHome, '.claude.json');
     fs.writeFileSync(
       claudeJsonPath,
       JSON.stringify({
         mcpServers: {
-          "github-old": { type: "stdio", command: "/some/wrapper" },
-          "github-personal": { type: "stdio", command: "/some/wrapper" },
-          grafana: { type: "stdio", command: "/some/wrapper" },
+          'github-old': { type: 'stdio', command: '/some/wrapper' },
+          'github-personal': { type: 'stdio', command: '/some/wrapper' },
+          grafana: { type: 'stdio', command: '/some/wrapper' },
         },
       }),
-      "utf8",
+      'utf8',
     );
 
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
 
-    removeStaleGithubRegistrations(new Set(["personal"]), fakeHome, stub);
+    removeStaleGithubRegistrations(new Set(['personal']), fakeHome, stub);
 
     const removeCalls = calls.filter(
-      (c) => c.cmd === "claude" && c.args.includes("remove"),
+      (c) => c.cmd === 'claude' && c.args.includes('remove'),
     );
-    assert.strictEqual(removeCalls.length, 1, "expected exactly 1 remove call");
+    assert.strictEqual(removeCalls.length, 1, 'expected exactly 1 remove call');
     assert.ok(
-      removeCalls[0]!.args.includes("github-old"),
+      removeCalls[0]!.args.includes('github-old'),
       `expected github-old to be removed, got: ${JSON.stringify(removeCalls[0]!.args)}`,
     );
 
     // Assert grafana and github-personal not removed
     for (const call of removeCalls) {
-      assert.ok(!call.args.includes("grafana"), "must not remove grafana");
+      assert.ok(!call.args.includes('grafana'), 'must not remove grafana');
       assert.ok(
-        !call.args.includes("github-personal"),
-        "must not remove github-personal (still desired)",
+        !call.args.includes('github-personal'),
+        'must not remove github-personal (still desired)',
       );
     }
   });
 
-  it("removes stale github-my_account (underscore suffix, F-10 mirror)", () => {
+  it('removes stale github-my_account (underscore suffix, F-10 mirror)', () => {
     const fakeHome = makeFakeHome();
-    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    const claudeJsonPath = path.join(fakeHome, '.claude.json');
     fs.writeFileSync(
       claudeJsonPath,
       JSON.stringify({
         mcpServers: {
-          "github-my_account": { type: "stdio", command: "/some/wrapper" },
+          'github-my_account': { type: 'stdio', command: '/some/wrapper' },
         },
       }),
-      "utf8",
+      'utf8',
     );
 
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
 
-    removeStaleGithubRegistrations(new Set(["personal"]), fakeHome, stub);
+    removeStaleGithubRegistrations(new Set(['personal']), fakeHome, stub);
 
     const removeCalls = calls.filter(
-      (c) => c.cmd === "claude" && c.args.includes("remove"),
+      (c) => c.cmd === 'claude' && c.args.includes('remove'),
     );
     assert.strictEqual(removeCalls.length, 1);
-    assert.ok(removeCalls[0]!.args.includes("github-my_account"));
+    assert.ok(removeCalls[0]!.args.includes('github-my_account'));
   });
 
-  it("does not remove the legacy github (no hyphen suffix) server", () => {
+  it('does not remove the legacy github (no hyphen suffix) server', () => {
     const fakeHome = makeFakeHome();
-    const claudeJsonPath = path.join(fakeHome, ".claude.json");
+    const claudeJsonPath = path.join(fakeHome, '.claude.json');
     fs.writeFileSync(
       claudeJsonPath,
       JSON.stringify({
         mcpServers: {
-          github: { type: "stdio", command: "/some/wrapper" },
+          github: { type: 'stdio', command: '/some/wrapper' },
         },
       }),
-      "utf8",
+      'utf8',
     );
 
     const calls: SpawnCall[] = [];
@@ -974,16 +974,16 @@ describe("removeStaleGithubRegistrations", () => {
     removeStaleGithubRegistrations(new Set(), fakeHome, stub);
 
     const removeCalls = calls.filter(
-      (c) => c.cmd === "claude" && c.args.includes("remove"),
+      (c) => c.cmd === 'claude' && c.args.includes('remove'),
     );
     assert.strictEqual(
       removeCalls.length,
       0,
-      "legacy github should not be removed by removeStale (removeLegacy handles it)",
+      'legacy github should not be removed by removeStale (removeLegacy handles it)',
     );
   });
 
-  it("returns silently when ~/.claude.json is absent", () => {
+  it('returns silently when ~/.claude.json is absent', () => {
     const fakeHome = makeFakeHome();
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
@@ -994,10 +994,10 @@ describe("removeStaleGithubRegistrations", () => {
     assert.strictEqual(calls.length, 0);
   });
 
-  it("prints yellow warning and returns without throwing when ~/.claude.json is malformed", () => {
+  it('prints yellow warning and returns without throwing when ~/.claude.json is malformed', () => {
     const fakeHome = makeFakeHome();
-    const claudeJsonPath = path.join(fakeHome, ".claude.json");
-    fs.writeFileSync(claudeJsonPath, "not-valid-json", "utf8");
+    const claudeJsonPath = path.join(fakeHome, '.claude.json');
+    fs.writeFileSync(claudeJsonPath, 'not-valid-json', 'utf8');
 
     const calls: SpawnCall[] = [];
     const stub = (cmd: string, args: string[]) => calls.push({ cmd, args });
@@ -1010,9 +1010,9 @@ describe("removeStaleGithubRegistrations", () => {
     );
     assert.ok(
       warnings.some(
-        (w) => w.includes("invalid JSON") || w.includes("claude.json"),
+        (w) => w.includes('invalid JSON') || w.includes('claude.json'),
       ),
-      `expected warning about invalid JSON, got: ${warnings.join(", ")}`,
+      `expected warning about invalid JSON, got: ${warnings.join(', ')}`,
     );
     assert.strictEqual(calls.length, 0);
   });
@@ -1022,163 +1022,163 @@ describe("removeStaleGithubRegistrations", () => {
 // updateGithubAllowList
 // ---------------------------------------------------------------------------
 
-describe("updateGithubAllowList", () => {
+describe('updateGithubAllowList', () => {
   /** Creates a settings.json with an allowedTools array (and optional extra tools). */
   function writeSettings(
     fakeHome: string,
     allowedTools: string[],
     extra: Record<string, unknown> = {},
   ): string {
-    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
     const content = { allowedTools, ...extra };
     fs.writeFileSync(
       settingsPath,
-      JSON.stringify(content, null, 2) + "\n",
-      "utf8",
+      JSON.stringify(content, null, 2) + '\n',
+      'utf8',
     );
     return settingsPath;
   }
 
   function readSettings(fakeHome: string): Record<string, unknown> {
-    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
-    return JSON.parse(fs.readFileSync(settingsPath, "utf8")) as Record<
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    return JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<
       string,
       unknown
     >;
   }
 
-  it("adds mcp__github-personal__* and mcp__github-work__* in sorted order", () => {
+  it('adds mcp__github-personal__* and mcp__github-work__* in sorted order', () => {
     const fakeHome = makeFakeHome();
-    writeSettings(fakeHome, ["Bash(git *)"]);
+    writeSettings(fakeHome, ['Bash(git *)']);
 
-    updateGithubAllowList(new Set(["work", "personal"]), fakeHome);
+    updateGithubAllowList(new Set(['work', 'personal']), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
-    assert.ok(tools.includes("mcp__github-personal__*"));
-    assert.ok(tools.includes("mcp__github-work__*"));
+    const tools = settings['allowedTools'] as string[];
+    assert.ok(tools.includes('mcp__github-personal__*'));
+    assert.ok(tools.includes('mcp__github-work__*'));
     // sorted: personal before work when appended
-    const piIdx = tools.indexOf("mcp__github-personal__*");
-    const wiIdx = tools.indexOf("mcp__github-work__*");
-    assert.ok(piIdx < wiIdx, "personal should appear before work (sorted)");
+    const piIdx = tools.indexOf('mcp__github-personal__*');
+    const wiIdx = tools.indexOf('mcp__github-work__*');
+    assert.ok(piIdx < wiIdx, 'personal should appear before work (sorted)');
     // Unrelated entry preserved
-    assert.ok(tools.includes("Bash(git *)"));
+    assert.ok(tools.includes('Bash(git *)'));
   });
 
-  it("is idempotent: calling twice with same input produces byte-identical output", () => {
+  it('is idempotent: calling twice with same input produces byte-identical output', () => {
     const fakeHome = makeFakeHome();
-    writeSettings(fakeHome, ["Bash(git *)"]);
+    writeSettings(fakeHome, ['Bash(git *)']);
 
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
-    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
-    const after1 = fs.readFileSync(settingsPath, "utf8");
+    updateGithubAllowList(new Set(['personal']), fakeHome);
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    const after1 = fs.readFileSync(settingsPath, 'utf8');
 
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
-    const after2 = fs.readFileSync(settingsPath, "utf8");
+    updateGithubAllowList(new Set(['personal']), fakeHome);
+    const after2 = fs.readFileSync(settingsPath, 'utf8');
 
     assert.strictEqual(
       after1,
       after2,
-      "file must be byte-identical on second run",
+      'file must be byte-identical on second run',
     );
   });
 
-  it("removes stale mcp__github-old__* when key is no longer in desired set", () => {
+  it('removes stale mcp__github-old__* when key is no longer in desired set', () => {
     const fakeHome = makeFakeHome();
-    writeSettings(fakeHome, ["mcp__github-old__*", "Bash(git *)"]);
+    writeSettings(fakeHome, ['mcp__github-old__*', 'Bash(git *)']);
 
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    updateGithubAllowList(new Set(['personal']), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
+    const tools = settings['allowedTools'] as string[];
     assert.ok(
-      !tools.includes("mcp__github-old__*"),
-      "stale entry must be removed",
+      !tools.includes('mcp__github-old__*'),
+      'stale entry must be removed',
     );
     assert.ok(
-      tools.includes("mcp__github-personal__*"),
-      "new entry must be added",
+      tools.includes('mcp__github-personal__*'),
+      'new entry must be added',
     );
     assert.ok(
-      tools.includes("Bash(git *)"),
-      "unrelated entry must be preserved",
+      tools.includes('Bash(git *)'),
+      'unrelated entry must be preserved',
     );
   });
 
-  it("removes mcp__github-my_account__* (underscore in key, F-10)", () => {
+  it('removes mcp__github-my_account__* (underscore in key, F-10)', () => {
     const fakeHome = makeFakeHome();
-    writeSettings(fakeHome, ["mcp__github-my_account__*", "Bash(git *)"]);
+    writeSettings(fakeHome, ['mcp__github-my_account__*', 'Bash(git *)']);
 
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    updateGithubAllowList(new Set(['personal']), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
+    const tools = settings['allowedTools'] as string[];
     assert.ok(
-      !tools.includes("mcp__github-my_account__*"),
-      "underscore-suffix stale entry must be removed",
+      !tools.includes('mcp__github-my_account__*'),
+      'underscore-suffix stale entry must be removed',
     );
-    assert.ok(tools.includes("mcp__github-personal__*"));
+    assert.ok(tools.includes('mcp__github-personal__*'));
   });
 
-  it("removes multi-character-class entries (dots, dashes, underscores) when desired set is empty", () => {
+  it('removes multi-character-class entries (dots, dashes, underscores) when desired set is empty', () => {
     const fakeHome = makeFakeHome();
     writeSettings(fakeHome, [
-      "mcp__github-foo.bar__*",
-      "mcp__github-foo-bar__*",
-      "mcp__github-foo_bar__*",
-      "Bash(git *)",
+      'mcp__github-foo.bar__*',
+      'mcp__github-foo-bar__*',
+      'mcp__github-foo_bar__*',
+      'Bash(git *)',
     ]);
 
     updateGithubAllowList(new Set(), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
-    assert.ok(!tools.includes("mcp__github-foo.bar__*"));
-    assert.ok(!tools.includes("mcp__github-foo-bar__*"));
-    assert.ok(!tools.includes("mcp__github-foo_bar__*"));
-    assert.ok(tools.includes("Bash(git *)"));
+    const tools = settings['allowedTools'] as string[];
+    assert.ok(!tools.includes('mcp__github-foo.bar__*'));
+    assert.ok(!tools.includes('mcp__github-foo-bar__*'));
+    assert.ok(!tools.includes('mcp__github-foo_bar__*'));
+    assert.ok(tools.includes('Bash(git *)'));
   });
 
-  it("removes github entry when desired set is empty", () => {
+  it('removes github entry when desired set is empty', () => {
     const fakeHome = makeFakeHome();
-    writeSettings(fakeHome, ["mcp__github-foo__*", "Bash(git *)"]);
+    writeSettings(fakeHome, ['mcp__github-foo__*', 'Bash(git *)']);
 
     updateGithubAllowList(new Set(), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
-    assert.ok(!tools.includes("mcp__github-foo__*"));
-    assert.ok(tools.includes("Bash(git *)"));
+    const tools = settings['allowedTools'] as string[];
+    assert.ok(!tools.includes('mcp__github-foo__*'));
+    assert.ok(tools.includes('Bash(git *)'));
   });
 
-  it("does not reorder or modify unrelated entries", () => {
+  it('does not reorder or modify unrelated entries', () => {
     const fakeHome = makeFakeHome();
     const originalTools = [
-      "Bash(git *)",
-      "mcp__grafana__search_dashboards",
-      "Write(~/.ai-tpk/**)",
+      'Bash(git *)',
+      'mcp__grafana__search_dashboards',
+      'Write(~/.ai-tpk/**)',
     ];
     writeSettings(fakeHome, originalTools);
 
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    updateGithubAllowList(new Set(['personal']), fakeHome);
 
     const settings = readSettings(fakeHome);
-    const tools = settings["allowedTools"] as string[];
+    const tools = settings['allowedTools'] as string[];
     // Original entries preserved and in original order
-    const gitIdx = tools.indexOf("Bash(git *)");
-    const grafanaIdx = tools.indexOf("mcp__grafana__search_dashboards");
-    const writeIdx = tools.indexOf("Write(~/.ai-tpk/**)");
-    assert.ok(gitIdx < grafanaIdx, "original order preserved");
-    assert.ok(grafanaIdx < writeIdx, "original order preserved");
+    const gitIdx = tools.indexOf('Bash(git *)');
+    const grafanaIdx = tools.indexOf('mcp__grafana__search_dashboards');
+    const writeIdx = tools.indexOf('Write(~/.ai-tpk/**)');
+    assert.ok(gitIdx < grafanaIdx, 'original order preserved');
+    assert.ok(grafanaIdx < writeIdx, 'original order preserved');
   });
 
-  it("throws when settings file is malformed and does not write", () => {
+  it('throws when settings file is malformed and does not write', () => {
     const fakeHome = makeFakeHome();
-    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
-    fs.writeFileSync(settingsPath, "not-valid-json", "utf8");
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    fs.writeFileSync(settingsPath, 'not-valid-json', 'utf8');
 
     assert.throws(
-      () => updateGithubAllowList(new Set(["personal"]), fakeHome),
+      () => updateGithubAllowList(new Set(['personal']), fakeHome),
       (err: unknown) => {
         assert.ok(err instanceof Error);
         return true;
@@ -1186,50 +1186,50 @@ describe("updateGithubAllowList", () => {
     );
 
     // File must remain unchanged
-    const onDisk = fs.readFileSync(settingsPath, "utf8");
-    assert.strictEqual(onDisk, "not-valid-json");
+    const onDisk = fs.readFileSync(settingsPath, 'utf8');
+    assert.strictEqual(onDisk, 'not-valid-json');
   });
 
-  it("prints warning and returns when settings file does not exist", () => {
+  it('prints warning and returns when settings file does not exist', () => {
     const fakeHome = makeFakeHome();
     // Don't write settings file
     const warnings: string[] = [];
     assert.doesNotThrow(() =>
-      updateGithubAllowList(new Set(["personal"]), fakeHome, (msg) =>
+      updateGithubAllowList(new Set(['personal']), fakeHome, (msg) =>
         warnings.push(msg),
       ),
     );
     assert.ok(
-      warnings.some((w) => w.includes("settings.json")),
-      `expected warning about missing settings.json, got: ${warnings.join(", ")}`,
+      warnings.some((w) => w.includes('settings.json')),
+      `expected warning about missing settings.json, got: ${warnings.join(', ')}`,
     );
   });
 
-  it("uses atomic temp+rename write pattern", () => {
+  it('uses atomic temp+rename write pattern', () => {
     const fakeHome = makeFakeHome();
-    const settingsPath = path.join(fakeHome, ".claude", "settings.json");
-    writeSettings(fakeHome, ["Bash(git *)"]);
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    writeSettings(fakeHome, ['Bash(git *)']);
 
     // Collect file ops by checking what files are created/modified in the .claude dir
     // We verify by checking that no .tmp file remains after the call
-    updateGithubAllowList(new Set(["personal"]), fakeHome);
+    updateGithubAllowList(new Set(['personal']), fakeHome);
 
     // The final file must exist and be valid JSON
-    const content = fs.readFileSync(settingsPath, "utf8");
+    const content = fs.readFileSync(settingsPath, 'utf8');
     const parsed = JSON.parse(content) as Record<string, unknown>;
     assert.ok(
-      Array.isArray(parsed["allowedTools"]),
-      "allowedTools must be an array",
+      Array.isArray(parsed['allowedTools']),
+      'allowedTools must be an array',
     );
 
     // No temp files should remain in .claude dir
-    const claudeDir = path.join(fakeHome, ".claude");
+    const claudeDir = path.join(fakeHome, '.claude');
     const entries = fs.readdirSync(claudeDir);
-    const tempFiles = entries.filter((e) => e.includes(".tmp."));
+    const tempFiles = entries.filter((e) => e.includes('.tmp.'));
     assert.strictEqual(
       tempFiles.length,
       0,
-      `temp files must be cleaned up, found: ${tempFiles.join(", ")}`,
+      `temp files must be cleaned up, found: ${tempFiles.join(', ')}`,
     );
   });
 });

--- a/src/installer/mcp.ts
+++ b/src/installer/mcp.ts
@@ -1,14 +1,14 @@
-import { execFileSync } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { c } from "./colors.js";
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { c } from './colors.js';
 
 interface McpServerConfig {
   name: string;
-  scope: "user" | "project";
-  transport: "stdio" | "sse" | "streamable-http";
+  scope: 'user' | 'project';
+  transport: 'stdio' | 'sse' | 'streamable-http';
   prereq?: string;
   env?: Record<string, string>;
   command?: string;
@@ -39,19 +39,19 @@ export function expandVars(value: string): string {
  * - Throws on malformed JSON or schema violations.
  */
 export function loadMcpServers(repoRoot: string): McpServerConfig[] {
-  const filePath = path.join(repoRoot, "src/mcp/mcp-servers.json");
+  const filePath = path.join(repoRoot, 'src/mcp/mcp-servers.json');
 
   let raw: string;
   try {
-    raw = fs.readFileSync(filePath, "utf8");
+    raw = fs.readFileSync(filePath, 'utf8');
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       console.log(
         c.yellow(
-          "Warning: mcp-servers.json not found -- skipping MCP server setup",
+          'Warning: mcp-servers.json not found -- skipping MCP server setup',
         ),
       );
       return [];
@@ -66,7 +66,7 @@ export function loadMcpServers(repoRoot: string): McpServerConfig[] {
     throw new Error(`mcp-servers.json: invalid JSON in ${filePath}`);
   }
 
-  if (typeof parsed !== "object" || parsed === null || !("servers" in parsed)) {
+  if (typeof parsed !== 'object' || parsed === null || !('servers' in parsed)) {
     throw new Error("mcp-servers.json: missing top-level 'servers' field");
   }
 
@@ -76,46 +76,46 @@ export function loadMcpServers(repoRoot: string): McpServerConfig[] {
     throw new Error("mcp-servers.json: 'servers' must be an array");
   }
 
-  const validScopes = ["user", "project"] as const;
-  const validTransports = ["stdio", "sse", "streamable-http"] as const;
+  const validScopes = ['user', 'project'] as const;
+  const validTransports = ['stdio', 'sse', 'streamable-http'] as const;
 
   for (const entry of servers as unknown[]) {
-    if (typeof entry !== "object" || entry === null) {
-      throw new Error("mcp-servers.json: each server entry must be an object");
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error('mcp-servers.json: each server entry must be an object');
     }
     const server = entry as Record<string, unknown>;
 
-    if (typeof server["name"] !== "string" || server["name"].trim() === "") {
+    if (typeof server['name'] !== 'string' || server['name'].trim() === '') {
       throw new Error(
         "mcp-servers.json: server entry missing required non-empty 'name' field",
       );
     }
-    const name = server["name"] as string;
+    const name = server['name'] as string;
 
     if (
-      !validScopes.includes(server["scope"] as (typeof validScopes)[number])
+      !validScopes.includes(server['scope'] as (typeof validScopes)[number])
     ) {
       throw new Error(
-        `mcp-servers.json: server '${name}' has invalid scope '${String(server["scope"])}' -- must be 'user' or 'project'`,
+        `mcp-servers.json: server '${name}' has invalid scope '${String(server['scope'])}' -- must be 'user' or 'project'`,
       );
     }
 
     if (
       !validTransports.includes(
-        server["transport"] as (typeof validTransports)[number],
+        server['transport'] as (typeof validTransports)[number],
       )
     ) {
       throw new Error(
-        `mcp-servers.json: server '${name}' has invalid transport '${String(server["transport"])}' -- must be 'stdio', 'sse', or 'streamable-http'`,
+        `mcp-servers.json: server '${name}' has invalid transport '${String(server['transport'])}' -- must be 'stdio', 'sse', or 'streamable-http'`,
       );
     }
 
     const hasWrapper =
-      typeof server["wrapper"] === "string" &&
-      (server["wrapper"] as string).trim() !== "";
+      typeof server['wrapper'] === 'string' &&
+      (server['wrapper'] as string).trim() !== '';
     const hasCommand =
-      typeof server["command"] === "string" &&
-      (server["command"] as string).trim() !== "";
+      typeof server['command'] === 'string' &&
+      (server['command'] as string).trim() !== '';
 
     if (hasWrapper && hasCommand) {
       throw new Error(
@@ -147,15 +147,15 @@ export function buildAddArgs(
 ): string[] {
   if (server.wrapper !== undefined) {
     const absoluteWrapperPath =
-      server.scope === "user"
-        ? path.join(homedir, ".claude", server.wrapper)
+      server.scope === 'user'
+        ? path.join(homedir, '.claude', server.wrapper)
         : path.join(repoRoot, server.wrapper);
     try {
       fs.statSync(absoluteWrapperPath);
     } catch (err: unknown) {
       if (
         err instanceof Error &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
       ) {
         throw new Error(
           `Wrapper script not found: ${absoluteWrapperPath} (defined in server '${server.name}')`,
@@ -165,20 +165,20 @@ export function buildAddArgs(
       throw err;
     }
     return [
-      "-s",
+      '-s',
       server.scope,
-      "-t",
+      '-t',
       server.transport,
-      "--",
+      '--',
       server.name,
       absoluteWrapperPath,
     ];
   }
 
-  const result: string[] = ["-s", server.scope, "-t", server.transport];
+  const result: string[] = ['-s', server.scope, '-t', server.transport];
 
   for (const [key, value] of Object.entries(server.env ?? {})) {
-    result.push("-e", `${key}=${expandVars(value)}`);
+    result.push('-e', `${key}=${expandVars(value)}`);
   }
 
   if (!server.command) {
@@ -186,7 +186,7 @@ export function buildAddArgs(
     throw new Error(`Server '${server.name}' has no command or wrapper field`);
   }
 
-  result.push("--", server.name, server.command);
+  result.push('--', server.name, server.command);
 
   for (const arg of server.args ?? []) {
     result.push(expandVars(arg));
@@ -198,8 +198,8 @@ export function buildAddArgs(
 // Path where install stamps are persisted across runs.
 const STAMPS_PATH = path.join(
   os.homedir(),
-  ".claude",
-  ".mcp-install-stamps.json",
+  '.claude',
+  '.mcp-install-stamps.json',
 );
 
 /**
@@ -220,8 +220,8 @@ export function computeConfigSignature(
     );
   }
   const wrapperPath =
-    server.scope === "user"
-      ? path.join(homedir, ".claude", server.wrapper)
+    server.scope === 'user'
+      ? path.join(homedir, '.claude', server.wrapper)
       : path.join(repoRoot, server.wrapper);
   return JSON.stringify({
     name: server.name,
@@ -239,11 +239,11 @@ export function computeConfigSignature(
 export function readStamps(stampsPath: string): Record<string, string> {
   let raw: string;
   try {
-    raw = fs.readFileSync(stampsPath, "utf8");
+    raw = fs.readFileSync(stampsPath, 'utf8');
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       return {};
     }
@@ -270,7 +270,7 @@ export function writeStamps(
   stamps: Record<string, string>,
 ): void {
   try {
-    fs.writeFileSync(stampsPath, JSON.stringify(stamps, null, 2), "utf8");
+    fs.writeFileSync(stampsPath, JSON.stringify(stamps, null, 2), 'utf8');
   } catch {
     console.log(
       c.yellow(
@@ -291,13 +291,13 @@ export function writeStamps(
  */
 function readFileModeOctal(filePath: string): string | null {
   try {
-    return execFileSync("stat", ["-f", "%Lp", filePath], {
-      encoding: "utf8",
+    return execFileSync('stat', ['-f', '%Lp', filePath], {
+      encoding: 'utf8',
     }).trim();
   } catch {
     try {
-      return execFileSync("stat", ["-c", "%a", filePath], {
-        encoding: "utf8",
+      return execFileSync('stat', ['-c', '%a', filePath], {
+        encoding: 'utf8',
       }).trim();
     } catch {
       return null;
@@ -317,7 +317,7 @@ type SpawnFn = (cmd: string, args: string[]) => void;
  * Default spawnFn that calls execFileSync with stdio: "pipe".
  */
 function defaultSpawn(cmd: string, args: string[]): void {
-  execFileSync(cmd, args, { stdio: "pipe" });
+  execFileSync(cmd, args, { stdio: 'pipe' });
 }
 
 /**
@@ -342,7 +342,7 @@ export function removeLegacyGithubRegistration(
   spawnFn: SpawnFn = defaultSpawn,
 ): void {
   try {
-    spawnFn("claude", ["mcp", "remove", "-s", "user", "github"]);
+    spawnFn('claude', ['mcp', 'remove', '-s', 'user', 'github']);
     console.log(c.green("Removed legacy 'github' MCP registration"));
   } catch {
     // Registration was not present — that is fine
@@ -361,7 +361,7 @@ export function assertWrappersDirNotWorldWritable(
   homedir: string = os.homedir(),
   warnFn: WarnFn = defaultWarn,
 ): void {
-  const wrappersDir = path.join(homedir, ".claude", "wrappers");
+  const wrappersDir = path.join(homedir, '.claude', 'wrappers');
   const modeStr = readFileModeOctal(wrappersDir);
   if (modeStr === null) {
     // Can't stat the dir — skip silently (may not exist yet on a fresh install)
@@ -404,7 +404,7 @@ export function registerGithubAccounts(
   spawnFn: SpawnFn = defaultSpawn,
   warnFn: WarnFn = defaultWarn,
 ): Set<string> {
-  const patsPath = path.join(homedir, ".config", "github-pats.json");
+  const patsPath = path.join(homedir, '.config', 'github-pats.json');
 
   // PATs file mode check at install time (V-1 part 2)
   try {
@@ -412,8 +412,8 @@ export function registerGithubAccounts(
     const modeStr = readFileModeOctal(patsPath);
     if (modeStr !== null) {
       // Normalise: strip leading zero for comparison
-      const normalised = modeStr.replace(/^0+/, "") || "0";
-      if (normalised !== "600") {
+      const normalised = modeStr.replace(/^0+/, '') || '0';
+      if (normalised !== '600') {
         warnFn(
           `Warning: ~/.config/github-pats.json mode is ${modeStr}; recommended mode is 0600.\n` +
             `Run: chmod 600 ~/.config/github-pats.json\n` +
@@ -424,10 +424,10 @@ export function registerGithubAccounts(
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       warnFn(
-        "Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup",
+        'Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup',
       );
       return new Set();
     }
@@ -437,14 +437,14 @@ export function registerGithubAccounts(
   // Read the PATs file
   let raw: string;
   try {
-    raw = fs.readFileSync(patsPath, "utf8");
+    raw = fs.readFileSync(patsPath, 'utf8');
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       warnFn(
-        "Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup",
+        'Warning: ~/.config/github-pats.json not found -- skipping GitHub MCP setup',
       );
       return new Set();
     }
@@ -463,7 +463,7 @@ export function registerGithubAccounts(
   }
 
   // Validate shape
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     throw new Error(`github-pats.json: ${patsPath} must be a flat JSON object`);
   }
 
@@ -477,7 +477,7 @@ export function registerGithubAccounts(
         `github-pats.json: key '${key}' contains characters outside [a-zA-Z0-9_.-]`,
       );
     }
-    if (typeof value !== "string" || value === "") {
+    if (typeof value !== 'string' || value === '') {
       // SECURITY: identify the offending entry by key only, never by value (V-4)
       throw new Error(
         `github-pats.json: PAT for account '${key}' must be a non-empty string`,
@@ -489,23 +489,23 @@ export function registerGithubAccounts(
   const sortedKeys = Object.keys(d).toSorted();
   if (sortedKeys.length === 0) {
     warnFn(
-      "Warning: ~/.config/github-pats.json is empty -- registering zero GitHub MCP servers",
+      'Warning: ~/.config/github-pats.json is empty -- registering zero GitHub MCP servers',
     );
     return new Set();
   }
 
   const wrapperPath = path.join(
     homedir,
-    ".claude",
-    "wrappers",
-    "mcp-github.sh",
+    '.claude',
+    'wrappers',
+    'mcp-github.sh',
   );
   const registered = new Set<string>();
 
   for (const key of sortedKeys) {
     // Best-effort remove any prior registration for this key (idempotent re-add)
     try {
-      spawnFn("claude", ["mcp", "remove", "-s", "user", `github-${key}`]);
+      spawnFn('claude', ['mcp', 'remove', '-s', 'user', `github-${key}`]);
     } catch {
       // Not previously registered — fine
     }
@@ -513,16 +513,16 @@ export function registerGithubAccounts(
     // Register the new server. Only GITHUB_ACCOUNT is passed as env — the PAT
     // is never passed here (resolves from ~/.config/github-pats.json at boot time).
     try {
-      spawnFn("claude", [
-        "mcp",
-        "add",
-        "-s",
-        "user",
-        "-t",
-        "stdio",
-        "-e",
+      spawnFn('claude', [
+        'mcp',
+        'add',
+        '-s',
+        'user',
+        '-t',
+        'stdio',
+        '-e',
         `GITHUB_ACCOUNT=${key}`,
-        "--",
+        '--',
         `github-${key}`,
         wrapperPath,
       ]);
@@ -562,15 +562,15 @@ export function removeStaleGithubRegistrations(
   spawnFn: SpawnFn = defaultSpawn,
   warnFn: WarnFn = defaultWarn,
 ): void {
-  const claudeStorePath = path.join(homedir, ".claude.json");
+  const claudeStorePath = path.join(homedir, '.claude.json');
 
   let raw: string;
   try {
-    raw = fs.readFileSync(claudeStorePath, "utf8");
+    raw = fs.readFileSync(claudeStorePath, 'utf8');
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       // No Claude CLI state present — nothing to clean
       return;
@@ -589,16 +589,16 @@ export function removeStaleGithubRegistrations(
   }
 
   if (
-    typeof parsed !== "object" ||
+    typeof parsed !== 'object' ||
     parsed === null ||
-    !("mcpServers" in parsed)
+    !('mcpServers' in parsed)
   ) {
     // No mcpServers key — nothing to clean
     return;
   }
 
-  const mcpServers = (parsed as Record<string, unknown>)["mcpServers"];
-  if (typeof mcpServers !== "object" || mcpServers === null) {
+  const mcpServers = (parsed as Record<string, unknown>)['mcpServers'];
+  if (typeof mcpServers !== 'object' || mcpServers === null) {
     return;
   }
 
@@ -614,7 +614,7 @@ export function removeStaleGithubRegistrations(
 
     // This registration is stale — remove it
     try {
-      spawnFn("claude", ["mcp", "remove", "-s", "user", serverName]);
+      spawnFn('claude', ['mcp', 'remove', '-s', 'user', serverName]);
       console.log(c.green(`Removed stale MCP registration '${serverName}'`));
     } catch {
       // Best-effort — do not abort
@@ -646,15 +646,15 @@ export function updateGithubAllowList(
   homedir: string = os.homedir(),
   warnFn: WarnFn = defaultWarn,
 ): void {
-  const settingsPath = path.join(homedir, ".claude", "settings.json");
+  const settingsPath = path.join(homedir, '.claude', 'settings.json');
 
   let raw: string;
   try {
-    raw = fs.readFileSync(settingsPath, "utf8");
+    raw = fs.readFileSync(settingsPath, 'utf8');
   } catch (err: unknown) {
     if (
       err instanceof Error &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       warnFn(
         `Warning: ~/.claude/settings.json not found -- skipping GitHub allow-list update`,
@@ -674,13 +674,13 @@ export function updateGithubAllowList(
     );
   }
 
-  if (typeof parsed !== "object" || parsed === null) {
+  if (typeof parsed !== 'object' || parsed === null) {
     throw new Error(`settings.json: expected a JSON object in ${settingsPath}`);
   }
 
   const settings = parsed as Record<string, unknown>;
-  const existingTools: string[] = Array.isArray(settings["allowedTools"])
-    ? (settings["allowedTools"] as string[])
+  const existingTools: string[] = Array.isArray(settings['allowedTools'])
+    ? (settings['allowedTools'] as string[])
     : [];
 
   // Compute desired set of GitHub patterns
@@ -713,12 +713,12 @@ export function updateGithubAllowList(
     .toSorted();
   const updatedTools = [...kept, ...toAdd];
 
-  settings["allowedTools"] = updatedTools;
+  settings['allowedTools'] = updatedTools;
 
   // Atomic write via temp + rename
-  const tmpPath = `${settingsPath}.tmp.${process.pid}.${randomBytes(8).toString("hex")}`;
+  const tmpPath = `${settingsPath}.tmp.${process.pid}.${randomBytes(8).toString('hex')}`;
   try {
-    fs.writeFileSync(tmpPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+    fs.writeFileSync(tmpPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
     fs.renameSync(tmpPath, settingsPath);
   } catch (err: unknown) {
     try {
@@ -733,9 +733,9 @@ export function updateGithubAllowList(
 export function installMcpServers(repoRoot: string): void {
   // Check claude CLI availability
   try {
-    execFileSync("claude", ["--version"], { stdio: "pipe" });
+    execFileSync('claude', ['--version'], { stdio: 'pipe' });
   } catch {
-    console.log(c.yellow("Skipping MCP server setup (claude CLI not found)"));
+    console.log(c.yellow('Skipping MCP server setup (claude CLI not found)'));
     return;
   }
 
@@ -749,7 +749,7 @@ export function installMcpServers(repoRoot: string): void {
     servers.filter((s) => s.wrapper !== undefined).map((s) => s.name),
   );
 
-  console.log(c.blue("Configuring MCP servers (user scope)..."));
+  console.log(c.blue('Configuring MCP servers (user scope)...'));
 
   for (const server of servers) {
     if (server.wrapper !== undefined) {
@@ -759,8 +759,8 @@ export function installMcpServers(repoRoot: string): void {
       if (stamps[server.name] === signature) {
         // Stamp matches — check that the registration is actually present.
         try {
-          execFileSync("claude", ["mcp", "get", server.name], {
-            stdio: "pipe",
+          execFileSync('claude', ['mcp', 'get', server.name], {
+            stdio: 'pipe',
           });
           console.log(
             c.green(`MCP server '${server.name}' already configured, skipping`),
@@ -777,8 +777,8 @@ export function installMcpServers(repoRoot: string): void {
       } else {
         // Stamp is absent or stale — remove any existing registration and re-add.
         try {
-          execFileSync("claude", ["mcp", "remove", server.name], {
-            stdio: "pipe",
+          execFileSync('claude', ['mcp', 'remove', server.name], {
+            stdio: 'pipe',
           });
         } catch {
           // Server was not registered — that is fine, proceed to add
@@ -792,7 +792,7 @@ export function installMcpServers(repoRoot: string): void {
         } catch (err: unknown) {
           if (
             err instanceof Error &&
-            (err as NodeJS.ErrnoException).code === "ENOENT"
+            (err as NodeJS.ErrnoException).code === 'ENOENT'
           ) {
             // prereq check is advisory: warn if missing, but always proceed to add
             console.log(
@@ -807,10 +807,10 @@ export function installMcpServers(repoRoot: string): void {
       // Add the server
       try {
         execFileSync(
-          "claude",
-          ["mcp", "add", ...buildAddArgs(server, repoRoot)],
+          'claude',
+          ['mcp', 'add', ...buildAddArgs(server, repoRoot)],
           {
-            stdio: "pipe",
+            stdio: 'pipe',
           },
         );
         updatedStamps[server.name] = signature;
@@ -822,7 +822,7 @@ export function installMcpServers(repoRoot: string): void {
     } else {
       // Command-based servers: skip if already configured
       try {
-        execFileSync("claude", ["mcp", "get", server.name], { stdio: "pipe" });
+        execFileSync('claude', ['mcp', 'get', server.name], { stdio: 'pipe' });
         console.log(
           c.green(`MCP server '${server.name}' already configured, skipping`),
         );
@@ -838,7 +838,7 @@ export function installMcpServers(repoRoot: string): void {
         } catch (err: unknown) {
           if (
             err instanceof Error &&
-            (err as NodeJS.ErrnoException).code === "ENOENT"
+            (err as NodeJS.ErrnoException).code === 'ENOENT'
           ) {
             // prereq check is advisory: warn if missing, but always proceed to add
             console.log(
@@ -853,10 +853,10 @@ export function installMcpServers(repoRoot: string): void {
       // Add the server
       try {
         execFileSync(
-          "claude",
-          ["mcp", "add", ...buildAddArgs(server, repoRoot)],
+          'claude',
+          ['mcp', 'add', ...buildAddArgs(server, repoRoot)],
           {
-            stdio: "pipe",
+            stdio: 'pipe',
           },
         );
         console.log(c.green(`MCP server '${server.name}' added`));

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -1,44 +1,44 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import {
   parseArgs,
   UnknownFlagError,
   TooManyPositionalsError,
-} from "./argv.js";
+} from './argv.js';
 
-describe("parseArgs", () => {
-  it("returns { skip: false, initialMessage: undefined } for an empty argv", () => {
+describe('parseArgs', () => {
+  it('returns { skip: false, initialMessage: undefined } for an empty argv', () => {
     const result = parseArgs([]);
     assert.deepStrictEqual(result, { skip: false, initialMessage: undefined });
   });
 
   it("returns { skip: true, initialMessage: undefined } for ['--skip']", () => {
-    const result = parseArgs(["--skip"]);
+    const result = parseArgs(['--skip']);
     assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
   });
 
   it("returns { skip: true, initialMessage: undefined } for duplicate ['--skip', '--skip'] (idempotent)", () => {
-    const result = parseArgs(["--skip", "--skip"]);
+    const result = parseArgs(['--skip', '--skip']);
     assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
   });
 
-  it("throws UnknownFlagError for an unknown flag, message contains the flag and usage hint", () => {
+  it('throws UnknownFlagError for an unknown flag, message contains the flag and usage hint', () => {
     assert.throws(
-      () => parseArgs(["--unknown"]),
+      () => parseArgs(['--unknown']),
       (err: unknown) => {
         assert.ok(
           err instanceof UnknownFlagError,
-          "should be UnknownFlagError",
+          'should be UnknownFlagError',
         );
         assert.ok(
-          (err as UnknownFlagError).message.includes("--unknown"),
-          "message should contain the offending flag",
+          (err as UnknownFlagError).message.includes('--unknown'),
+          'message should contain the offending flag',
         );
         assert.ok(
           (err as UnknownFlagError).message.includes(
-            "Usage: myclaude [--skip]",
+            'Usage: myclaude [--skip]',
           ),
-          "message should contain the usage hint",
+          'message should contain the usage hint',
         );
         return true;
       },
@@ -46,85 +46,85 @@ describe("parseArgs", () => {
   });
 
   it("captures initial message after --skip: parseArgs(['--skip', '/feature-issue 42']) returns { skip: true, initialMessage: '/feature-issue 42' }", () => {
-    const result = parseArgs(["--skip", "/feature-issue 42"]);
+    const result = parseArgs(['--skip', '/feature-issue 42']);
     assert.deepStrictEqual(result, {
       skip: true,
-      initialMessage: "/feature-issue 42",
+      initialMessage: '/feature-issue 42',
     });
   });
 
   it("captures initial message before --skip: parseArgs(['/cmd', '--skip']) returns { skip: true, initialMessage: '/cmd' }", () => {
-    const result = parseArgs(["/cmd", "--skip"]);
-    assert.deepStrictEqual(result, { skip: true, initialMessage: "/cmd" });
+    const result = parseArgs(['/cmd', '--skip']);
+    assert.deepStrictEqual(result, { skip: true, initialMessage: '/cmd' });
   });
 
   it("captures initial message without --skip: parseArgs(['/cmd']) returns { skip: false, initialMessage: '/cmd' }", () => {
-    const result = parseArgs(["/cmd"]);
-    assert.deepStrictEqual(result, { skip: false, initialMessage: "/cmd" });
+    const result = parseArgs(['/cmd']);
+    assert.deepStrictEqual(result, { skip: false, initialMessage: '/cmd' });
   });
 
-  it("throws TooManyPositionalsError when two positionals are supplied", () => {
+  it('throws TooManyPositionalsError when two positionals are supplied', () => {
     assert.throws(
-      () => parseArgs(["--skip", "a", "b"]),
+      () => parseArgs(['--skip', 'a', 'b']),
       (err: unknown) => {
         assert.ok(
           err instanceof TooManyPositionalsError,
-          "should be TooManyPositionalsError",
+          'should be TooManyPositionalsError',
         );
         assert.ok(
           (err as TooManyPositionalsError).message.includes(
-            "Too many positional arguments",
+            'Too many positional arguments',
           ),
-          "message should mention too many positional arguments",
+          'message should mention too many positional arguments',
         );
         assert.ok(
           (err as TooManyPositionalsError).message.includes(
-            "Usage: myclaude [--skip]",
+            'Usage: myclaude [--skip]',
           ),
-          "message should contain the usage hint",
+          'message should contain the usage hint',
         );
         return true;
       },
     );
   });
 
-  it("still throws UnknownFlagError for an unknown flag in the presence of a positional", () => {
+  it('still throws UnknownFlagError for an unknown flag in the presence of a positional', () => {
     assert.throws(
-      () => parseArgs(["--unknown", "/cmd"]),
+      () => parseArgs(['--unknown', '/cmd']),
       (err: unknown) => {
         assert.ok(
           err instanceof UnknownFlagError,
-          "should be UnknownFlagError (not TooManyPositionalsError)",
+          'should be UnknownFlagError (not TooManyPositionalsError)',
         );
         return true;
       },
     );
   });
 
-  it("throws UnknownFlagError for a single-dash flag after --skip", () => {
+  it('throws UnknownFlagError for a single-dash flag after --skip', () => {
     assert.throws(
-      () => parseArgs(["--skip", "-h"]),
+      () => parseArgs(['--skip', '-h']),
       (err: unknown) => {
         assert.ok(
           err instanceof UnknownFlagError,
-          "should be UnknownFlagError",
+          'should be UnknownFlagError',
         );
         assert.ok(
-          (err as UnknownFlagError).message.includes("-h"),
-          "message should contain the offending flag",
+          (err as UnknownFlagError).message.includes('-h'),
+          'message should contain the offending flag',
         );
         return true;
       },
     );
   });
 
-  it("throws UnknownFlagError for a bare single dash", () => {
+  it('throws UnknownFlagError for a bare single dash', () => {
     assert.throws(
-      () => parseArgs(["-"]),
+      () => parseArgs(['-']),
       (err: unknown) => {
         assert.ok(
           err instanceof UnknownFlagError,
-          "should be UnknownFlagError",
+          'should be UnknownFlagError',
         );
         return true;
       },

--- a/src/launcher/argv.ts
+++ b/src/launcher/argv.ts
@@ -16,16 +16,16 @@ export class UnknownFlagError extends Error {
     super(
       `Unknown flag: ${flag}. Usage: myclaude [--skip] [<initial-message>]`,
     );
-    this.name = "UnknownFlagError";
+    this.name = 'UnknownFlagError';
   }
 }
 
 export class TooManyPositionalsError extends Error {
   constructor() {
     super(
-      "Too many positional arguments. Only one initial message is allowed. Usage: myclaude [--skip] [<initial-message>]",
+      'Too many positional arguments. Only one initial message is allowed. Usage: myclaude [--skip] [<initial-message>]',
     );
-    this.name = "TooManyPositionalsError";
+    this.name = 'TooManyPositionalsError';
   }
 }
 
@@ -46,9 +46,9 @@ export function parseArgs(argv: string[]): {
   let skip = false;
   let initialMessage: string | undefined = undefined;
   for (const token of argv) {
-    if (token === "--skip") {
+    if (token === '--skip') {
       skip = true;
-    } else if (token.startsWith("-")) {
+    } else if (token.startsWith('-')) {
       throw new UnknownFlagError(token);
     } else if (initialMessage !== undefined) {
       throw new TooManyPositionalsError();

--- a/src/launcher/cancel.ts
+++ b/src/launcher/cancel.ts
@@ -1,4 +1,4 @@
-import { isCancel, cancel } from "@clack/prompts";
+import { isCancel, cancel } from '@clack/prompts';
 
 /**
  * Asserts that a prompt value is not a cancellation signal.
@@ -13,7 +13,7 @@ export function handleCancel(
   value: unknown,
 ): asserts value is NonNullable<unknown> {
   if (isCancel(value)) {
-    cancel("Operation cancelled.");
+    cancel('Operation cancelled.');
     process.exit(0);
   }
 }

--- a/src/launcher/claude-args.ts
+++ b/src/launcher/claude-args.ts
@@ -12,7 +12,7 @@
  */
 export function buildClaudeArgs(initialMessage: string | undefined): string[] {
   if (initialMessage === undefined) {
-    return ["--agent", "dungeonmaster"];
+    return ['--agent', 'dungeonmaster'];
   }
-  return ["--agent", "dungeonmaster", initialMessage];
+  return ['--agent', 'dungeonmaster', initialMessage];
 }

--- a/src/launcher/config.test.ts
+++ b/src/launcher/config.test.ts
@@ -1,26 +1,26 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { loadConfig, saveConfig } from "./config.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadConfig, saveConfig } from './config.js';
 
 // ---------------------------------------------------------------------------
 // The real CONFIG_FILE path (hardcoded in config.ts — no path injection).
 // We back up any existing file before the suite and restore it after.
 // ---------------------------------------------------------------------------
 
-const configDir = path.join(os.homedir(), ".config", "myclaude");
+const configDir = path.join(os.homedir(), '.config', 'myclaude');
 // Re-derive using the same logic as config.ts
 const REAL_CONFIG_FILE = path.join(
   os.homedir(),
-  ".config",
-  "myclaude",
-  "config.json",
+  '.config',
+  'myclaude',
+  'config.json',
 );
 
 // Temp dir for scratch space used in tests that need it
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-config-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-config-test-'));
 
 // Snapshot state before any tests run
 let priorContent: string | null = null;
@@ -29,7 +29,7 @@ let priorDirExisted = false;
 before(() => {
   priorDirExisted = fs.existsSync(configDir);
   if (fs.existsSync(REAL_CONFIG_FILE)) {
-    priorContent = fs.readFileSync(REAL_CONFIG_FILE, "utf8");
+    priorContent = fs.readFileSync(REAL_CONFIG_FILE, 'utf8');
   }
 });
 
@@ -37,7 +37,7 @@ after(() => {
   // Restore original state
   if (priorContent !== null) {
     fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(REAL_CONFIG_FILE, priorContent, "utf8");
+    fs.writeFileSync(REAL_CONFIG_FILE, priorContent, 'utf8');
   } else if (!priorDirExisted && fs.existsSync(configDir)) {
     // We created the dir during tests; remove it
     fs.rmSync(configDir, { recursive: true });
@@ -62,27 +62,27 @@ function removeConfigFile(): void {
 // loadConfig
 // ---------------------------------------------------------------------------
 
-describe("loadConfig", () => {
-  it("returns { selectedMcps: [] } when file does not exist", () => {
+describe('loadConfig', () => {
+  it('returns { selectedMcps: [] } when file does not exist', () => {
     removeConfigFile();
     const result = loadConfig();
     assert.deepStrictEqual(result, { selectedMcps: [] });
   });
 
-  it("returns { selectedMcps: [] } when file contains malformed JSON", () => {
+  it('returns { selectedMcps: [] } when file contains malformed JSON', () => {
     fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(REAL_CONFIG_FILE, "not valid json {{", "utf8");
+    fs.writeFileSync(REAL_CONFIG_FILE, 'not valid json {{', 'utf8');
     const result = loadConfig();
     assert.deepStrictEqual(result, { selectedMcps: [] });
   });
 
-  it("correctly parses a valid config file", () => {
+  it('correctly parses a valid config file', () => {
     const config = {
-      selectedMcps: ["grafana", "cloudwatch"],
-      cloudwatch: { profile: "my-profile" },
+      selectedMcps: ['grafana', 'cloudwatch'],
+      cloudwatch: { profile: 'my-profile' },
     };
     fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(REAL_CONFIG_FILE, JSON.stringify(config), "utf8");
+    fs.writeFileSync(REAL_CONFIG_FILE, JSON.stringify(config), 'utf8');
     const result = loadConfig();
     assert.deepStrictEqual(result, config);
   });
@@ -92,8 +92,8 @@ describe("loadConfig", () => {
 // saveConfig
 // ---------------------------------------------------------------------------
 
-describe("saveConfig", () => {
-  it("creates the directory and file when they do not exist", () => {
+describe('saveConfig', () => {
+  it('creates the directory and file when they do not exist', () => {
     // Remove both file and dir so saveConfig must create them from scratch
     if (fs.existsSync(REAL_CONFIG_FILE)) {
       fs.rmSync(REAL_CONFIG_FILE);
@@ -101,39 +101,39 @@ describe("saveConfig", () => {
     if (fs.existsSync(configDir)) {
       fs.rmSync(configDir, { recursive: true });
     }
-    saveConfig({ selectedMcps: ["grafana"] });
+    saveConfig({ selectedMcps: ['grafana'] });
     assert.ok(
       fs.existsSync(REAL_CONFIG_FILE),
-      "config file should exist after saveConfig",
+      'config file should exist after saveConfig',
     );
   });
 
-  it("overwrites an existing config file", () => {
+  it('overwrites an existing config file', () => {
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
       REAL_CONFIG_FILE,
-      JSON.stringify({ selectedMcps: ["old"] }),
-      "utf8",
+      JSON.stringify({ selectedMcps: ['old'] }),
+      'utf8',
     );
-    saveConfig({ selectedMcps: ["new"] });
+    saveConfig({ selectedMcps: ['new'] });
     const written = JSON.parse(
-      fs.readFileSync(REAL_CONFIG_FILE, "utf8"),
+      fs.readFileSync(REAL_CONFIG_FILE, 'utf8'),
     ) as unknown;
-    assert.deepStrictEqual(written, { selectedMcps: ["new"] });
+    assert.deepStrictEqual(written, { selectedMcps: ['new'] });
   });
 
-  it("round-trip: saveConfig then loadConfig returns the same data", () => {
+  it('round-trip: saveConfig then loadConfig returns the same data', () => {
     const config = {
-      selectedMcps: ["grafana", "cloudwatch"],
-      grafana: { clusterId: "prod", role: "viewer" as const },
-      cloudwatch: { profile: "default" },
+      selectedMcps: ['grafana', 'cloudwatch'],
+      grafana: { clusterId: 'prod', role: 'viewer' as const },
+      cloudwatch: { profile: 'default' },
     };
     saveConfig(config);
     const loaded = loadConfig();
     assert.deepStrictEqual(loaded, config);
   });
 
-  it("writes the file with mode 0o600", () => {
+  it('writes the file with mode 0o600', () => {
     saveConfig({ selectedMcps: [] });
     const mode = fs.statSync(REAL_CONFIG_FILE).mode & 0o777;
     assert.strictEqual(

--- a/src/launcher/config.ts
+++ b/src/launcher/config.ts
@@ -1,10 +1,10 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import type { LauncherConfig } from "./types.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { LauncherConfig } from './types.js';
 
-const CONFIG_DIR = path.join(os.homedir(), ".config", "myclaude");
-const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
+const CONFIG_DIR = path.join(os.homedir(), '.config', 'myclaude');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 
 const DEFAULT_CONFIG: LauncherConfig = {
   selectedMcps: [],
@@ -12,7 +12,7 @@ const DEFAULT_CONFIG: LauncherConfig = {
 
 export function loadConfig(): LauncherConfig {
   try {
-    const raw = fs.readFileSync(CONFIG_FILE, "utf8");
+    const raw = fs.readFileSync(CONFIG_FILE, 'utf8');
     const parsed = JSON.parse(raw) as LauncherConfig;
     return parsed;
   } catch {
@@ -25,6 +25,6 @@ export function saveConfig(config: LauncherConfig): void {
   fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
     mode: 0o600,
-    encoding: "utf8",
+    encoding: 'utf8',
   });
 }

--- a/src/launcher/dotfile.ts
+++ b/src/launcher/dotfile.ts
@@ -1,13 +1,13 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 export function writeDotfile(name: string, value: string): void {
-  const dotfilePath = path.join(os.homedir(), ".claude", "." + name);
+  const dotfilePath = path.join(os.homedir(), '.claude', '.' + name);
   const dotfileDir = path.dirname(dotfilePath);
   fs.mkdirSync(dotfileDir, { recursive: true });
-  fs.writeFileSync(dotfilePath, value + "\n", {
+  fs.writeFileSync(dotfilePath, value + '\n', {
     mode: 0o600,
-    encoding: "utf8",
+    encoding: 'utf8',
   });
 }

--- a/src/launcher/env.test.ts
+++ b/src/launcher/env.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { buildEnvVars } from "./env.js";
-import type { ResolvedConfig, GrafanaCluster } from "./types.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { buildEnvVars } from './env.js';
+import type { ResolvedConfig, GrafanaCluster } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Dotfile isolation strategy:
@@ -15,10 +15,10 @@ import type { ResolvedConfig, GrafanaCluster } from "./types.js";
 // suppressing the real write, which means the dotfile path remains exercised.
 // ---------------------------------------------------------------------------
 
-const dotfileDir = path.join(os.homedir(), ".claude");
-const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
-const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
-const kubeDotfilePath = path.join(dotfileDir, ".current-kube-context");
+const dotfileDir = path.join(os.homedir(), '.claude');
+const dotfilePath = path.join(dotfileDir, '.current-aws-profile');
+const gcpDotfilePath = path.join(dotfileDir, '.current-gcp-project');
+const kubeDotfilePath = path.join(dotfileDir, '.current-kube-context');
 
 let priorDotfileContent: string | null = null;
 let priorGcpDotfileContent: string | null = null;
@@ -26,13 +26,13 @@ let priorKubeDotfileContent: string | null = null;
 
 before(() => {
   if (fs.existsSync(dotfilePath)) {
-    priorDotfileContent = fs.readFileSync(dotfilePath, "utf8");
+    priorDotfileContent = fs.readFileSync(dotfilePath, 'utf8');
   }
   if (fs.existsSync(gcpDotfilePath)) {
-    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, "utf8");
+    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, 'utf8');
   }
   if (fs.existsSync(kubeDotfilePath)) {
-    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, "utf8");
+    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, 'utf8');
   }
 });
 
@@ -41,7 +41,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(dotfilePath, priorDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(dotfilePath)) {
     fs.rmSync(dotfilePath);
@@ -51,7 +51,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(gcpDotfilePath, priorGcpDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(gcpDotfilePath)) {
     fs.rmSync(gcpDotfilePath);
@@ -61,7 +61,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(kubeDotfilePath, priorKubeDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(kubeDotfilePath)) {
     fs.rmSync(kubeDotfilePath);
@@ -73,150 +73,150 @@ after(() => {
 // ---------------------------------------------------------------------------
 
 const fakeCluster: GrafanaCluster = {
-  id: "test-cluster",
-  name: "Test Cluster",
-  url: "https://grafana.test.example.com",
-  viewer_token: "viewer-token-abc",
-  editor_token: "editor-token-xyz",
+  id: 'test-cluster',
+  name: 'Test Cluster',
+  url: 'https://grafana.test.example.com',
+  viewer_token: 'viewer-token-abc',
+  editor_token: 'editor-token-xyz',
 };
 
 // ---------------------------------------------------------------------------
 // buildEnvVars
 // ---------------------------------------------------------------------------
 
-describe("buildEnvVars", () => {
-  it("Grafana viewer: sets URL, token from viewer_token, and GRAFANA_DISABLE_WRITE=true", () => {
+describe('buildEnvVars', () => {
+  it('Grafana viewer: sets URL, token from viewer_token, and GRAFANA_DISABLE_WRITE=true', () => {
     const config: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "viewer" },
+      grafana: { cluster: fakeCluster, role: 'viewer' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(env['GRAFANA_URL'], fakeCluster.url);
     assert.strictEqual(
-      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      env['GRAFANA_SERVICE_ACCOUNT_TOKEN'],
       fakeCluster.viewer_token,
     );
-    assert.strictEqual(env["GRAFANA_DISABLE_WRITE"], "true");
+    assert.strictEqual(env['GRAFANA_DISABLE_WRITE'], 'true');
   });
 
-  it("Grafana editor: sets URL and token from editor_token, and GRAFANA_DISABLE_WRITE is absent", () => {
+  it('Grafana editor: sets URL and token from editor_token, and GRAFANA_DISABLE_WRITE is absent', () => {
     const config: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "editor" },
+      grafana: { cluster: fakeCluster, role: 'editor' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(env['GRAFANA_URL'], fakeCluster.url);
     assert.strictEqual(
-      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      env['GRAFANA_SERVICE_ACCOUNT_TOKEN'],
       fakeCluster.editor_token,
     );
     assert.ok(
-      !Object.prototype.hasOwnProperty.call(env, "GRAFANA_DISABLE_WRITE"),
-      "GRAFANA_DISABLE_WRITE must not be present for editor role",
+      !Object.prototype.hasOwnProperty.call(env, 'GRAFANA_DISABLE_WRITE'),
+      'GRAFANA_DISABLE_WRITE must not be present for editor role',
     );
   });
 
-  it("CloudWatch only: returns AWS_PROFILE", () => {
+  it('CloudWatch only: returns AWS_PROFILE', () => {
     const config: ResolvedConfig = {
-      cloudwatch: { profile: "my-dev-profile" },
+      cloudwatch: { profile: 'my-dev-profile' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["AWS_PROFILE"], "my-dev-profile");
+    assert.strictEqual(env['AWS_PROFILE'], 'my-dev-profile');
     assert.ok(
-      !Object.prototype.hasOwnProperty.call(env, "GRAFANA_URL"),
-      "GRAFANA_URL must not be present when no Grafana config",
+      !Object.prototype.hasOwnProperty.call(env, 'GRAFANA_URL'),
+      'GRAFANA_URL must not be present when no Grafana config',
     );
   });
 
-  it("Grafana + CloudWatch combined: all keys merged correctly", () => {
+  it('Grafana + CloudWatch combined: all keys merged correctly', () => {
     const config: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "viewer" },
-      cloudwatch: { profile: "prod" },
+      grafana: { cluster: fakeCluster, role: 'viewer' },
+      cloudwatch: { profile: 'prod' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
+    assert.strictEqual(env['GRAFANA_URL'], fakeCluster.url);
     assert.strictEqual(
-      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"],
+      env['GRAFANA_SERVICE_ACCOUNT_TOKEN'],
       fakeCluster.viewer_token,
     );
-    assert.strictEqual(env["GRAFANA_DISABLE_WRITE"], "true");
-    assert.strictEqual(env["AWS_PROFILE"], "prod");
+    assert.strictEqual(env['GRAFANA_DISABLE_WRITE'], 'true');
+    assert.strictEqual(env['AWS_PROFILE'], 'prod');
   });
 
-  it("empty config ({}): returns empty env var map", () => {
+  it('empty config ({}): returns empty env var map', () => {
     const config: ResolvedConfig = {};
     const env = buildEnvVars(config);
     assert.deepStrictEqual(env, {});
   });
 
-  it("GCP Observability only: returns GOOGLE_CLOUD_PROJECT", () => {
+  it('GCP Observability only: returns GOOGLE_CLOUD_PROJECT', () => {
     const config: ResolvedConfig = {
-      gcpObservability: { project: "my-gcp-project" },
+      gcpObservability: { project: 'my-gcp-project' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+    assert.strictEqual(env['GOOGLE_CLOUD_PROJECT'], 'my-gcp-project');
     assert.ok(
-      !Object.prototype.hasOwnProperty.call(env, "AWS_PROFILE"),
-      "AWS_PROFILE must not be present when no CloudWatch config",
+      !Object.prototype.hasOwnProperty.call(env, 'AWS_PROFILE'),
+      'AWS_PROFILE must not be present when no CloudWatch config',
     );
   });
 
-  it("GCP Observability + CloudWatch combined: both keys present", () => {
+  it('GCP Observability + CloudWatch combined: both keys present', () => {
     const config: ResolvedConfig = {
-      cloudwatch: { profile: "prod" },
-      gcpObservability: { project: "my-gcp-project" },
+      cloudwatch: { profile: 'prod' },
+      gcpObservability: { project: 'my-gcp-project' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["AWS_PROFILE"], "prod");
-    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+    assert.strictEqual(env['AWS_PROFILE'], 'prod');
+    assert.strictEqual(env['GOOGLE_CLOUD_PROJECT'], 'my-gcp-project');
   });
 
-  it("GCP Observability + Grafana combined: all keys merged", () => {
+  it('GCP Observability + Grafana combined: all keys merged', () => {
     const config: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "viewer" },
-      gcpObservability: { project: "my-gcp-project" },
+      grafana: { cluster: fakeCluster, role: 'viewer' },
+      gcpObservability: { project: 'my-gcp-project' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GRAFANA_URL"], fakeCluster.url);
-    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
+    assert.strictEqual(env['GRAFANA_URL'], fakeCluster.url);
+    assert.strictEqual(env['GOOGLE_CLOUD_PROJECT'], 'my-gcp-project');
   });
 
-  it("Kubernetes only: returns K8S_CONTEXT", () => {
+  it('Kubernetes only: returns K8S_CONTEXT', () => {
     const config: ResolvedConfig = {
-      kubernetes: { context: "my-cluster" },
+      kubernetes: { context: 'my-cluster' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["K8S_CONTEXT"], "my-cluster");
+    assert.strictEqual(env['K8S_CONTEXT'], 'my-cluster');
     assert.ok(
-      !Object.prototype.hasOwnProperty.call(env, "AWS_PROFILE"),
-      "AWS_PROFILE must not be present when no CloudWatch config",
+      !Object.prototype.hasOwnProperty.call(env, 'AWS_PROFILE'),
+      'AWS_PROFILE must not be present when no CloudWatch config',
     );
     assert.ok(
-      !Object.prototype.hasOwnProperty.call(env, "GOOGLE_CLOUD_PROJECT"),
-      "GOOGLE_CLOUD_PROJECT must not be present when no GCP config",
+      !Object.prototype.hasOwnProperty.call(env, 'GOOGLE_CLOUD_PROJECT'),
+      'GOOGLE_CLOUD_PROJECT must not be present when no GCP config',
     );
     // Verify the dotfile was written with the correct content
     assert.strictEqual(
-      fs.readFileSync(kubeDotfilePath, "utf8"),
-      "my-cluster\n",
+      fs.readFileSync(kubeDotfilePath, 'utf8'),
+      'my-cluster\n',
     );
   });
 
-  it("Kubernetes + CloudWatch combined: both keys present", () => {
+  it('Kubernetes + CloudWatch combined: both keys present', () => {
     const config: ResolvedConfig = {
-      cloudwatch: { profile: "prod" },
-      kubernetes: { context: "production-cluster" },
+      cloudwatch: { profile: 'prod' },
+      kubernetes: { context: 'production-cluster' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["AWS_PROFILE"], "prod");
-    assert.strictEqual(env["K8S_CONTEXT"], "production-cluster");
+    assert.strictEqual(env['AWS_PROFILE'], 'prod');
+    assert.strictEqual(env['K8S_CONTEXT'], 'production-cluster');
   });
 
-  it("Kubernetes + GCP Observability combined: both keys present", () => {
+  it('Kubernetes + GCP Observability combined: both keys present', () => {
     const config: ResolvedConfig = {
-      gcpObservability: { project: "my-gcp-project" },
-      kubernetes: { context: "staging-cluster" },
+      gcpObservability: { project: 'my-gcp-project' },
+      kubernetes: { context: 'staging-cluster' },
     };
     const env = buildEnvVars(config);
-    assert.strictEqual(env["GOOGLE_CLOUD_PROJECT"], "my-gcp-project");
-    assert.strictEqual(env["K8S_CONTEXT"], "staging-cluster");
+    assert.strictEqual(env['GOOGLE_CLOUD_PROJECT'], 'my-gcp-project');
+    assert.strictEqual(env['K8S_CONTEXT'], 'staging-cluster');
   });
 });

--- a/src/launcher/env.ts
+++ b/src/launcher/env.ts
@@ -1,5 +1,5 @@
-import type { ResolvedConfig } from "./types.js";
-import { registry } from "./mcp-command.js";
+import type { ResolvedConfig } from './types.js';
+import { registry } from './mcp-command.js';
 
 export function buildEnvVars(config: ResolvedConfig): Record<string, string> {
   const envVars: Record<string, string> = {};

--- a/src/launcher/main.test.ts
+++ b/src/launcher/main.test.ts
@@ -1,24 +1,24 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { buildClaudeArgs } from "./claude-args.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildClaudeArgs } from './claude-args.js';
 
-describe("buildClaudeArgs", () => {
+describe('buildClaudeArgs', () => {
   it("returns ['--agent', 'dungeonmaster'] when initialMessage is undefined", () => {
     const result = buildClaudeArgs(undefined);
-    assert.deepStrictEqual(result, ["--agent", "dungeonmaster"]);
+    assert.deepStrictEqual(result, ['--agent', 'dungeonmaster']);
   });
 
-  it("appends the message as a third element and preserves internal spaces as a single argv element", () => {
-    const result = buildClaudeArgs("/feature-issue 42");
+  it('appends the message as a third element and preserves internal spaces as a single argv element', () => {
+    const result = buildClaudeArgs('/feature-issue 42');
     assert.deepStrictEqual(result, [
-      "--agent",
-      "dungeonmaster",
-      "/feature-issue 42",
+      '--agent',
+      'dungeonmaster',
+      '/feature-issue 42',
     ]);
   });
 
   it("returns ['--agent', 'dungeonmaster', ''] for an empty string (present but empty message forwarded verbatim)", () => {
-    const result = buildClaudeArgs("");
-    assert.deepStrictEqual(result, ["--agent", "dungeonmaster", ""]);
+    const result = buildClaudeArgs('');
+    assert.deepStrictEqual(result, ['--agent', 'dungeonmaster', '']);
   });
 });

--- a/src/launcher/main.ts
+++ b/src/launcher/main.ts
@@ -1,20 +1,20 @@
-import { spawnSync } from "node:child_process";
-import { intro, outro } from "@clack/prompts";
-import { loadConfig, saveConfig } from "./config.js";
-import { selectMcps } from "./prompts.js";
-import { buildEnvVars } from "./env.js";
-import { buildOutroLines } from "./outro.js";
-import { promptSummaryAction } from "./summary.js";
-import { buildResolvedFromSaved } from "./resolve.js";
-import { registry } from "./mcp-command.js";
-import { applyKubernetesContextSwitch } from "./mcp/kubernetes.js";
+import { spawnSync } from 'node:child_process';
+import { intro, outro } from '@clack/prompts';
+import { loadConfig, saveConfig } from './config.js';
+import { selectMcps } from './prompts.js';
+import { buildEnvVars } from './env.js';
+import { buildOutroLines } from './outro.js';
+import { promptSummaryAction } from './summary.js';
+import { buildResolvedFromSaved } from './resolve.js';
+import { registry } from './mcp-command.js';
+import { applyKubernetesContextSwitch } from './mcp/kubernetes.js';
 import {
   parseArgs,
   UnknownFlagError,
   TooManyPositionalsError,
-} from "./argv.js";
-import { buildClaudeArgs } from "./claude-args.js";
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
+} from './argv.js';
+import { buildClaudeArgs } from './claude-args.js';
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from './types.js';
 
 function launchClaude(
   resolved: ResolvedConfig,
@@ -33,21 +33,21 @@ function launchClaude(
   const envVars = buildEnvVars(outroResolved);
   const lines = buildOutroLines(outroResolved, effectiveSkipped);
   if (lines.length === 0) {
-    lines.push("No MCPs configured — launching Claude with current env.");
+    lines.push('No MCPs configured — launching Claude with current env.');
   }
 
   // Clear terminal so the Claude session starts on a clean screen.
   // The return value is intentionally ignored: if `clear` is missing from PATH
   // or exits non-zero, the launch must still proceed.
   // stderr is suppressed to silence noise from a potentially misconfigured binary.
-  spawnSync("clear", [], { stdio: ["inherit", "inherit", "ignore"] });
-  outro(`Launching: ${lines.join(" · ")}`);
+  spawnSync('clear', [], { stdio: ['inherit', 'inherit', 'ignore'] });
+  outro(`Launching: ${lines.join(' · ')}`);
 
   // Launch Claude with merged env vars
   const env = { ...process.env, ...envVars };
   const claudeArgs = buildClaudeArgs(initialMessage);
-  const result = spawnSync("claude", claudeArgs, {
-    stdio: "inherit",
+  const result = spawnSync('claude', claudeArgs, {
+    stdio: 'inherit',
     env,
   });
   process.exit(result.status ?? 1);
@@ -59,14 +59,14 @@ function runSkipLaunch(
 ): never {
   if (savedConfig.selectedMcps.length === 0) {
     console.error(
-      "No saved config found — run myclaude without --skip first to configure.",
+      'No saved config found — run myclaude without --skip first to configure.',
     );
     process.exit(1);
   }
   const resolved = buildResolvedFromSaved(savedConfig);
   if (resolved === null) {
     console.error(
-      "Saved config could not be resolved (e.g. Grafana cluster is no longer valid) — re-run myclaude without --skip to reconfigure.",
+      'Saved config could not be resolved (e.g. Grafana cluster is no longer valid) — re-run myclaude without --skip to reconfigure.',
     );
     process.exit(1);
   }
@@ -93,12 +93,12 @@ async function main(): Promise<void> {
 
   if (initialMessage !== undefined && !skip) {
     console.error(
-      "Initial message requires --skip. Usage: myclaude --skip <initial-message>",
+      'Initial message requires --skip. Usage: myclaude --skip <initial-message>',
     );
     process.exit(2);
   }
 
-  intro("myclaude — Session Launcher");
+  intro('myclaude — Session Launcher');
 
   const savedConfig = loadConfig();
 
@@ -112,7 +112,7 @@ async function main(): Promise<void> {
   if (hasExistingConfig) {
     const action = await promptSummaryAction(savedConfig);
 
-    if (action === "launch") {
+    if (action === 'launch') {
       const resolved = buildResolvedFromSaved(savedConfig);
       if (resolved === null) {
         // Fall through to configure flow.
@@ -147,7 +147,7 @@ async function main(): Promise<void> {
     if (!selectedMcps.includes(cmd.id)) continue;
     const result = await cmd.configureInteractive(updatedConfig); // eslint-disable-line no-await-in-loop
     if (result === null) {
-      skipped[cmd.skippedKey] = "loader-failed";
+      skipped[cmd.skippedKey] = 'loader-failed';
       continue;
     }
     Object.assign(resolved, result.resolved);

--- a/src/launcher/mcp-command-types.ts
+++ b/src/launcher/mcp-command-types.ts
@@ -11,7 +11,7 @@
  * file to avoid the cycle.
  */
 
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from './types.js';
 
 /**
  * Thrown by an McpCommand's resolveFromSaved when a saved resource is no
@@ -22,7 +22,7 @@ import type { ResolvedConfig, LauncherConfig, SkippedMap } from "./types.js";
 export class StaleResourceError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "StaleResourceError";
+    this.name = 'StaleResourceError';
   }
 }
 

--- a/src/launcher/mcp-command.test.ts
+++ b/src/launcher/mcp-command.test.ts
@@ -11,31 +11,31 @@
  * orchestration files to use it.
  */
 
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { registry } from "./mcp-command.js";
-import { buildEnvVars } from "./env.js";
-import { buildOutroLines } from "./outro.js";
-import { formatSummaryLines } from "./summary.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { registry } from './mcp-command.js';
+import { buildEnvVars } from './env.js';
+import { buildOutroLines } from './outro.js';
+import { formatSummaryLines } from './summary.js';
 import type {
   ResolvedConfig,
   SkippedMap,
   LauncherConfig,
   GrafanaCluster,
-} from "./types.js";
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Dotfile isolation (mirrors env.test.ts strategy)
 // ---------------------------------------------------------------------------
 
-const dotfileDir = path.join(os.homedir(), ".claude");
-const dotfilePath = path.join(dotfileDir, ".current-aws-profile");
-const gcpDotfilePath = path.join(dotfileDir, ".current-gcp-project");
-const kubeDotfilePath = path.join(dotfileDir, ".current-kube-context");
-const argocdDotfilePath = path.join(dotfileDir, ".current-argocd-cluster");
+const dotfileDir = path.join(os.homedir(), '.claude');
+const dotfilePath = path.join(dotfileDir, '.current-aws-profile');
+const gcpDotfilePath = path.join(dotfileDir, '.current-gcp-project');
+const kubeDotfilePath = path.join(dotfileDir, '.current-kube-context');
+const argocdDotfilePath = path.join(dotfileDir, '.current-argocd-cluster');
 
 let priorDotfileContent: string | null = null;
 let priorGcpDotfileContent: string | null = null;
@@ -44,16 +44,16 @@ let priorArgoCdDotfileContent: string | null = null;
 
 before(() => {
   if (fs.existsSync(dotfilePath)) {
-    priorDotfileContent = fs.readFileSync(dotfilePath, "utf8");
+    priorDotfileContent = fs.readFileSync(dotfilePath, 'utf8');
   }
   if (fs.existsSync(gcpDotfilePath)) {
-    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, "utf8");
+    priorGcpDotfileContent = fs.readFileSync(gcpDotfilePath, 'utf8');
   }
   if (fs.existsSync(kubeDotfilePath)) {
-    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, "utf8");
+    priorKubeDotfileContent = fs.readFileSync(kubeDotfilePath, 'utf8');
   }
   if (fs.existsSync(argocdDotfilePath)) {
-    priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, "utf8");
+    priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, 'utf8');
   }
 });
 
@@ -62,7 +62,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(dotfilePath, priorDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(dotfilePath)) {
     fs.rmSync(dotfilePath);
@@ -72,7 +72,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(gcpDotfilePath, priorGcpDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(gcpDotfilePath)) {
     fs.rmSync(gcpDotfilePath);
@@ -82,7 +82,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(kubeDotfilePath, priorKubeDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(kubeDotfilePath)) {
     fs.rmSync(kubeDotfilePath);
@@ -92,7 +92,7 @@ after(() => {
     fs.mkdirSync(dotfileDir, { recursive: true });
     fs.writeFileSync(argocdDotfilePath, priorArgoCdDotfileContent, {
       mode: 0o600,
-      encoding: "utf8",
+      encoding: 'utf8',
     });
   } else if (fs.existsSync(argocdDotfilePath)) {
     fs.rmSync(argocdDotfilePath);
@@ -104,23 +104,23 @@ after(() => {
 // ---------------------------------------------------------------------------
 
 const fakeCluster: GrafanaCluster = {
-  id: "test-cluster",
-  name: "Test Cluster",
-  url: "https://grafana.test.example.com",
-  viewer_token: "viewer-token-abc",
-  editor_token: "editor-token-xyz",
+  id: 'test-cluster',
+  name: 'Test Cluster',
+  url: 'https://grafana.test.example.com',
+  viewer_token: 'viewer-token-abc',
+  editor_token: 'editor-token-xyz',
 };
 
 const allMcpsResolved: ResolvedConfig = {
-  grafana: { cluster: fakeCluster, role: "viewer" },
-  cloudwatch: { profile: "my-dev-profile" },
-  gcpObservability: { project: "my-gcp-project" },
-  kubernetes: { context: "my-cluster" },
+  grafana: { cluster: fakeCluster, role: 'viewer' },
+  cloudwatch: { profile: 'my-dev-profile' },
+  gcpObservability: { project: 'my-gcp-project' },
+  kubernetes: { context: 'my-cluster' },
   argocd: {
     cluster: {
-      id: "argo-prod",
-      url: "https://argocd.example.com",
-      token: "fake-token",
+      id: 'argo-prod',
+      url: 'https://argocd.example.com',
+      token: 'fake-token',
     },
   },
 };
@@ -169,7 +169,7 @@ function buildOutroLinesViaRegistry(
 // ---------------------------------------------------------------------------
 
 function formatSummaryLinesViaRegistry(config: LauncherConfig): string[] {
-  if (config.selectedMcps.length === 0) return ["No MCPs configured."];
+  if (config.selectedMcps.length === 0) return ['No MCPs configured.'];
   return config.selectedMcps.map((name) => {
     const cmd = registry.find((c) => c.id === name);
     if (cmd === undefined) return `${name}: (unknown MCP)`;
@@ -181,12 +181,12 @@ function formatSummaryLinesViaRegistry(config: LauncherConfig): string[] {
 // registry length assertion (Step 3 acceptance check)
 // ---------------------------------------------------------------------------
 
-describe("registry", () => {
-  it("contains exactly five entries in canonical order", () => {
+describe('registry', () => {
+  it('contains exactly five entries in canonical order', () => {
     assert.strictEqual(registry.length, 5);
     assert.deepStrictEqual(
       registry.map((c) => c.id),
-      ["grafana", "cloudwatch", "gcp-observability", "kubernetes", "argocd"],
+      ['grafana', 'cloudwatch', 'gcp-observability', 'kubernetes', 'argocd'],
     );
   });
 });
@@ -195,50 +195,50 @@ describe("registry", () => {
 // Env var behavioural-equivalence tests
 // ---------------------------------------------------------------------------
 
-describe("registry emitEnvVars: behavioural equivalence with buildEnvVars", () => {
-  it("all MCPs resolved: registry produces same env map as buildEnvVars", () => {
+describe('registry emitEnvVars: behavioural equivalence with buildEnvVars', () => {
+  it('all MCPs resolved: registry produces same env map as buildEnvVars', () => {
     const oracle = buildEnvVars(allMcpsResolved);
     const actual = buildEnvVarsViaRegistry(allMcpsResolved);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("Grafana viewer only: registry produces same env map as buildEnvVars", () => {
+  it('Grafana viewer only: registry produces same env map as buildEnvVars', () => {
     const resolved: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "viewer" },
+      grafana: { cluster: fakeCluster, role: 'viewer' },
     };
     const oracle = buildEnvVars(resolved);
     const actual = buildEnvVarsViaRegistry(resolved);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("Grafana editor only: registry produces same env map as buildEnvVars", () => {
+  it('Grafana editor only: registry produces same env map as buildEnvVars', () => {
     const resolved: ResolvedConfig = {
-      grafana: { cluster: fakeCluster, role: "editor" },
+      grafana: { cluster: fakeCluster, role: 'editor' },
     };
     const oracle = buildEnvVars(resolved);
     const actual = buildEnvVarsViaRegistry(resolved);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("CloudWatch only: registry produces same env map as buildEnvVars", () => {
+  it('CloudWatch only: registry produces same env map as buildEnvVars', () => {
     const resolved: ResolvedConfig = {
-      cloudwatch: { profile: "my-dev-profile" },
+      cloudwatch: { profile: 'my-dev-profile' },
     };
     const oracle = buildEnvVars(resolved);
     const actual = buildEnvVarsViaRegistry(resolved);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("empty config: registry produces same empty env map as buildEnvVars", () => {
+  it('empty config: registry produces same empty env map as buildEnvVars', () => {
     const resolved: ResolvedConfig = {};
     const oracle = buildEnvVars(resolved);
     const actual = buildEnvVarsViaRegistry(resolved);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("all five MCPs resolved: env map includes ARGOCD_BASE_URL from ArgoCD fixture", () => {
+  it('all five MCPs resolved: env map includes ARGOCD_BASE_URL from ArgoCD fixture', () => {
     const env = buildEnvVarsViaRegistry(allMcpsResolved);
-    assert.strictEqual(env["ARGOCD_BASE_URL"], "https://argocd.example.com");
+    assert.strictEqual(env['ARGOCD_BASE_URL'], 'https://argocd.example.com');
   });
 });
 
@@ -247,22 +247,22 @@ describe("registry emitEnvVars: behavioural equivalence with buildEnvVars", () =
 // (mirrors outro.test.ts cases (a), (b), (e), (e2), (g))
 // ---------------------------------------------------------------------------
 
-describe("registry buildOutroLines: behavioural equivalence with buildOutroLines", () => {
-  it("(a) all MCPs configured and none skipped: same lines as buildOutroLines", () => {
+describe('registry buildOutroLines: behavioural equivalence with buildOutroLines', () => {
+  it('(a) all MCPs configured and none skipped: same lines as buildOutroLines', () => {
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
-      cloudwatch: { profile: "my-aws-profile" },
-      gcpObservability: { project: "my-gcp-project" },
-      kubernetes: { context: "prod-us-east" },
+      cloudwatch: { profile: 'my-aws-profile' },
+      gcpObservability: { project: 'my-gcp-project' },
+      kubernetes: { context: 'prod-us-east' },
     };
     const effectiveSkipped: SkippedMap = {};
     const oracle = buildOutroLines(resolved, effectiveSkipped);
@@ -270,45 +270,45 @@ describe("registry buildOutroLines: behavioural equivalence with buildOutroLines
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("(b) all MCPs skipped via loader failure: same lines as buildOutroLines", () => {
+  it('(b) all MCPs skipped via loader failure: same lines as buildOutroLines', () => {
     const resolved: ResolvedConfig = {};
     const effectiveSkipped: SkippedMap = {
-      grafana: "loader-failed",
-      cloudwatch: "loader-failed",
-      gcp: "loader-failed",
-      kubernetes: "loader-failed",
+      grafana: 'loader-failed',
+      cloudwatch: 'loader-failed',
+      gcp: 'loader-failed',
+      kubernetes: 'loader-failed',
     };
     const oracle = buildOutroLines(resolved, effectiveSkipped);
     const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("(e) success lines before skip lines in canonical order: same as buildOutroLines", () => {
+  it('(e) success lines before skip lines in canonical order: same as buildOutroLines', () => {
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
-      gcpObservability: { project: "my-gcp-project" },
-      kubernetes: { context: "prod-us-east" },
+      gcpObservability: { project: 'my-gcp-project' },
+      kubernetes: { context: 'prod-us-east' },
     };
-    const effectiveSkipped: SkippedMap = { cloudwatch: "loader-failed" };
+    const effectiveSkipped: SkippedMap = { cloudwatch: 'loader-failed' };
     const oracle = buildOutroLines(resolved, effectiveSkipped);
     const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("(e2) success-first ordering when skipped MCP ranks before resolved: same as buildOutroLines", () => {
+  it('(e2) success-first ordering when skipped MCP ranks before resolved: same as buildOutroLines', () => {
     const resolved: ResolvedConfig = {
-      cloudwatch: { profile: "my-aws-profile" },
+      cloudwatch: { profile: 'my-aws-profile' },
     };
-    const effectiveSkipped: SkippedMap = { grafana: "loader-failed" };
+    const effectiveSkipped: SkippedMap = { grafana: 'loader-failed' };
     const oracle = buildOutroLines(resolved, effectiveSkipped);
     const actual = buildOutroLinesViaRegistry(resolved, effectiveSkipped);
     assert.deepStrictEqual(actual, oracle);
@@ -318,22 +318,22 @@ describe("registry buildOutroLines: behavioural equivalence with buildOutroLines
     const effectiveSkipped: SkippedMap = {};
     const lines = buildOutroLinesViaRegistry(allMcpsResolved, effectiveSkipped);
     assert.ok(
-      lines.includes("ArgoCD: argo-prod"),
+      lines.includes('ArgoCD: argo-prod'),
       `Expected outro to include "ArgoCD: argo-prod" but got: ${JSON.stringify(lines)}`,
     );
   });
 
-  it("(g) effectiveSkipped=false does not suppress success line: same as buildOutroLines", () => {
+  it('(g) effectiveSkipped=false does not suppress success line: same as buildOutroLines', () => {
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
     };
     const effectiveSkipped: SkippedMap = { grafana: false };
@@ -347,38 +347,38 @@ describe("registry buildOutroLines: behavioural equivalence with buildOutroLines
 // Summary line behavioural-equivalence tests
 // ---------------------------------------------------------------------------
 
-describe("registry buildSummaryLine: behavioural equivalence with formatSummaryLines", () => {
-  it("empty selectedMcps: same result as formatSummaryLines", () => {
+describe('registry buildSummaryLine: behavioural equivalence with formatSummaryLines', () => {
+  it('empty selectedMcps: same result as formatSummaryLines', () => {
     const config: LauncherConfig = { selectedMcps: [] };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("all five MCPs configured: same lines as formatSummaryLines", () => {
+  it('all five MCPs configured: same lines as formatSummaryLines', () => {
     const config: LauncherConfig = {
       selectedMcps: [
-        "grafana",
-        "cloudwatch",
-        "gcp-observability",
-        "kubernetes",
-        "argocd",
+        'grafana',
+        'cloudwatch',
+        'gcp-observability',
+        'kubernetes',
+        'argocd',
       ],
-      grafana: { clusterId: "prod-us", role: "editor" },
-      cloudwatch: { profile: "prod" },
-      gcpObservability: { project: "gcp-prod" },
-      kubernetes: { context: "prod-cluster" },
-      argocd: { clusterId: "argo-prod" },
+      grafana: { clusterId: 'prod-us', role: 'editor' },
+      cloudwatch: { profile: 'prod' },
+      gcpObservability: { project: 'gcp-prod' },
+      kubernetes: { context: 'prod-cluster' },
+      argocd: { clusterId: 'argo-prod' },
     };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);
     assert.deepStrictEqual(actual, oracle);
   });
 
-  it("single MCP cloudwatch: same line as formatSummaryLines", () => {
+  it('single MCP cloudwatch: same line as formatSummaryLines', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch"],
-      cloudwatch: { profile: "prod" },
+      selectedMcps: ['cloudwatch'],
+      cloudwatch: { profile: 'prod' },
     };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);
@@ -386,14 +386,14 @@ describe("registry buildSummaryLine: behavioural equivalence with formatSummaryL
   });
 
   it("unknown MCP in selectedMcps: same '(unknown MCP)' line as formatSummaryLines", () => {
-    const config: LauncherConfig = { selectedMcps: ["future-mcp"] };
+    const config: LauncherConfig = { selectedMcps: ['future-mcp'] };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);
     assert.deepStrictEqual(actual, oracle);
   });
 
   it("MCP in selectedMcps with missing sub-object: same '(not yet configured)' line as formatSummaryLines", () => {
-    const config: LauncherConfig = { selectedMcps: ["grafana"] };
+    const config: LauncherConfig = { selectedMcps: ['grafana'] };
     const oracle = formatSummaryLines(config);
     const actual = formatSummaryLinesViaRegistry(config);
     assert.deepStrictEqual(actual, oracle);

--- a/src/launcher/mcp-command.ts
+++ b/src/launcher/mcp-command.ts
@@ -40,15 +40,15 @@
  */
 
 // Re-export the core types so consumers can import from a single location.
-export type { McpCommand } from "./mcp-command-types.js";
-export { StaleResourceError } from "./mcp-command-types.js";
+export type { McpCommand } from './mcp-command-types.js';
+export { StaleResourceError } from './mcp-command-types.js';
 
-import type { McpCommand } from "./mcp-command-types.js";
-import { grafanaCommand } from "./mcp/grafana.js";
-import { cloudwatchCommand } from "./mcp/cloudwatch.js";
-import { gcpObservabilityCommand } from "./mcp/gcp-observability.js";
-import { kubernetesCommand } from "./mcp/kubernetes.js";
-import { argoCdCommand } from "./mcp/argocd.js";
+import type { McpCommand } from './mcp-command-types.js';
+import { grafanaCommand } from './mcp/grafana.js';
+import { cloudwatchCommand } from './mcp/cloudwatch.js';
+import { gcpObservabilityCommand } from './mcp/gcp-observability.js';
+import { kubernetesCommand } from './mcp/kubernetes.js';
+import { argoCdCommand } from './mcp/argocd.js';
 
 export const registry: McpCommand[] = [
   grafanaCommand,

--- a/src/launcher/mcp/argocd.test.ts
+++ b/src/launcher/mcp/argocd.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import * as prompts from "@clack/prompts";
-import { loadArgoCdAccounts, argoCdCommand } from "./argocd.js";
-import type { ResolvedConfig, LauncherConfig } from "../types.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as prompts from '@clack/prompts';
+import { loadArgoCdAccounts, argoCdCommand } from './argocd.js';
+import type { ResolvedConfig, LauncherConfig } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
 // ---------------------------------------------------------------------------
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-argocd-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-argocd-test-'));
 
 after(() => {
   fs.rmSync(tmpDir, { recursive: true });
@@ -23,7 +23,7 @@ after(() => {
 
 function writeTempFile(name: string, content: string): string {
   const filePath = path.join(tmpDir, name);
-  fs.writeFileSync(filePath, content, "utf8");
+  fs.writeFileSync(filePath, content, 'utf8');
   return filePath;
 }
 
@@ -31,35 +31,35 @@ function writeTempFile(name: string, content: string): string {
 // loadArgoCdAccounts — loader tests
 // ---------------------------------------------------------------------------
 
-describe("loadArgoCdAccounts", () => {
-  it("valid one cluster → returns one ArgoCdCluster with correct id, url, token", () => {
+describe('loadArgoCdAccounts', () => {
+  it('valid one cluster → returns one ArgoCdCluster with correct id, url, token', () => {
     const filePath = writeTempFile(
-      "one-cluster.json",
+      'one-cluster.json',
       JSON.stringify({
-        "prod-east": {
-          url: "https://argocd.prod-east.example.com",
-          token: "tok-abc",
+        'prod-east': {
+          url: 'https://argocd.prod-east.example.com',
+          token: 'tok-abc',
         },
       }),
     );
     fs.chmodSync(filePath, 0o600);
     const clusters = loadArgoCdAccounts(filePath);
     assert.strictEqual(clusters.length, 1);
-    assert.strictEqual(clusters[0]!.id, "prod-east");
+    assert.strictEqual(clusters[0]!.id, 'prod-east');
     assert.strictEqual(
       clusters[0]!.url,
-      "https://argocd.prod-east.example.com",
+      'https://argocd.prod-east.example.com',
     );
-    assert.strictEqual(clusters[0]!.token, "tok-abc");
+    assert.strictEqual(clusters[0]!.token, 'tok-abc');
   });
 
-  it("valid three clusters → returns three entries sorted alphabetically by id", () => {
+  it('valid three clusters → returns three entries sorted alphabetically by id', () => {
     const filePath = writeTempFile(
-      "three-clusters.json",
+      'three-clusters.json',
       JSON.stringify({
-        charlie: { url: "https://argocd.charlie.example.com", token: "tok-c" },
-        alpha: { url: "https://argocd.alpha.example.com", token: "tok-a" },
-        bravo: { url: "https://argocd.bravo.example.com", token: "tok-b" },
+        charlie: { url: 'https://argocd.charlie.example.com', token: 'tok-c' },
+        alpha: { url: 'https://argocd.alpha.example.com', token: 'tok-a' },
+        bravo: { url: 'https://argocd.bravo.example.com', token: 'tok-b' },
       }),
     );
     fs.chmodSync(filePath, 0o600);
@@ -67,116 +67,116 @@ describe("loadArgoCdAccounts", () => {
     assert.strictEqual(clusters.length, 3);
     assert.deepStrictEqual(
       clusters.map((c) => c.id),
-      ["alpha", "bravo", "charlie"],
+      ['alpha', 'bravo', 'charlie'],
     );
   });
 
   it("missing file → throws with message containing 'ArgoCD accounts file not found'", () => {
-    const missingPath = path.join(tmpDir, "does-not-exist.json");
+    const missingPath = path.join(tmpDir, 'does-not-exist.json');
     assert.throws(
       () => loadArgoCdAccounts(missingPath),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("ArgoCD accounts file not found"),
+        err.message.includes('ArgoCD accounts file not found'),
     );
   });
 
   it("invalid JSON → throws with message containing 'is not valid JSON'", () => {
-    const filePath = writeTempFile("invalid.json", "{ not valid json }");
+    const filePath = writeTempFile('invalid.json', '{ not valid json }');
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("is not valid JSON"),
+        err instanceof Error && err.message.includes('is not valid JSON'),
     );
   });
 
   it("null value (null JSON) → throws with message containing 'must be a flat JSON object'", () => {
-    const filePath = writeTempFile("null-value.json", "null");
+    const filePath = writeTempFile('null-value.json', 'null');
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("must be a flat JSON object"),
+        err.message.includes('must be a flat JSON object'),
     );
   });
 
   it("array value ([] JSON) → throws with message containing 'must be a flat JSON object'", () => {
-    const filePath = writeTempFile("array-value.json", "[]");
+    const filePath = writeTempFile('array-value.json', '[]');
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("must be a flat JSON object"),
+        err.message.includes('must be a flat JSON object'),
     );
   });
 
   it("empty object ({} JSON) → throws with message containing 'contains no clusters'", () => {
-    const filePath = writeTempFile("empty-object.json", "{}");
+    const filePath = writeTempFile('empty-object.json', '{}');
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("contains no clusters"),
+        err instanceof Error && err.message.includes('contains no clusters'),
     );
   });
 
   it("cluster id with space → throws with message containing 'contains characters outside'", () => {
     const filePath = writeTempFile(
-      "bad-id.json",
+      'bad-id.json',
       JSON.stringify({
-        "invalid id": { url: "https://example.com", token: "tok" },
+        'invalid id': { url: 'https://example.com', token: 'tok' },
       }),
     );
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("contains characters outside"),
+        err.message.includes('contains characters outside'),
     );
   });
 
   it("missing token field → throws with message containing 'must have string fields'", () => {
     const filePath = writeTempFile(
-      "missing-token.json",
-      JSON.stringify({ prod: { url: "https://argocd.example.com" } }),
+      'missing-token.json',
+      JSON.stringify({ prod: { url: 'https://argocd.example.com' } }),
     );
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("must have string fields"),
+        err instanceof Error && err.message.includes('must have string fields'),
     );
   });
 
   it("invalid URL (ftp://example) → throws with message containing 'missing or invalid url'", () => {
     const filePath = writeTempFile(
-      "ftp-url.json",
-      JSON.stringify({ prod: { url: "ftp://example.com", token: "tok" } }),
+      'ftp-url.json',
+      JSON.stringify({ prod: { url: 'ftp://example.com', token: 'tok' } }),
     );
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("missing or invalid url"),
+        err instanceof Error && err.message.includes('missing or invalid url'),
     );
   });
 
   it("empty token ('') → throws with message containing 'empty token'", () => {
     const filePath = writeTempFile(
-      "empty-token.json",
+      'empty-token.json',
       JSON.stringify({
-        prod: { url: "https://argocd.example.com", token: "" },
+        prod: { url: 'https://argocd.example.com', token: '' },
       }),
     );
     assert.throws(
       () => loadArgoCdAccounts(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("empty token"),
+        err instanceof Error && err.message.includes('empty token'),
     );
   });
 
   it("file-mode warning: 0o644 file triggers log.warn with 'is readable by other users'", () => {
     const filePath = writeTempFile(
-      "world-readable.json",
+      'world-readable.json',
       JSON.stringify({
-        prod: { url: "https://argocd.example.com", token: "tok" },
+        prod: { url: 'https://argocd.example.com', token: 'tok' },
       }),
     );
     fs.chmodSync(filePath, 0o644);
@@ -205,7 +205,7 @@ describe("loadArgoCdAccounts", () => {
       warnCalls.some((args) =>
         args.some(
           (a) =>
-            typeof a === "string" && a.includes("is readable by other users"),
+            typeof a === 'string' && a.includes('is readable by other users'),
         ),
       ),
       "log.warn should have been called with a message containing 'is readable by other users'",
@@ -217,17 +217,17 @@ describe("loadArgoCdAccounts", () => {
 // argoCdCommand — McpCommand contract tests
 // ---------------------------------------------------------------------------
 
-describe("argoCdCommand contract", () => {
+describe('argoCdCommand contract', () => {
   // ---------------------------------------------------------------------------
   // before/after for dotfile isolation (emitEnvVars writes .current-argocd-cluster)
   // ---------------------------------------------------------------------------
-  const dotfileDir = path.join(os.homedir(), ".claude");
-  const argocdDotfilePath = path.join(dotfileDir, ".current-argocd-cluster");
+  const dotfileDir = path.join(os.homedir(), '.claude');
+  const argocdDotfilePath = path.join(dotfileDir, '.current-argocd-cluster');
   let priorArgoCdDotfileContent: string | null = null;
 
   before(() => {
     if (fs.existsSync(argocdDotfilePath)) {
-      priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, "utf8");
+      priorArgoCdDotfileContent = fs.readFileSync(argocdDotfilePath, 'utf8');
     }
   });
 
@@ -236,7 +236,7 @@ describe("argoCdCommand contract", () => {
       fs.mkdirSync(dotfileDir, { recursive: true });
       fs.writeFileSync(argocdDotfilePath, priorArgoCdDotfileContent, {
         mode: 0o600,
-        encoding: "utf8",
+        encoding: 'utf8',
       });
     } else if (fs.existsSync(argocdDotfilePath)) {
       fs.rmSync(argocdDotfilePath);
@@ -244,60 +244,60 @@ describe("argoCdCommand contract", () => {
   });
 
   it("id, skippedKey, multiselectOption.value are all 'argocd'", () => {
-    assert.strictEqual(argoCdCommand.id, "argocd");
-    assert.strictEqual(argoCdCommand.skippedKey, "argocd");
-    assert.strictEqual(argoCdCommand.multiselectOption.value, "argocd");
+    assert.strictEqual(argoCdCommand.id, 'argocd');
+    assert.strictEqual(argoCdCommand.skippedKey, 'argocd');
+    assert.strictEqual(argoCdCommand.multiselectOption.value, 'argocd');
   });
 
-  it("buildOutroSuccessLine with undefined argocd → null", () => {
+  it('buildOutroSuccessLine with undefined argocd → null', () => {
     const resolved: ResolvedConfig = {};
     assert.strictEqual(argoCdCommand.buildOutroSuccessLine(resolved), null);
   });
 
   it("buildOutroSuccessLine with argocd cluster → 'ArgoCD: prod-east'", () => {
     const resolved: ResolvedConfig = {
-      argocd: { cluster: { id: "prod-east", url: "https://x", token: "t" } },
+      argocd: { cluster: { id: 'prod-east', url: 'https://x', token: 't' } },
     };
     assert.strictEqual(
       argoCdCommand.buildOutroSuccessLine(resolved),
-      "ArgoCD: prod-east",
+      'ArgoCD: prod-east',
     );
   });
 
   it("buildOutroSkipLine(false) → null; buildOutroSkipLine('loader-failed') → skip message", () => {
     assert.strictEqual(argoCdCommand.buildOutroSkipLine(false), null);
     assert.strictEqual(
-      argoCdCommand.buildOutroSkipLine("loader-failed"),
-      "ArgoCD: skipped (accounts unavailable)",
+      argoCdCommand.buildOutroSkipLine('loader-failed'),
+      'ArgoCD: skipped (accounts unavailable)',
     );
   });
 
   it("buildSummaryLine with argocd undefined → '(not yet configured)'", () => {
-    const config: LauncherConfig = { selectedMcps: ["argocd"] };
+    const config: LauncherConfig = { selectedMcps: ['argocd'] };
     assert.strictEqual(
       argoCdCommand.buildSummaryLine(config),
-      "ArgoCD: (not yet configured)",
+      'ArgoCD: (not yet configured)',
     );
   });
 
   it("buildSummaryLine with clusterId → 'ArgoCD: cluster prod-east'", () => {
     const config: LauncherConfig = {
-      selectedMcps: ["argocd"],
-      argocd: { clusterId: "prod-east" },
+      selectedMcps: ['argocd'],
+      argocd: { clusterId: 'prod-east' },
     };
     assert.strictEqual(
       argoCdCommand.buildSummaryLine(config),
-      "ArgoCD: cluster prod-east",
+      'ArgoCD: cluster prod-east',
     );
   });
 
-  it("emitEnvVars with argocd cluster → sets ARGOCD_BASE_URL and ARGOCD_API_TOKEN", () => {
+  it('emitEnvVars with argocd cluster → sets ARGOCD_BASE_URL and ARGOCD_API_TOKEN', () => {
     const resolved: ResolvedConfig = {
       argocd: {
         cluster: {
-          id: "prod-east",
-          url: "https://argocd.prod.example.com",
-          token: "secret-token",
+          id: 'prod-east',
+          url: 'https://argocd.prod.example.com',
+          token: 'secret-token',
         },
       },
     };
@@ -305,13 +305,13 @@ describe("argoCdCommand contract", () => {
     // emitEnvVars also calls writeDotfile — that's fine for this test
     argoCdCommand.emitEnvVars(resolved, env);
     assert.strictEqual(
-      env["ARGOCD_BASE_URL"],
-      "https://argocd.prod.example.com",
+      env['ARGOCD_BASE_URL'],
+      'https://argocd.prod.example.com',
     );
-    assert.strictEqual(env["ARGOCD_API_TOKEN"], "secret-token");
+    assert.strictEqual(env['ARGOCD_API_TOKEN'], 'secret-token');
   });
 
-  it("emitEnvVars with resolved.argocd undefined → env stays empty", () => {
+  it('emitEnvVars with resolved.argocd undefined → env stays empty', () => {
     const resolved: ResolvedConfig = {};
     const env: Record<string, string> = {};
     argoCdCommand.emitEnvVars(resolved, env);

--- a/src/launcher/mcp/argocd.ts
+++ b/src/launcher/mcp/argocd.ts
@@ -1,24 +1,24 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { log, select } from "@clack/prompts";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { log, select } from '@clack/prompts';
 import type {
   ArgoCdCluster,
   ArgoCdConfig,
   ResolvedConfig,
   LauncherConfig,
   SkippedMap,
-} from "../types.js";
-import { handleCancel } from "../cancel.js";
-import type { McpCommand } from "../mcp-command-types.js";
-import { StaleResourceError } from "../mcp-command-types.js";
-import { tryLoad } from "../utils.js";
-import { writeDotfile } from "../dotfile.js";
+} from '../types.js';
+import { handleCancel } from '../cancel.js';
+import type { McpCommand } from '../mcp-command-types.js';
+import { StaleResourceError } from '../mcp-command-types.js';
+import { tryLoad } from '../utils.js';
+import { writeDotfile } from '../dotfile.js';
 
 export const DEFAULT_CONFIG_PATH = path.join(
   os.homedir(),
-  ".config",
-  "argocd-accounts.json",
+  '.config',
+  'argocd-accounts.json',
 );
 
 /**
@@ -45,7 +45,7 @@ export function loadArgoCdAccounts(configPath?: string): ArgoCdCluster[] {
 
   let parsed: unknown;
   try {
-    const raw = fs.readFileSync(resolvedPath, "utf8");
+    const raw = fs.readFileSync(resolvedPath, 'utf8');
     parsed = JSON.parse(raw);
   } catch {
     throw new Error(
@@ -53,7 +53,7 @@ export function loadArgoCdAccounts(configPath?: string): ArgoCdCluster[] {
     );
   }
 
-  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
     throw new Error(
       `ArgoCD accounts file at ${resolvedPath} must be a flat JSON object mapping cluster names to {url, token} objects.`,
     );
@@ -76,17 +76,17 @@ export function loadArgoCdAccounts(configPath?: string): ArgoCdCluster[] {
     }
 
     const value = record[id];
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
       throw new Error(
         `ArgoCD cluster "${id}" must have string fields "url" and "token".`,
       );
     }
 
     const entry = value as Record<string, unknown>;
-    const url = entry["url"];
-    const token = entry["token"];
+    const url = entry['url'];
+    const token = entry['token'];
 
-    if (typeof url !== "string" || typeof token !== "string") {
+    if (typeof url !== 'string' || typeof token !== 'string') {
       throw new Error(
         `ArgoCD cluster "${id}" must have string fields "url" and "token".`,
       );
@@ -98,7 +98,7 @@ export function loadArgoCdAccounts(configPath?: string): ArgoCdCluster[] {
       );
     }
 
-    if (token === "") {
+    if (token === '') {
       throw new Error(`ArgoCD cluster "${id}" has an empty token.`);
     }
 
@@ -120,7 +120,7 @@ export async function configureArgoCd(
       : clusters[0]?.id;
 
   const selected = await select({
-    message: "Select ArgoCD cluster:",
+    message: 'Select ArgoCD cluster:',
     options: clusters.map((c) => ({ value: c.id, label: c.id, hint: c.url })),
     initialValue,
   });
@@ -135,19 +135,19 @@ export async function configureArgoCd(
 }
 
 export const argoCdCommand: McpCommand = {
-  id: "argocd",
-  skippedKey: "argocd" as keyof SkippedMap,
+  id: 'argocd',
+  skippedKey: 'argocd' as keyof SkippedMap,
   multiselectOption: {
-    value: "argocd",
-    label: "ArgoCD",
-    hint: "cluster",
+    value: 'argocd',
+    label: 'ArgoCD',
+    hint: 'cluster',
   },
 
   async configureInteractive(savedConfig: LauncherConfig): Promise<{
     resolved: Partial<ResolvedConfig>;
     persistable: Partial<LauncherConfig>;
   } | null> {
-    const clusters = tryLoad(() => loadArgoCdAccounts(), "argocd");
+    const clusters = tryLoad(() => loadArgoCdAccounts(), 'argocd');
     if (clusters === null) return null;
     const result = await configureArgoCd(
       clusters,
@@ -174,7 +174,7 @@ export const argoCdCommand: McpCommand = {
       log.warn(
         `Could not load ArgoCD accounts: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
       );
-      throw new StaleResourceError("ArgoCD accounts file unavailable");
+      throw new StaleResourceError('ArgoCD accounts file unavailable');
     }
     const cluster = clusters.find((c) => c.id === config.argocd!.clusterId);
     if (cluster === undefined) {
@@ -190,9 +190,9 @@ export const argoCdCommand: McpCommand = {
 
   emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
     if (!resolved.argocd) return;
-    env["ARGOCD_BASE_URL"] = resolved.argocd.cluster.url;
-    env["ARGOCD_API_TOKEN"] = resolved.argocd.cluster.token;
-    writeDotfile("current-argocd-cluster", resolved.argocd.cluster.id);
+    env['ARGOCD_BASE_URL'] = resolved.argocd.cluster.url;
+    env['ARGOCD_API_TOKEN'] = resolved.argocd.cluster.token;
+    writeDotfile('current-argocd-cluster', resolved.argocd.cluster.id);
   },
 
   buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
@@ -201,14 +201,14 @@ export const argoCdCommand: McpCommand = {
   },
 
   buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
-    if (skipped === "loader-failed")
-      return "ArgoCD: skipped (accounts unavailable)";
+    if (skipped === 'loader-failed')
+      return 'ArgoCD: skipped (accounts unavailable)';
     return null;
   },
 
   buildSummaryLine(config: LauncherConfig): string {
     if (config.argocd === undefined) {
-      return "ArgoCD: (not yet configured)";
+      return 'ArgoCD: (not yet configured)';
     }
     return `ArgoCD: cluster ${config.argocd.clusterId}`;
   },

--- a/src/launcher/mcp/cloudwatch.test.ts
+++ b/src/launcher/mcp/cloudwatch.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { loadAwsProfiles, parseProfileSections } from "./cloudwatch.js";
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadAwsProfiles, parseProfileSections } from './cloudwatch.js';
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
 // ---------------------------------------------------------------------------
 
 const tmpDir = fs.mkdtempSync(
-  path.join(os.tmpdir(), "ai-tpk-cloudwatch-test-"),
+  path.join(os.tmpdir(), 'ai-tpk-cloudwatch-test-'),
 );
 
 after(() => {
@@ -23,7 +23,7 @@ after(() => {
 
 function writeTempFile(name: string, content: string): string {
   const filePath = path.join(tmpDir, name);
-  fs.writeFileSync(filePath, content, "utf8");
+  fs.writeFileSync(filePath, content, 'utf8');
   return filePath;
 }
 
@@ -31,32 +31,32 @@ function writeTempFile(name: string, content: string): string {
 // parseProfileSections — config format
 // ---------------------------------------------------------------------------
 
-describe("parseProfileSections (config format)", () => {
+describe('parseProfileSections (config format)', () => {
   it('parses [default] as "default"', () => {
     const profiles = parseProfileSections(
-      "[default]\nregion = us-east-1\n",
-      "config",
+      '[default]\nregion = us-east-1\n',
+      'config',
     );
-    assert.deepStrictEqual(profiles, ["default"]);
+    assert.deepStrictEqual(profiles, ['default']);
   });
 
   it('parses [profile foo-bar] as "foo-bar"', () => {
     const profiles = parseProfileSections(
-      "[profile foo-bar]\nregion = eu-west-1\n",
-      "config",
+      '[profile foo-bar]\nregion = eu-west-1\n',
+      'config',
     );
-    assert.deepStrictEqual(profiles, ["foo-bar"]);
+    assert.deepStrictEqual(profiles, ['foo-bar']);
   });
 
-  it("rejects bare [dev] (no profile prefix) in config format", () => {
+  it('rejects bare [dev] (no profile prefix) in config format', () => {
     const profiles = parseProfileSections(
-      "[dev]\nregion = us-east-1\n",
-      "config",
+      '[dev]\nregion = us-east-1\n',
+      'config',
     );
     assert.deepStrictEqual(profiles, []);
   });
 
-  it("ignores non-profile sections like [sso-session my-session]", () => {
+  it('ignores non-profile sections like [sso-session my-session]', () => {
     const content = `
 [default]
 region = us-east-1
@@ -64,19 +64,19 @@ region = us-east-1
 [sso-session my-session]
 sso_start_url = https://example.awsapps.com/start
 `;
-    const profiles = parseProfileSections(content, "config");
-    assert.deepStrictEqual(profiles, ["default"]);
+    const profiles = parseProfileSections(content, 'config');
+    assert.deepStrictEqual(profiles, ['default']);
   });
 
-  it("trims whitespace from profile names", () => {
+  it('trims whitespace from profile names', () => {
     const profiles = parseProfileSections(
-      "[profile  padded ]\nregion = us-east-1\n",
-      "config",
+      '[profile  padded ]\nregion = us-east-1\n',
+      'config',
     );
-    assert.deepStrictEqual(profiles, ["padded"]);
+    assert.deepStrictEqual(profiles, ['padded']);
   });
 
-  it("handles multiple profiles", () => {
+  it('handles multiple profiles', () => {
     const content = `
 [default]
 region = us-east-1
@@ -87,8 +87,8 @@ region = us-west-2
 [profile prod]
 region = eu-central-1
 `;
-    const profiles = parseProfileSections(content, "config");
-    assert.deepStrictEqual(profiles, ["default", "dev", "prod"]);
+    const profiles = parseProfileSections(content, 'config');
+    assert.deepStrictEqual(profiles, ['default', 'dev', 'prod']);
   });
 });
 
@@ -96,8 +96,8 @@ region = eu-central-1
 // parseProfileSections — credentials format
 // ---------------------------------------------------------------------------
 
-describe("parseProfileSections (credentials format)", () => {
-  it("parses [default] and named sections without profile prefix", () => {
+describe('parseProfileSections (credentials format)', () => {
+  it('parses [default] and named sections without profile prefix', () => {
     const content = `
 [default]
 aws_access_key_id = AKIA...
@@ -107,11 +107,11 @@ aws_secret_access_key = ...
 aws_access_key_id = AKIA...
 aws_secret_access_key = ...
 `;
-    const profiles = parseProfileSections(content, "credentials");
-    assert.deepStrictEqual(profiles, ["default", "myprofile"]);
+    const profiles = parseProfileSections(content, 'credentials');
+    assert.deepStrictEqual(profiles, ['default', 'myprofile']);
   });
 
-  it("parses multiple named profiles", () => {
+  it('parses multiple named profiles', () => {
     const content = `
 [default]
 aws_access_key_id = AKIA...
@@ -122,27 +122,27 @@ aws_access_key_id = AKIA...
 [prod]
 aws_access_key_id = AKIA...
 `;
-    const profiles = parseProfileSections(content, "credentials");
-    assert.deepStrictEqual(profiles, ["default", "dev", "prod"]);
+    const profiles = parseProfileSections(content, 'credentials');
+    assert.deepStrictEqual(profiles, ['default', 'dev', 'prod']);
   });
 
-  it("includes all section headers as profile names", () => {
+  it('includes all section headers as profile names', () => {
     const profiles = parseProfileSections(
-      "[default]\n[foo-bar]\n[baz_qux]\n",
-      "credentials",
+      '[default]\n[foo-bar]\n[baz_qux]\n',
+      'credentials',
     );
-    assert.deepStrictEqual(profiles, ["baz_qux", "default", "foo-bar"]);
+    assert.deepStrictEqual(profiles, ['baz_qux', 'default', 'foo-bar']);
   });
 
-  it("returns empty array for content with no section headers", () => {
+  it('returns empty array for content with no section headers', () => {
     const profiles = parseProfileSections(
-      "# no sections here\nkey = value\n",
-      "credentials",
+      '# no sections here\nkey = value\n',
+      'credentials',
     );
     assert.deepStrictEqual(profiles, []);
   });
 
-  it("deduplicates entries that differ only by . vs _ — keeps first occurrence", () => {
+  it('deduplicates entries that differ only by . vs _ — keeps first occurrence', () => {
     const content = `
 [default]
 aws_access_key_id = AKIA...
@@ -156,11 +156,11 @@ aws_access_key_id = AKIA...
 [baz]
 aws_access_key_id = AKIA...
 `;
-    const profiles = parseProfileSections(content, "credentials");
-    assert.deepStrictEqual(profiles, ["baz", "default", "foo.bar"]);
+    const profiles = parseProfileSections(content, 'credentials');
+    assert.deepStrictEqual(profiles, ['baz', 'default', 'foo.bar']);
   });
 
-  it("deduplicates entries that differ only by . vs _ — underscore-first ordering", () => {
+  it('deduplicates entries that differ only by . vs _ — underscore-first ordering', () => {
     const content = `
 [default]
 aws_access_key_id = AKIA...
@@ -174,16 +174,16 @@ aws_access_key_id = AKIA...
 [baz]
 aws_access_key_id = AKIA...
 `;
-    const profiles = parseProfileSections(content, "credentials");
+    const profiles = parseProfileSections(content, 'credentials');
     assert.ok(
-      profiles.includes("foo_bar"),
-      "foo_bar should be kept (first occurrence)",
+      profiles.includes('foo_bar'),
+      'foo_bar should be kept (first occurrence)',
     );
     assert.ok(
-      !profiles.includes("foo.bar"),
-      "foo.bar should be removed (duplicate)",
+      !profiles.includes('foo.bar'),
+      'foo.bar should be removed (duplicate)',
     );
-    assert.deepStrictEqual(profiles, ["baz", "default", "foo_bar"]);
+    assert.deepStrictEqual(profiles, ['baz', 'default', 'foo_bar']);
   });
 });
 
@@ -191,34 +191,34 @@ aws_access_key_id = AKIA...
 // loadAwsProfiles — config file path (existing behaviour)
 // ---------------------------------------------------------------------------
 
-describe("loadAwsProfiles", () => {
+describe('loadAwsProfiles', () => {
   it('parses [default] as "default"', () => {
     const filePath = writeTempFile(
-      "default-only.ini",
+      'default-only.ini',
       `
 [default]
 region = us-east-1
 `,
     );
     const profiles = loadAwsProfiles(filePath);
-    assert.deepStrictEqual(profiles, ["default"]);
+    assert.deepStrictEqual(profiles, ['default']);
   });
 
   it('parses [profile foo-bar] as "foo-bar"', () => {
     const filePath = writeTempFile(
-      "named-profile.ini",
+      'named-profile.ini',
       `
 [profile foo-bar]
 region = eu-west-1
 `,
     );
     const profiles = loadAwsProfiles(filePath);
-    assert.deepStrictEqual(profiles, ["foo-bar"]);
+    assert.deepStrictEqual(profiles, ['foo-bar']);
   });
 
-  it("handles a file with multiple profiles (default + named)", () => {
+  it('handles a file with multiple profiles (default + named)', () => {
     const filePath = writeTempFile(
-      "multi-profile.ini",
+      'multi-profile.ini',
       `
 [default]
 region = us-east-1
@@ -231,12 +231,12 @@ region = eu-central-1
 `,
     );
     const profiles = loadAwsProfiles(filePath);
-    assert.deepStrictEqual(profiles, ["default", "dev", "prod"]);
+    assert.deepStrictEqual(profiles, ['default', 'dev', 'prod']);
   });
 
-  it("ignores non-profile sections (e.g. [sso-session my-session])", () => {
+  it('ignores non-profile sections (e.g. [sso-session my-session])', () => {
     const filePath = writeTempFile(
-      "with-sso.ini",
+      'with-sso.ini',
       `
 [default]
 region = us-east-1
@@ -246,33 +246,33 @@ sso_start_url = https://example.awsapps.com/start
 `,
     );
     const profiles = loadAwsProfiles(filePath);
-    assert.deepStrictEqual(profiles, ["default"]);
+    assert.deepStrictEqual(profiles, ['default']);
   });
 
-  it("trims whitespace from profile names", () => {
+  it('trims whitespace from profile names', () => {
     const filePath = writeTempFile(
-      "padded.ini",
+      'padded.ini',
       `
 [profile  padded ]
 region = us-east-1
 `,
     );
     const profiles = loadAwsProfiles(filePath);
-    assert.deepStrictEqual(profiles, ["padded"]);
+    assert.deepStrictEqual(profiles, ['padded']);
   });
 
-  it("throws when the config file does not exist", () => {
-    const missingPath = path.join(tmpDir, "does-not-exist.ini");
+  it('throws when the config file does not exist', () => {
+    const missingPath = path.join(tmpDir, 'does-not-exist.ini');
     assert.throws(
       () => loadAwsProfiles(missingPath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("AWS config not found"),
+        err instanceof Error && err.message.includes('AWS config not found'),
     );
   });
 
-  it("throws when no profiles are found in the file", () => {
+  it('throws when no profiles are found in the file', () => {
     const filePath = writeTempFile(
-      "no-profiles.ini",
+      'no-profiles.ini',
       `
 # This file has no profile sections
 region = us-east-1
@@ -282,7 +282,7 @@ output = json
     assert.throws(
       () => loadAwsProfiles(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("No AWS profiles found"),
+        err instanceof Error && err.message.includes('No AWS profiles found'),
     );
   });
 });
@@ -294,111 +294,111 @@ output = json
 // are hermetic — no dependency on the real ~/.aws/* files.
 // ---------------------------------------------------------------------------
 
-describe("loadAwsProfiles (credentials fallback)", () => {
+describe('loadAwsProfiles (credentials fallback)', () => {
   // Helper: create a fresh subdirectory for hermetic path isolation
   function makeSubDir(label: string): string {
-    return fs.mkdtempSync(path.join(tmpDir, label + "-"));
+    return fs.mkdtempSync(path.join(tmpDir, label + '-'));
   }
 
-  it("no config, credentials with [default] and [myprofile] → returns both profiles", () => {
+  it('no config, credentials with [default] and [myprofile] → returns both profiles', () => {
     // This is the primary F-1 integration test. We need configPath to be absent
     // without triggering the explicit-path guard (which requires configPath===undefined).
     // We achieve hermeticity by using a credentials override (credentialsPath) combined
     // with calling loadAwsProfiles() with configPath=undefined. On machines where
     // ~/.aws/config is absent, the fallback fires and we verify exact profile output.
     // On machines where ~/.aws/config exists, the config is used instead (correct behaviour).
-    const subDir = makeSubDir("f1-primary");
-    const credPath = path.join(subDir, "credentials");
+    const subDir = makeSubDir('f1-primary');
+    const credPath = path.join(subDir, 'credentials');
     fs.writeFileSync(
       credPath,
-      "[default]\naws_access_key_id = AKIA...\n\n[myprofile]\naws_access_key_id = AKIA...\n",
-      "utf8",
+      '[default]\naws_access_key_id = AKIA...\n\n[myprofile]\naws_access_key_id = AKIA...\n',
+      'utf8',
     );
-    const defaultConfigPath = path.join(os.homedir(), ".aws", "config");
+    const defaultConfigPath = path.join(os.homedir(), '.aws', 'config');
     const configExists = fs.existsSync(defaultConfigPath);
 
     const profiles = loadAwsProfiles(undefined, credPath);
 
     if (configExists) {
       // Config takes priority — we can't assert exact profiles but must get a non-empty array
-      assert.ok(Array.isArray(profiles), "should return an array");
+      assert.ok(Array.isArray(profiles), 'should return an array');
       assert.ok(
         profiles.length > 0,
-        "should find at least one profile from config",
+        'should find at least one profile from config',
       );
     } else {
       // Fallback path exercised — assert exact output
-      assert.deepStrictEqual(profiles, ["default", "myprofile"]);
+      assert.deepStrictEqual(profiles, ['default', 'myprofile']);
     }
   });
 
-  it("both files present → config takes priority, credentials ignored", () => {
+  it('both files present → config takes priority, credentials ignored', () => {
     const configFile = writeTempFile(
-      "priority-config.ini",
-      "[default]\nregion = us-east-1\n\n[profile config-only]\nregion = us-west-2\n",
+      'priority-config.ini',
+      '[default]\nregion = us-east-1\n\n[profile config-only]\nregion = us-west-2\n',
     );
     const credFile = writeTempFile(
-      "priority-creds.ini",
-      "[default]\n[creds-only]\n",
+      'priority-creds.ini',
+      '[default]\n[creds-only]\n',
     );
     const profiles = loadAwsProfiles(configFile, credFile);
-    assert.deepStrictEqual(profiles, ["default", "config-only"]);
+    assert.deepStrictEqual(profiles, ['default', 'config-only']);
     assert.ok(
-      !profiles.includes("creds-only"),
-      "credentials profiles must not appear when config exists",
+      !profiles.includes('creds-only'),
+      'credentials profiles must not appear when config exists',
     );
   });
 
-  it("neither file exists → throws error naming both files", () => {
+  it('neither file exists → throws error naming both files', () => {
     // Use the explicit-path guard scenario for the hermetic throw test:
     // pass a non-existent configPath (explicit) → throws "AWS config not found".
     // This is the nearest hermetic equivalent; the "both missing" message
     // (mentioning both files) is tested via parseProfileSections unit tests + error message
     // inspection in the non-hermetic scenario below.
-    const missingConfig = path.join(tmpDir, "missing-cfg.ini");
-    const missingCreds = path.join(tmpDir, "missing-creds.ini");
+    const missingConfig = path.join(tmpDir, 'missing-cfg.ini');
+    const missingCreds = path.join(tmpDir, 'missing-creds.ini');
     assert.throws(
       () => loadAwsProfiles(missingConfig, missingCreds),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("AWS config not found"),
+        err instanceof Error && err.message.includes('AWS config not found'),
     );
   });
 
-  it("neither default file exists → throws error mentioning both paths", () => {
+  it('neither default file exists → throws error mentioning both paths', () => {
     // On machines where ~/.aws/config is absent and we pass a missing credentialsPath,
     // the function throws "No AWS configuration found ... ~/.aws/config or ~/.aws/credentials".
     // On machines where ~/.aws/config exists, loadAwsProfiles succeeds (no throw).
     // We skip the assertion on machines with ~/.aws/config to avoid false failures.
-    const defaultConfigPath = path.join(os.homedir(), ".aws", "config");
-    const missingCreds = path.join(tmpDir, "absent-creds.ini");
+    const defaultConfigPath = path.join(os.homedir(), '.aws', 'config');
+    const missingCreds = path.join(tmpDir, 'absent-creds.ini');
 
     if (!fs.existsSync(defaultConfigPath)) {
       assert.throws(
         () => loadAwsProfiles(undefined, missingCreds),
         (err: unknown) =>
           err instanceof Error &&
-          err.message.includes("~/.aws/config") &&
-          err.message.includes("~/.aws/credentials"),
+          err.message.includes('~/.aws/config') &&
+          err.message.includes('~/.aws/credentials'),
       );
     }
     // If ~/.aws/config exists: test is a no-op (correct — we can't make the default path absent)
   });
 
-  it("credentials file used when config exists — sanity check for both-path override", () => {
+  it('credentials file used when config exists — sanity check for both-path override', () => {
     const configFile = writeTempFile(
-      "sanity-config.ini",
-      "[profile alpha]\nregion = us-east-1\n",
+      'sanity-config.ini',
+      '[profile alpha]\nregion = us-east-1\n',
     );
-    const credFile = writeTempFile("sanity-creds.ini", "[default]\n[beta]\n");
+    const credFile = writeTempFile('sanity-creds.ini', '[default]\n[beta]\n');
     const profiles = loadAwsProfiles(configFile, credFile);
-    assert.deepStrictEqual(profiles, ["alpha"]);
+    assert.deepStrictEqual(profiles, ['alpha']);
     assert.ok(
-      !profiles.includes("beta"),
-      "beta from credentials must not appear",
+      !profiles.includes('beta'),
+      'beta from credentials must not appear',
     );
     assert.ok(
-      !profiles.includes("default"),
-      "default from credentials must not appear",
+      !profiles.includes('default'),
+      'default from credentials must not appear',
     );
   });
 });

--- a/src/launcher/mcp/cloudwatch.ts
+++ b/src/launcher/mcp/cloudwatch.ts
@@ -1,32 +1,32 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { select } from "@clack/prompts";
-import type { CloudWatchConfig } from "../types.js";
-import { handleCancel } from "../cancel.js";
-import type { McpCommand } from "../mcp-command-types.js";
-import { tryLoad } from "../utils.js";
-import { writeDotfile } from "../dotfile.js";
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { select } from '@clack/prompts';
+import type { CloudWatchConfig } from '../types.js';
+import { handleCancel } from '../cancel.js';
+import type { McpCommand } from '../mcp-command-types.js';
+import { tryLoad } from '../utils.js';
+import { writeDotfile } from '../dotfile.js';
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from '../types.js';
 
-const DEFAULT_CONFIG_PATH = path.join(os.homedir(), ".aws", "config");
-const DEFAULT_CREDENTIALS_PATH = path.join(os.homedir(), ".aws", "credentials");
+const DEFAULT_CONFIG_PATH = path.join(os.homedir(), '.aws', 'config');
+const DEFAULT_CREDENTIALS_PATH = path.join(os.homedir(), '.aws', 'credentials');
 
 export function parseProfileSections(
   content: string,
-  format: "config" | "credentials",
+  format: 'config' | 'credentials',
 ): string[] {
-  const lines = content.split("\n");
+  const lines = content.split('\n');
   const profiles: string[] = [];
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    if (format === "config") {
+    if (format === 'config') {
       // Match [default] or [profile <name>]
       const defaultMatch = /^\[default\]$/i.exec(trimmed);
       if (defaultMatch) {
-        profiles.push("default");
+        profiles.push('default');
         continue;
       }
       const profileMatch = /^\[profile\s+([^\]]+)\]$/i.exec(trimmed);
@@ -48,11 +48,11 @@ export function parseProfileSections(
     }
   }
 
-  if (format === "credentials") {
+  if (format === 'credentials') {
     const seen = new Set<string>();
     return profiles
       .filter((p) => {
-        const key = p.replace(/\./g, "_");
+        const key = p.replace(/\./g, '_');
         if (seen.has(key)) return false;
         seen.add(key);
         return true;
@@ -72,8 +72,8 @@ export function loadAwsProfiles(
   const configExplicitlyProvided = configPath !== undefined;
 
   if (fs.existsSync(resolvedConfigPath)) {
-    const content = fs.readFileSync(resolvedConfigPath, "utf8");
-    const profiles = parseProfileSections(content, "config");
+    const content = fs.readFileSync(resolvedConfigPath, 'utf8');
+    const profiles = parseProfileSections(content, 'config');
 
     if (profiles.length === 0) {
       throw new Error(
@@ -93,8 +93,8 @@ export function loadAwsProfiles(
 
   // Default config path absent — try credentials file
   if (fs.existsSync(resolvedCredentialsPath)) {
-    const content = fs.readFileSync(resolvedCredentialsPath, "utf8");
-    const profiles = parseProfileSections(content, "credentials");
+    const content = fs.readFileSync(resolvedCredentialsPath, 'utf8');
+    const profiles = parseProfileSections(content, 'credentials');
 
     if (profiles.length === 0) {
       throw new Error(
@@ -115,7 +115,7 @@ export async function configureCloudWatch(
   previousProfile?: string,
 ): Promise<CloudWatchConfig> {
   const profileValue = await select({
-    message: "Select AWS profile for CloudWatch:",
+    message: 'Select AWS profile for CloudWatch:',
     options: profiles.map((p) => ({ value: p, label: p })),
     initialValue:
       previousProfile && profiles.includes(previousProfile)
@@ -128,19 +128,19 @@ export async function configureCloudWatch(
 }
 
 export const cloudwatchCommand: McpCommand = {
-  id: "cloudwatch",
-  skippedKey: "cloudwatch",
+  id: 'cloudwatch',
+  skippedKey: 'cloudwatch',
   multiselectOption: {
-    value: "cloudwatch",
-    label: "CloudWatch",
-    hint: "AWS profile",
+    value: 'cloudwatch',
+    label: 'CloudWatch',
+    hint: 'AWS profile',
   },
 
   async configureInteractive(savedConfig: LauncherConfig): Promise<{
     resolved: Partial<ResolvedConfig>;
     persistable: Partial<LauncherConfig>;
   } | null> {
-    const profiles = tryLoad(() => loadAwsProfiles(), "cloudwatch");
+    const profiles = tryLoad(() => loadAwsProfiles(), 'cloudwatch');
     if (profiles === null) return null;
     const result = await configureCloudWatch(
       profiles,
@@ -160,10 +160,10 @@ export const cloudwatchCommand: McpCommand = {
   emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
     if (!resolved.cloudwatch) return;
     const profile = resolved.cloudwatch.profile;
-    env["AWS_PROFILE"] = profile;
+    env['AWS_PROFILE'] = profile;
     // mcp-cloudwatch.sh reads ~/.claude/.current-aws-profile and overrides AWS_PROFILE.
     // Write the dotfile so both paths agree — same behaviour as /set-aws-profile command.
-    writeDotfile("current-aws-profile", profile);
+    writeDotfile('current-aws-profile', profile);
   },
 
   buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
@@ -173,12 +173,12 @@ export const cloudwatchCommand: McpCommand = {
 
   buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
     if (!skipped) return null;
-    return "CloudWatch: skipped (profiles unavailable)";
+    return 'CloudWatch: skipped (profiles unavailable)';
   },
 
   buildSummaryLine(config: LauncherConfig): string {
     if (config.cloudwatch === undefined) {
-      return "CloudWatch: (not yet configured)";
+      return 'CloudWatch: (not yet configured)';
     }
     return `CloudWatch: profile ${config.cloudwatch.profile}`;
   },

--- a/src/launcher/mcp/gcp-observability.test.ts
+++ b/src/launcher/mcp/gcp-observability.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { checkAdcCredentials, loadGcpProjects } from "./gcp-observability.js";
-import type { GcloudRunner } from "./gcp-observability.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { checkAdcCredentials, loadGcpProjects } from './gcp-observability.js';
+import type { GcloudRunner } from './gcp-observability.js';
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
 // ---------------------------------------------------------------------------
 
 const tmpDir = fs.mkdtempSync(
-  path.join(os.tmpdir(), "ai-tpk-gcp-observability-test-"),
+  path.join(os.tmpdir(), 'ai-tpk-gcp-observability-test-'),
 );
 
 after(() => {
@@ -24,7 +24,7 @@ after(() => {
 
 function writeTempFile(name: string, content: string): string {
   const filePath = path.join(tmpDir, name);
-  fs.writeFileSync(filePath, content, "utf8");
+  fs.writeFileSync(filePath, content, 'utf8');
   return filePath;
 }
 
@@ -32,7 +32,7 @@ function writeTempFile(name: string, content: string): string {
 // checkAdcCredentials
 // ---------------------------------------------------------------------------
 
-describe("checkAdcCredentials", () => {
+describe('checkAdcCredentials', () => {
   // Save and restore GOOGLE_APPLICATION_CREDENTIALS for env var isolation
   let savedEnvCredPath: string | undefined;
 
@@ -49,28 +49,28 @@ describe("checkAdcCredentials", () => {
     }
   });
 
-  it("throws when neither GOOGLE_APPLICATION_CREDENTIALS is set nor default ADC path exists", () => {
-    const missingPath = path.join(tmpDir, "does-not-exist.json");
+  it('throws when neither GOOGLE_APPLICATION_CREDENTIALS is set nor default ADC path exists', () => {
+    const missingPath = path.join(tmpDir, 'does-not-exist.json');
     assert.throws(
       () => checkAdcCredentials(missingPath),
       (err: unknown) => err instanceof Error,
     );
   });
 
-  it("does not throw when default ADC file exists (via adcPath param)", () => {
+  it('does not throw when default ADC file exists (via adcPath param)', () => {
     const adcFile = writeTempFile(
-      "adc-credentials.json",
+      'adc-credentials.json',
       '{"type":"authorized_user"}',
     );
     assert.doesNotThrow(() => checkAdcCredentials(adcFile));
   });
 
-  it("does not throw when GOOGLE_APPLICATION_CREDENTIALS points to an existing file (even if default ADC path is missing)", () => {
+  it('does not throw when GOOGLE_APPLICATION_CREDENTIALS points to an existing file (even if default ADC path is missing)', () => {
     const credFile = writeTempFile(
-      "env-credentials.json",
+      'env-credentials.json',
       '{"type":"service_account"}',
     );
-    const missingAdcPath = path.join(tmpDir, "missing-adc.json");
+    const missingAdcPath = path.join(tmpDir, 'missing-adc.json');
     process.env.GOOGLE_APPLICATION_CREDENTIALS = credFile;
     try {
       assert.doesNotThrow(() => checkAdcCredentials(missingAdcPath));
@@ -79,9 +79,9 @@ describe("checkAdcCredentials", () => {
     }
   });
 
-  it("throws when GOOGLE_APPLICATION_CREDENTIALS points to non-existent file AND default ADC path is missing", () => {
-    const missingEnvPath = path.join(tmpDir, "missing-env-cred.json");
-    const missingAdcPath = path.join(tmpDir, "missing-adc-2.json");
+  it('throws when GOOGLE_APPLICATION_CREDENTIALS points to non-existent file AND default ADC path is missing', () => {
+    const missingEnvPath = path.join(tmpDir, 'missing-env-cred.json');
+    const missingAdcPath = path.join(tmpDir, 'missing-adc-2.json');
     process.env.GOOGLE_APPLICATION_CREDENTIALS = missingEnvPath;
     try {
       assert.throws(
@@ -93,8 +93,8 @@ describe("checkAdcCredentials", () => {
     }
   });
 
-  it("error message includes GOOGLE_APPLICATION_CREDENTIALS and gcloud auth application-default login", () => {
-    const missingPath = path.join(tmpDir, "missing-for-message-test.json");
+  it('error message includes GOOGLE_APPLICATION_CREDENTIALS and gcloud auth application-default login', () => {
+    const missingPath = path.join(tmpDir, 'missing-for-message-test.json');
     let caughtError: Error | null = null;
     try {
       checkAdcCredentials(missingPath);
@@ -103,14 +103,14 @@ describe("checkAdcCredentials", () => {
         caughtError = err;
       }
     }
-    assert.ok(caughtError !== null, "Expected an error to be thrown");
+    assert.ok(caughtError !== null, 'Expected an error to be thrown');
     assert.ok(
-      caughtError!.message.includes("GOOGLE_APPLICATION_CREDENTIALS"),
-      "Error message must mention GOOGLE_APPLICATION_CREDENTIALS",
+      caughtError!.message.includes('GOOGLE_APPLICATION_CREDENTIALS'),
+      'Error message must mention GOOGLE_APPLICATION_CREDENTIALS',
     );
     assert.ok(
-      caughtError!.message.includes("gcloud auth application-default login"),
-      "Error message must mention gcloud auth application-default login",
+      caughtError!.message.includes('gcloud auth application-default login'),
+      'Error message must mention gcloud auth application-default login',
     );
   });
 });
@@ -120,88 +120,88 @@ describe("checkAdcCredentials", () => {
 // ---------------------------------------------------------------------------
 
 const runnerNotFound: GcloudRunner = () => {
-  const err = new Error("spawnSync gcloud ENOENT") as NodeJS.ErrnoException;
-  err.code = "ENOENT";
-  return { status: null, stdout: "", stderr: "", error: err };
+  const err = new Error('spawnSync gcloud ENOENT') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return { status: null, stdout: '', stderr: '', error: err };
 };
 
 const runnerNonZeroExit: GcloudRunner = () => ({
   status: 1,
-  stdout: "",
-  stderr: "ERROR: (gcloud.projects.list) not authenticated",
+  stdout: '',
+  stderr: 'ERROR: (gcloud.projects.list) not authenticated',
 });
 
 const runnerEmptyOutput: GcloudRunner = () => ({
   status: 0,
-  stdout: "   \n  \n  ",
-  stderr: "",
+  stdout: '   \n  \n  ',
+  stderr: '',
 });
 
 const runnerValidOutput: GcloudRunner = () => ({
   status: 0,
-  stdout: "alpha-project\ncharlie-project\nbravo-project\n",
-  stderr: "",
+  stdout: 'alpha-project\ncharlie-project\nbravo-project\n',
+  stderr: '',
 });
 
 const runnerWhitespaceOutput: GcloudRunner = () => ({
   status: 0,
-  stdout: "\nmy-project\n\nanother-project\n\n",
-  stderr: "",
+  stdout: '\nmy-project\n\nanother-project\n\n',
+  stderr: '',
 });
 
 const runnerTimeout: GcloudRunner = () => ({
   status: null,
-  stdout: "",
-  stderr: "",
-  signal: "SIGTERM",
+  stdout: '',
+  stderr: '',
+  signal: 'SIGTERM',
 });
 
-describe("loadGcpProjects", () => {
-  it("throws when gcloud is not found on PATH", () => {
+describe('loadGcpProjects', () => {
+  it('throws when gcloud is not found on PATH', () => {
     assert.throws(
       () => loadGcpProjects(runnerNotFound),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("gcloud CLI not found"),
+        err instanceof Error && err.message.includes('gcloud CLI not found'),
     );
   });
 
-  it("throws with stderr when gcloud exits non-zero", () => {
+  it('throws with stderr when gcloud exits non-zero', () => {
     assert.throws(
       () => loadGcpProjects(runnerNonZeroExit),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("gcloud projects list failed") &&
-        err.message.includes("not authenticated"),
+        err.message.includes('gcloud projects list failed') &&
+        err.message.includes('not authenticated'),
     );
   });
 
-  it("throws when gcloud returns empty output", () => {
+  it('throws when gcloud returns empty output', () => {
     assert.throws(
       () => loadGcpProjects(runnerEmptyOutput),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("No GCP projects found"),
+        err instanceof Error && err.message.includes('No GCP projects found'),
     );
   });
 
-  it("returns project IDs in the order provided by gcloud", () => {
+  it('returns project IDs in the order provided by gcloud', () => {
     const projects = loadGcpProjects(runnerValidOutput);
     assert.deepStrictEqual(projects, [
-      "alpha-project",
-      "charlie-project",
-      "bravo-project",
+      'alpha-project',
+      'charlie-project',
+      'bravo-project',
     ]);
   });
 
-  it("handles trailing newlines and filters empty lines", () => {
+  it('handles trailing newlines and filters empty lines', () => {
     const projects = loadGcpProjects(runnerWhitespaceOutput);
-    assert.deepStrictEqual(projects, ["my-project", "another-project"]);
+    assert.deepStrictEqual(projects, ['my-project', 'another-project']);
   });
 
-  it("throws when gcloud times out", () => {
+  it('throws when gcloud times out', () => {
     assert.throws(
       () => loadGcpProjects(runnerTimeout),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("timed out after 15s"),
+        err instanceof Error && err.message.includes('timed out after 15s'),
     );
   });
 });

--- a/src/launcher/mcp/gcp-observability.ts
+++ b/src/launcher/mcp/gcp-observability.ts
@@ -1,14 +1,14 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { spawnSync } from "node:child_process";
-import { select } from "@clack/prompts";
-import type { GcpObservabilityConfig } from "../types.js";
-import { handleCancel } from "../cancel.js";
-import type { McpCommand } from "../mcp-command-types.js";
-import { tryLoad } from "../utils.js";
-import { writeDotfile } from "../dotfile.js";
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { select } from '@clack/prompts';
+import type { GcpObservabilityConfig } from '../types.js';
+import { handleCancel } from '../cancel.js';
+import type { McpCommand } from '../mcp-command-types.js';
+import { tryLoad } from '../utils.js';
+import { writeDotfile } from '../dotfile.js';
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from '../types.js';
 
 export interface GcloudResult {
   status: number | null;
@@ -22,14 +22,14 @@ export type GcloudRunner = () => GcloudResult;
 
 function defaultGcloudRunner(): GcloudResult {
   const result = spawnSync(
-    "gcloud",
-    ["projects", "list", "--format=value(projectId)", "--sort-by=projectId"],
-    { encoding: "utf8", timeout: 15000 },
+    'gcloud',
+    ['projects', 'list', '--format=value(projectId)', '--sort-by=projectId'],
+    { encoding: 'utf8', timeout: 15000 },
   );
   return {
     status: result.status,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
     signal: result.signal ?? undefined,
     error: result.error,
   };
@@ -38,18 +38,18 @@ function defaultGcloudRunner(): GcloudResult {
 export function loadGcpProjects(runner?: GcloudRunner): string[] {
   const result = (runner ?? defaultGcloudRunner)();
 
-  if (result.status === null && result.signal === "SIGTERM") {
+  if (result.status === null && result.signal === 'SIGTERM') {
     throw new Error(
-      "gcloud projects list timed out after 15s. Check your network connection or try running `gcloud projects list` manually.",
+      'gcloud projects list timed out after 15s. Check your network connection or try running `gcloud projects list` manually.',
     );
   }
 
   if (result.error) {
     const isNotFound =
-      (result.error as NodeJS.ErrnoException).code === "ENOENT";
+      (result.error as NodeJS.ErrnoException).code === 'ENOENT';
     throw new Error(
       isNotFound
-        ? "gcloud CLI not found. Install it from https://cloud.google.com/sdk/docs/install or ensure it is on your PATH."
+        ? 'gcloud CLI not found. Install it from https://cloud.google.com/sdk/docs/install or ensure it is on your PATH.'
         : `Failed to run gcloud CLI (${result.error.message}). Ensure gcloud is installed and on your PATH.`,
     );
   }
@@ -60,23 +60,23 @@ export function loadGcpProjects(runner?: GcloudRunner): string[] {
     );
   }
 
-  if (result.stdout.trim() === "") {
+  if (result.stdout.trim() === '') {
     throw new Error(
-      "No GCP projects found. Ensure you have access to at least one project, or run: gcloud auth login",
+      'No GCP projects found. Ensure you have access to at least one project, or run: gcloud auth login',
     );
   }
 
   return result.stdout
     .trim()
-    .split("\n")
+    .split('\n')
     .filter((line) => line.trim().length > 0);
 }
 
 const DEFAULT_ADC_PATH = path.join(
   os.homedir(),
-  ".config",
-  "gcloud",
-  "application_default_credentials.json",
+  '.config',
+  'gcloud',
+  'application_default_credentials.json',
 );
 
 /**
@@ -101,7 +101,7 @@ export function checkAdcCredentials(adcPath?: string): void {
 
   throw new Error(
     `GCP Application Default Credentials not found. Checked:\n` +
-      `  - GOOGLE_APPLICATION_CREDENTIALS env var${envCredPath ? ` (${envCredPath} — file not found)` : " (not set)"}\n` +
+      `  - GOOGLE_APPLICATION_CREDENTIALS env var${envCredPath ? ` (${envCredPath} — file not found)` : ' (not set)'}\n` +
       `  - ${resolvedPath}\n` +
       `Set GOOGLE_APPLICATION_CREDENTIALS to a valid credential file, or run: gcloud auth application-default login`,
   );
@@ -115,7 +115,7 @@ export async function configureGcpObservability(
   previousProject?: string,
 ): Promise<GcpObservabilityConfig> {
   const projectValue = await select({
-    message: "Select GCP project for Observability:",
+    message: 'Select GCP project for Observability:',
     options: projects.map((p) => ({ value: p, label: p })),
     // Intentionally more defensive than the CloudWatch pattern: guards against a
     // stale previousProject that is no longer present in the current project list.
@@ -130,12 +130,12 @@ export async function configureGcpObservability(
 }
 
 export const gcpObservabilityCommand: McpCommand = {
-  id: "gcp-observability",
-  skippedKey: "gcp",
+  id: 'gcp-observability',
+  skippedKey: 'gcp',
   multiselectOption: {
-    value: "gcp-observability",
-    label: "GCP Observability",
-    hint: "GCP project",
+    value: 'gcp-observability',
+    label: 'GCP Observability',
+    hint: 'GCP project',
   },
 
   async configureInteractive(savedConfig: LauncherConfig): Promise<{
@@ -144,15 +144,15 @@ export const gcpObservabilityCommand: McpCommand = {
   } | null> {
     const projects = tryLoad(
       () => loadGcpProjects(),
-      "gcp",
-      "GCP project list unavailable — skipping gcp-observability MCP. Run `gcloud auth login` and re-launch.",
+      'gcp',
+      'GCP project list unavailable — skipping gcp-observability MCP. Run `gcloud auth login` and re-launch.',
     );
     if (projects === null) return null;
 
     const adcResult = tryLoad(
       () => checkAdcCredentials(),
-      "gcp-adc",
-      "GCP ADC credentials unavailable — skipping gcp-observability MCP. Run `gcloud auth application-default login` and re-launch.",
+      'gcp-adc',
+      'GCP ADC credentials unavailable — skipping gcp-observability MCP. Run `gcloud auth application-default login` and re-launch.',
     );
     // checkAdcCredentials returns void on success; tryLoad propagates void as undefined, not null.
     // Use !== null (not falsy !) to distinguish success (undefined) from failure (null).
@@ -176,14 +176,14 @@ export const gcpObservabilityCommand: McpCommand = {
   emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
     if (!resolved.gcpObservability) return;
     const project = resolved.gcpObservability.project;
-    env["GOOGLE_CLOUD_PROJECT"] = project;
+    env['GOOGLE_CLOUD_PROJECT'] = project;
     // mcp-gcp-observability.sh reads ~/.claude/.current-gcp-project and overrides GOOGLE_CLOUD_PROJECT.
     // Write the dotfile so both paths agree.
     // Note: GOOGLE_CLOUD_PROJECT is used by google-auth-library's getProjectId() for project ID resolution.
     // getProjectId() checks the GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT env var group (GCLOUD_PROJECT first,
     // then GOOGLE_CLOUD_PROJECT), before credential files or the metadata server.
     // It does NOT auto-populate tool call parameters.
-    writeDotfile("current-gcp-project", project);
+    writeDotfile('current-gcp-project', project);
   },
 
   buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
@@ -193,12 +193,12 @@ export const gcpObservabilityCommand: McpCommand = {
 
   buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
     if (!skipped) return null;
-    return "GCP Observability: skipped (auth unavailable)";
+    return 'GCP Observability: skipped (auth unavailable)';
   },
 
   buildSummaryLine(config: LauncherConfig): string {
     if (config.gcpObservability === undefined) {
-      return "GCP Observability: (not yet configured)";
+      return 'GCP Observability: (not yet configured)';
     }
     return `GCP Observability: project ${config.gcpObservability.project}`;
   },

--- a/src/launcher/mcp/grafana.test.ts
+++ b/src/launcher/mcp/grafana.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { loadGrafanaClusters } from "./grafana.js";
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadGrafanaClusters } from './grafana.js';
 
 // ---------------------------------------------------------------------------
 // Shared temp directory — cleaned up after all tests complete
 // ---------------------------------------------------------------------------
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-grafana-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-grafana-test-'));
 
 after(() => {
   fs.rmSync(tmpDir, { recursive: true });
@@ -21,7 +21,7 @@ after(() => {
 
 function writeYaml(name: string, content: string): string {
   const filePath = path.join(tmpDir, name);
-  fs.writeFileSync(filePath, content, "utf8");
+  fs.writeFileSync(filePath, content, 'utf8');
   return filePath;
 }
 
@@ -29,10 +29,10 @@ function writeYaml(name: string, content: string): string {
 // loadGrafanaClusters
 // ---------------------------------------------------------------------------
 
-describe("loadGrafanaClusters", () => {
-  it("parses a valid YAML file with viewer_token and editor_token fields", () => {
+describe('loadGrafanaClusters', () => {
+  it('parses a valid YAML file with viewer_token and editor_token fields', () => {
     const filePath = writeYaml(
-      "valid.yaml",
+      'valid.yaml',
       `
 clusters:
   - id: prod
@@ -45,18 +45,18 @@ clusters:
     const clusters = loadGrafanaClusters(filePath);
     assert.strictEqual(clusters.length, 1);
     assert.deepStrictEqual(clusters[0], {
-      id: "prod",
-      name: "Production",
-      url: "https://grafana.example.com",
-      viewer_token: "viewer-tok-123",
-      editor_token: "editor-tok-456",
+      id: 'prod',
+      name: 'Production',
+      url: 'https://grafana.example.com',
+      viewer_token: 'viewer-tok-123',
+      editor_token: 'editor-tok-456',
     });
   });
 
-  it("falls back when a cluster has legacy token but no viewer_token/editor_token", () => {
+  it('falls back when a cluster has legacy token but no viewer_token/editor_token', () => {
     // The log.warn call from @clack/prompts may emit to stdout — this is acceptable.
     const filePath = writeYaml(
-      "legacy.yaml",
+      'legacy.yaml',
       `
 clusters:
   - id: staging
@@ -67,23 +67,23 @@ clusters:
     );
     const clusters = loadGrafanaClusters(filePath);
     assert.strictEqual(clusters.length, 1);
-    assert.strictEqual(clusters[0]?.viewer_token, "legacy-tok-789");
-    assert.strictEqual(clusters[0]?.editor_token, "");
+    assert.strictEqual(clusters[0]?.viewer_token, 'legacy-tok-789');
+    assert.strictEqual(clusters[0]?.editor_token, '');
   });
 
-  it("throws when the config file does not exist", () => {
-    const missingPath = path.join(tmpDir, "does-not-exist.yaml");
+  it('throws when the config file does not exist', () => {
+    const missingPath = path.join(tmpDir, 'does-not-exist.yaml');
     assert.throws(
       () => loadGrafanaClusters(missingPath),
       (err: unknown) =>
         err instanceof Error &&
-        err.message.includes("Grafana clusters config not found"),
+        err.message.includes('Grafana clusters config not found'),
     );
   });
 
-  it("throws when the file has no clusters key", () => {
+  it('throws when the file has no clusters key', () => {
     const filePath = writeYaml(
-      "no-clusters.yaml",
+      'no-clusters.yaml',
       `
 something_else:
   - id: x
@@ -96,9 +96,9 @@ something_else:
     );
   });
 
-  it("throws when the clusters array is empty", () => {
+  it('throws when the clusters array is empty', () => {
     const filePath = writeYaml(
-      "empty-clusters.yaml",
+      'empty-clusters.yaml',
       `
 clusters: []
 `,
@@ -110,9 +110,9 @@ clusters: []
     );
   });
 
-  it("throws when a cluster entry is missing required id or name fields", () => {
+  it('throws when a cluster entry is missing required id or name fields', () => {
     const filePath = writeYaml(
-      "missing-fields.yaml",
+      'missing-fields.yaml',
       `
 clusters:
   - url: https://grafana.example.com
@@ -123,13 +123,13 @@ clusters:
     assert.throws(
       () => loadGrafanaClusters(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("missing required fields"),
+        err instanceof Error && err.message.includes('missing required fields'),
     );
   });
 
-  it("throws when a cluster entry has an invalid or missing url", () => {
+  it('throws when a cluster entry has an invalid or missing url', () => {
     const filePath = writeYaml(
-      "bad-url.yaml",
+      'bad-url.yaml',
       `
 clusters:
   - id: broken
@@ -142,7 +142,7 @@ clusters:
     assert.throws(
       () => loadGrafanaClusters(filePath),
       (err: unknown) =>
-        err instanceof Error && err.message.includes("missing or invalid url"),
+        err instanceof Error && err.message.includes('missing or invalid url'),
     );
   });
 });

--- a/src/launcher/mcp/grafana.ts
+++ b/src/launcher/mcp/grafana.ts
@@ -1,19 +1,19 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { parse as parseYaml } from "yaml";
-import { log, select, cancel } from "@clack/prompts";
-import type { GrafanaCluster, GrafanaConfig, GrafanaRole } from "../types.js";
-import { handleCancel } from "../cancel.js";
-import type { McpCommand } from "../mcp-command-types.js";
-import { StaleResourceError } from "../mcp-command-types.js";
-import { tryLoad } from "../utils.js";
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { parse as parseYaml } from 'yaml';
+import { log, select, cancel } from '@clack/prompts';
+import type { GrafanaCluster, GrafanaConfig, GrafanaRole } from '../types.js';
+import { handleCancel } from '../cancel.js';
+import type { McpCommand } from '../mcp-command-types.js';
+import { StaleResourceError } from '../mcp-command-types.js';
+import { tryLoad } from '../utils.js';
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from '../types.js';
 
 const DEFAULT_CONFIG_PATH = path.join(
   os.homedir(),
-  ".config",
-  "grafana-clusters.yaml",
+  '.config',
+  'grafana-clusters.yaml',
 );
 
 interface RawCluster {
@@ -42,7 +42,7 @@ export function loadGrafanaClusters(configPath?: string): GrafanaCluster[] {
     );
   }
 
-  const raw = fs.readFileSync(resolvedPath, "utf8");
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
   // maxAliasCount guards against YAML anchor/alias expansion bombs
   const parsed = parseYaml(raw, { maxAliasCount: 100 }) as {
     clusters?: RawCluster[];
@@ -61,9 +61,9 @@ export function loadGrafanaClusters(configPath?: string): GrafanaCluster[] {
   }
 
   return parsed.clusters.map((c: RawCluster, idx: number): GrafanaCluster => {
-    const id = String(c.id ?? "");
-    const name = String(c.name ?? "");
-    const url = String(c.url ?? "");
+    const id = String(c.id ?? '');
+    const name = String(c.name ?? '');
+    const url = String(c.url ?? '');
 
     if (!id || !name) {
       throw new Error(
@@ -78,15 +78,15 @@ export function loadGrafanaClusters(configPath?: string): GrafanaCluster[] {
     }
 
     // Legacy token fallback: warn and use token as viewer_token
-    let viewer_token = String(c.viewer_token ?? "");
-    let editor_token = String(c.editor_token ?? "");
+    let viewer_token = String(c.viewer_token ?? '');
+    let editor_token = String(c.editor_token ?? '');
 
     if (!viewer_token && !editor_token && c.token) {
       log.warn(
         `Cluster "${name}" uses legacy 'token' field. Add 'viewer_token' and 'editor_token' to ~/.config/grafana-clusters.yaml.`,
       );
       viewer_token = String(c.token);
-      editor_token = "";
+      editor_token = '';
     }
 
     return { id, name, url, viewer_token, editor_token };
@@ -99,7 +99,7 @@ export async function configureGrafana(
   previousRole?: GrafanaRole,
 ): Promise<GrafanaConfig> {
   const clusterValue = await select({
-    message: "Select Grafana cluster:",
+    message: 'Select Grafana cluster:',
     options: clusters.map((c) => ({
       value: c.id,
       label: c.name,
@@ -114,35 +114,35 @@ export async function configureGrafana(
 
   const selectedCluster = clusters.find((c) => c.id === clusterValue);
   if (!selectedCluster) {
-    cancel("Selected cluster not found.");
+    cancel('Selected cluster not found.');
     process.exit(1);
   }
 
   const roleValue = await select<GrafanaRole>({
-    message: "Select access role:",
+    message: 'Select access role:',
     options: [
       {
-        value: "viewer" as GrafanaRole,
-        label: "Viewer (read-only)",
-        hint: "uses --disable-write",
+        value: 'viewer' as GrafanaRole,
+        label: 'Viewer (read-only)',
+        hint: 'uses --disable-write',
       },
       {
-        value: "editor" as GrafanaRole,
-        label: "Editor (read + write)",
+        value: 'editor' as GrafanaRole,
+        label: 'Editor (read + write)',
       },
     ],
-    initialValue: previousRole ?? "viewer",
+    initialValue: previousRole ?? 'viewer',
   });
   handleCancel(roleValue);
 
-  if (roleValue === "editor" && !selectedCluster.editor_token) {
+  if (roleValue === 'editor' && !selectedCluster.editor_token) {
     cancel(
       `Cluster "${selectedCluster.name}" has no editor_token configured. Update ~/.config/grafana-clusters.yaml or select Viewer role.`,
     );
     process.exit(1);
   }
 
-  if (roleValue === "viewer" && !selectedCluster.viewer_token) {
+  if (roleValue === 'viewer' && !selectedCluster.viewer_token) {
     cancel(
       `Cluster "${selectedCluster.name}" has no viewer_token configured. Update ~/.config/grafana-clusters.yaml or select Editor role.`,
     );
@@ -156,19 +156,19 @@ export async function configureGrafana(
 }
 
 export const grafanaCommand: McpCommand = {
-  id: "grafana",
-  skippedKey: "grafana",
+  id: 'grafana',
+  skippedKey: 'grafana',
   multiselectOption: {
-    value: "grafana",
-    label: "Grafana",
-    hint: "cluster + role",
+    value: 'grafana',
+    label: 'Grafana',
+    hint: 'cluster + role',
   },
 
   async configureInteractive(savedConfig: LauncherConfig): Promise<{
     resolved: Partial<ResolvedConfig>;
     persistable: Partial<LauncherConfig>;
   } | null> {
-    const clusters = tryLoad(() => loadGrafanaClusters(), "grafana");
+    const clusters = tryLoad(() => loadGrafanaClusters(), 'grafana');
     if (clusters === null) return null;
     const result = await configureGrafana(
       clusters,
@@ -198,7 +198,7 @@ export const grafanaCommand: McpCommand = {
         `Could not load Grafana clusters: ${err instanceof Error ? err.message : String(err)}. Falling through to configure flow.`,
       );
       // Message arg is for diagnostic use only; user warning is emitted above.
-      throw new StaleResourceError("Grafana clusters file unavailable");
+      throw new StaleResourceError('Grafana clusters file unavailable');
     }
     const cluster = clusters.find((c) => c.id === config.grafana!.clusterId);
     if (cluster === undefined) {
@@ -216,13 +216,13 @@ export const grafanaCommand: McpCommand = {
   emitEnvVars(resolved: ResolvedConfig, env: Record<string, string>): void {
     if (!resolved.grafana) return;
     const { cluster, role } = resolved.grafana;
-    env["GRAFANA_URL"] = cluster.url;
-    if (role === "viewer") {
-      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.viewer_token;
-      env["GRAFANA_DISABLE_WRITE"] = "true";
+    env['GRAFANA_URL'] = cluster.url;
+    if (role === 'viewer') {
+      env['GRAFANA_SERVICE_ACCOUNT_TOKEN'] = cluster.viewer_token;
+      env['GRAFANA_DISABLE_WRITE'] = 'true';
     } else {
       // editor role — no GRAFANA_DISABLE_WRITE
-      env["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = cluster.editor_token;
+      env['GRAFANA_SERVICE_ACCOUNT_TOKEN'] = cluster.editor_token;
     }
   },
 
@@ -233,12 +233,12 @@ export const grafanaCommand: McpCommand = {
 
   buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
     if (!skipped) return null;
-    return "Grafana: skipped (clusters unavailable)";
+    return 'Grafana: skipped (clusters unavailable)';
   },
 
   buildSummaryLine(config: LauncherConfig): string {
     if (config.grafana === undefined) {
-      return "Grafana: (not yet configured)";
+      return 'Grafana: (not yet configured)';
     }
     return `Grafana: cluster ${config.grafana.clusterId}, role ${config.grafana.role}`;
   },

--- a/src/launcher/mcp/initialValue.test.ts
+++ b/src/launcher/mcp/initialValue.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 
 // ---------------------------------------------------------------------------
 // Step 7: initialValue staleness guard logic (Finding 7)
@@ -30,85 +30,85 @@ function resolveGrafanaDefault(
 function resolveKubernetesDefault(
   list: string[],
   previous?: string,
-  currentContext: string = "",
+  currentContext: string = '',
 ): string | undefined {
   return previous && list.includes(previous)
     ? previous
     : currentContext || list[0];
 }
 
-describe("CloudWatch initialValue staleness guard", () => {
-  it("returns previousProfile when it exists in the list", () => {
+describe('CloudWatch initialValue staleness guard', () => {
+  it('returns previousProfile when it exists in the list', () => {
     assert.strictEqual(
-      resolveStringDefault(["default", "dev", "prod"], "dev"),
-      "dev",
+      resolveStringDefault(['default', 'dev', 'prod'], 'dev'),
+      'dev',
     );
   });
 
-  it("returns first profile when previousProfile is not in the list (stale)", () => {
+  it('returns first profile when previousProfile is not in the list (stale)', () => {
     assert.strictEqual(
-      resolveStringDefault(["default", "dev", "prod"], "old-profile"),
-      "default",
+      resolveStringDefault(['default', 'dev', 'prod'], 'old-profile'),
+      'default',
     );
   });
 
-  it("returns first profile when previousProfile is undefined", () => {
+  it('returns first profile when previousProfile is undefined', () => {
     assert.strictEqual(
-      resolveStringDefault(["default", "dev"], undefined),
-      "default",
-    );
-  });
-});
-
-describe("Grafana initialValue staleness guard", () => {
-  it("returns previousClusterId when it exists in the list", () => {
-    assert.strictEqual(
-      resolveGrafanaDefault(["prod", "staging", "dev"], "staging"),
-      "staging",
-    );
-  });
-
-  it("returns first cluster id when previousClusterId is not in the list (stale)", () => {
-    assert.strictEqual(
-      resolveGrafanaDefault(["prod", "staging"], "deleted-cluster"),
-      "prod",
-    );
-  });
-
-  it("returns first cluster id when previousClusterId is undefined", () => {
-    assert.strictEqual(
-      resolveGrafanaDefault(["prod", "staging"], undefined),
-      "prod",
+      resolveStringDefault(['default', 'dev'], undefined),
+      'default',
     );
   });
 });
 
-describe("Kubernetes initialValue staleness guard", () => {
-  it("returns previousContext when it exists in the list", () => {
+describe('Grafana initialValue staleness guard', () => {
+  it('returns previousClusterId when it exists in the list', () => {
     assert.strictEqual(
-      resolveKubernetesDefault(["prod", "staging", "dev"], "staging", "dev"),
-      "staging",
+      resolveGrafanaDefault(['prod', 'staging', 'dev'], 'staging'),
+      'staging',
     );
   });
 
-  it("returns currentContext when previousContext is stale and currentContext is in the list", () => {
+  it('returns first cluster id when previousClusterId is not in the list (stale)', () => {
     assert.strictEqual(
-      resolveKubernetesDefault(["prod", "staging"], "old-context", "staging"),
-      "staging",
+      resolveGrafanaDefault(['prod', 'staging'], 'deleted-cluster'),
+      'prod',
     );
   });
 
-  it("returns first context when both previousContext is stale and currentContext is empty", () => {
+  it('returns first cluster id when previousClusterId is undefined', () => {
     assert.strictEqual(
-      resolveKubernetesDefault(["prod", "staging"], "old-context", ""),
-      "prod",
+      resolveGrafanaDefault(['prod', 'staging'], undefined),
+      'prod',
+    );
+  });
+});
+
+describe('Kubernetes initialValue staleness guard', () => {
+  it('returns previousContext when it exists in the list', () => {
+    assert.strictEqual(
+      resolveKubernetesDefault(['prod', 'staging', 'dev'], 'staging', 'dev'),
+      'staging',
     );
   });
 
-  it("returns first context when previousContext is undefined and currentContext is empty", () => {
+  it('returns currentContext when previousContext is stale and currentContext is in the list', () => {
     assert.strictEqual(
-      resolveKubernetesDefault(["prod", "staging"], undefined, ""),
-      "prod",
+      resolveKubernetesDefault(['prod', 'staging'], 'old-context', 'staging'),
+      'staging',
+    );
+  });
+
+  it('returns first context when both previousContext is stale and currentContext is empty', () => {
+    assert.strictEqual(
+      resolveKubernetesDefault(['prod', 'staging'], 'old-context', ''),
+      'prod',
+    );
+  });
+
+  it('returns first context when previousContext is undefined and currentContext is empty', () => {
+    assert.strictEqual(
+      resolveKubernetesDefault(['prod', 'staging'], undefined, ''),
+      'prod',
     );
   });
 });

--- a/src/launcher/mcp/kubernetes.test.ts
+++ b/src/launcher/mcp/kubernetes.test.ts
@@ -1,37 +1,37 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { parseKubectxOutput } from "./kubernetes.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseKubectxOutput } from './kubernetes.js';
 
 // Note: loadKubectxContexts() and switchContext() invoke spawnSync("kubectx", ...)
 // which requires kubectx on PATH. Their error paths (ENOENT, non-zero exit, empty
 // output) are integration-tested manually. parseKubectxOutput() covers the parsing
 // logic that is pure and unit-testable.
 
-describe("parseKubectxOutput", () => {
-  it("parses a standard kubectx output with multiple contexts", () => {
-    const stdout = "production\nstaging\ndevelopment\n";
+describe('parseKubectxOutput', () => {
+  it('parses a standard kubectx output with multiple contexts', () => {
+    const stdout = 'production\nstaging\ndevelopment\n';
     assert.deepEqual(parseKubectxOutput(stdout), [
-      "production",
-      "staging",
-      "development",
+      'production',
+      'staging',
+      'development',
     ]);
   });
 
-  it("handles empty string (no contexts)", () => {
-    assert.deepEqual(parseKubectxOutput(""), []);
+  it('handles empty string (no contexts)', () => {
+    assert.deepEqual(parseKubectxOutput(''), []);
   });
 
-  it("filters blank lines", () => {
-    const stdout = "production\n\nstaging\n";
-    assert.deepEqual(parseKubectxOutput(stdout), ["production", "staging"]);
+  it('filters blank lines', () => {
+    const stdout = 'production\n\nstaging\n';
+    assert.deepEqual(parseKubectxOutput(stdout), ['production', 'staging']);
   });
 
-  it("trims whitespace from context names", () => {
-    const stdout = "  production  \n  staging  \n";
-    assert.deepEqual(parseKubectxOutput(stdout), ["production", "staging"]);
+  it('trims whitespace from context names', () => {
+    const stdout = '  production  \n  staging  \n';
+    assert.deepEqual(parseKubectxOutput(stdout), ['production', 'staging']);
   });
 
-  it("handles a single context", () => {
-    assert.deepEqual(parseKubectxOutput("my-cluster\n"), ["my-cluster"]);
+  it('handles a single context', () => {
+    assert.deepEqual(parseKubectxOutput('my-cluster\n'), ['my-cluster']);
   });
 });

--- a/src/launcher/mcp/kubernetes.ts
+++ b/src/launcher/mcp/kubernetes.ts
@@ -1,11 +1,11 @@
-import { spawnSync } from "node:child_process";
-import { select } from "@clack/prompts";
-import type { KubernetesConfig } from "../types.js";
-import { handleCancel } from "../cancel.js";
-import type { McpCommand } from "../mcp-command-types.js";
-import { tryLoad } from "../utils.js";
-import { writeDotfile } from "../dotfile.js";
-import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
+import { spawnSync } from 'node:child_process';
+import { select } from '@clack/prompts';
+import type { KubernetesConfig } from '../types.js';
+import { handleCancel } from '../cancel.js';
+import type { McpCommand } from '../mcp-command-types.js';
+import { tryLoad } from '../utils.js';
+import { writeDotfile } from '../dotfile.js';
+import type { ResolvedConfig, LauncherConfig, SkippedMap } from '../types.js';
 
 /**
  * Parses stdout from `kubectx` (no args) into a list of context names.
@@ -13,7 +13,7 @@ import type { ResolvedConfig, LauncherConfig, SkippedMap } from "../types.js";
  */
 export function parseKubectxOutput(stdout: string): string[] {
   return stdout
-    .split("\n")
+    .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 }
@@ -23,22 +23,22 @@ export function parseKubectxOutput(stdout: string): string[] {
  * Throws if kubectx is not found, exits non-zero, or returns no contexts.
  */
 export function loadKubectxContexts(): string[] {
-  const result = spawnSync("kubectx", [], { encoding: "utf8" });
+  const result = spawnSync('kubectx', [], { encoding: 'utf8' });
   if (result.error) {
     throw new Error(
       `Failed to run kubectx: ${result.error.message}\nEnsure kubectx is installed and available on your PATH.`,
     );
   }
   if (result.status !== 0) {
-    const stderr = result.stderr?.trim() ?? "";
+    const stderr = result.stderr?.trim() ?? '';
     throw new Error(
-      `kubectx exited with status ${result.status}${stderr ? `: ${stderr}` : ""}.`,
+      `kubectx exited with status ${result.status}${stderr ? `: ${stderr}` : ''}.`,
     );
   }
-  const contexts = parseKubectxOutput(result.stdout ?? "");
+  const contexts = parseKubectxOutput(result.stdout ?? '');
   if (contexts.length === 0) {
     throw new Error(
-      "No Kubernetes contexts found. Run `kubectl config get-contexts` to check your kubeconfig.",
+      'No Kubernetes contexts found. Run `kubectl config get-contexts` to check your kubeconfig.',
     );
   }
   return contexts;
@@ -50,13 +50,13 @@ export function loadKubectxContexts(): string[] {
  * (e.g., kubectl not installed, no current context set).
  */
 export function getCurrentContext(): string {
-  const result = spawnSync("kubectl", ["config", "current-context"], {
-    encoding: "utf8",
+  const result = spawnSync('kubectl', ['config', 'current-context'], {
+    encoding: 'utf8',
   });
   if (result.error || result.status !== 0) {
-    return "";
+    return '';
   }
-  return result.stdout?.trim() ?? "";
+  return result.stdout?.trim() ?? '';
 }
 
 /**
@@ -68,14 +68,14 @@ export function switchContext(selected: string, previous?: string): void {
   if (selected === previous) {
     return;
   }
-  const result = spawnSync("kubectx", [selected], { encoding: "utf8" });
+  const result = spawnSync('kubectx', [selected], { encoding: 'utf8' });
   if (result.error) {
     throw new Error(`Failed to run kubectx: ${result.error.message}`);
   }
   if (result.status !== 0) {
-    const stderr = result.stderr?.trim() ?? "";
+    const stderr = result.stderr?.trim() ?? '';
     throw new Error(
-      `kubectx exited with status ${result.status} when switching to "${selected}"${stderr ? `: ${stderr}` : ""}.`,
+      `kubectx exited with status ${result.status} when switching to "${selected}"${stderr ? `: ${stderr}` : ''}.`,
     );
   }
 }
@@ -97,7 +97,7 @@ export async function configureKubernetes(
   const options = contexts.map((ctx) => ({ value: ctx, label: ctx }));
 
   const selected = await select({
-    message: "Select Kubernetes context:",
+    message: 'Select Kubernetes context:',
     options,
     initialValue,
   });
@@ -107,19 +107,19 @@ export async function configureKubernetes(
 }
 
 export const kubernetesCommand: McpCommand = {
-  id: "kubernetes",
-  skippedKey: "kubernetes",
+  id: 'kubernetes',
+  skippedKey: 'kubernetes',
   multiselectOption: {
-    value: "kubernetes",
-    label: "Kubernetes",
-    hint: "cluster context",
+    value: 'kubernetes',
+    label: 'Kubernetes',
+    hint: 'cluster context',
   },
 
   async configureInteractive(savedConfig: LauncherConfig): Promise<{
     resolved: Partial<ResolvedConfig>;
     persistable: Partial<LauncherConfig>;
   } | null> {
-    const contexts = tryLoad(() => loadKubectxContexts(), "kubernetes");
+    const contexts = tryLoad(() => loadKubectxContexts(), 'kubernetes');
     if (contexts === null) return null;
     const result = await configureKubernetes(
       contexts,
@@ -143,10 +143,10 @@ export const kubernetesCommand: McpCommand = {
     // Takes higher priority than ~/.kube/config active context, ensuring the
     // selected context is respected even when other kubeconfig env vars
     // (KUBECONFIG, K8S_SERVER, etc.) are present in the environment.
-    env["K8S_CONTEXT"] = context;
+    env['K8S_CONTEXT'] = context;
     // Write dotfile for symmetry with cloudwatch/gcp patterns and potential
     // future use by wrapper scripts or slash commands.
-    writeDotfile("current-kube-context", context);
+    writeDotfile('current-kube-context', context);
   },
 
   buildOutroSuccessLine(resolved: ResolvedConfig): string | null {
@@ -155,16 +155,16 @@ export const kubernetesCommand: McpCommand = {
   },
 
   buildOutroSkipLine(skipped: SkippedMap[keyof SkippedMap]): string | null {
-    if (skipped === "loader-failed")
-      return "Kubernetes: skipped (contexts unavailable)";
-    if (skipped === "switch-failed")
-      return "Kubernetes: skipped (context switch failed)";
+    if (skipped === 'loader-failed')
+      return 'Kubernetes: skipped (contexts unavailable)';
+    if (skipped === 'switch-failed')
+      return 'Kubernetes: skipped (context switch failed)';
     return null;
   },
 
   buildSummaryLine(config: LauncherConfig): string {
     if (config.kubernetes === undefined) {
-      return "Kubernetes: (not yet configured)";
+      return 'Kubernetes: (not yet configured)';
     }
     return `Kubernetes: context ${config.kubernetes.context}`;
   },
@@ -201,7 +201,7 @@ export function applyKubernetesContextSwitch(
         resolved.kubernetes!.context,
         savedConfig.kubernetes?.context,
       ),
-    "kubernetes-switch",
+    'kubernetes-switch',
     `Failed to switch Kubernetes context to "${resolved.kubernetes!.context}" — launching with the previously active context.`,
   );
   const switchFailed = switchResult === null;
@@ -209,7 +209,7 @@ export function applyKubernetesContextSwitch(
     effectiveSkipped: {
       ...skipped,
       kubernetes: switchFailed
-        ? "switch-failed"
+        ? 'switch-failed'
         : (skipped.kubernetes ?? false),
     },
     outroResolved: switchFailed

--- a/src/launcher/outro.test.ts
+++ b/src/launcher/outro.test.ts
@@ -1,134 +1,134 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { buildOutroLines } from "./outro.js";
-import type { ResolvedConfig, SkippedMap } from "./types.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOutroLines } from './outro.js';
+import type { ResolvedConfig, SkippedMap } from './types.js';
 
-describe("buildOutroLines", () => {
-  it("(a) returns four success lines in canonical order when all MCPs are configured and none are skipped", () => {
+describe('buildOutroLines', () => {
+  it('(a) returns four success lines in canonical order when all MCPs are configured and none are skipped', () => {
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
-      cloudwatch: { profile: "my-aws-profile" },
-      gcpObservability: { project: "my-gcp-project" },
-      kubernetes: { context: "prod-us-east" },
+      cloudwatch: { profile: 'my-aws-profile' },
+      gcpObservability: { project: 'my-gcp-project' },
+      kubernetes: { context: 'prod-us-east' },
     };
     const effectiveSkipped: SkippedMap = {};
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "Grafana: Production US-East (viewer)",
-      "CloudWatch: my-aws-profile",
-      "GCP Observability: my-gcp-project",
-      "Kubernetes: prod-us-east",
+      'Grafana: Production US-East (viewer)',
+      'CloudWatch: my-aws-profile',
+      'GCP Observability: my-gcp-project',
+      'Kubernetes: prod-us-east',
     ]);
   });
 
-  it("(b) returns four skip lines in canonical order when all MCPs are skipped via loader failure", () => {
+  it('(b) returns four skip lines in canonical order when all MCPs are skipped via loader failure', () => {
     const resolved: ResolvedConfig = {};
     const effectiveSkipped: SkippedMap = {
-      grafana: "loader-failed",
-      cloudwatch: "loader-failed",
-      gcp: "loader-failed",
-      kubernetes: "loader-failed",
+      grafana: 'loader-failed',
+      cloudwatch: 'loader-failed',
+      gcp: 'loader-failed',
+      kubernetes: 'loader-failed',
     };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "Grafana: skipped (clusters unavailable)",
-      "CloudWatch: skipped (profiles unavailable)",
-      "GCP Observability: skipped (auth unavailable)",
-      "Kubernetes: skipped (contexts unavailable)",
+      'Grafana: skipped (clusters unavailable)',
+      'CloudWatch: skipped (profiles unavailable)',
+      'GCP Observability: skipped (auth unavailable)',
+      'Kubernetes: skipped (contexts unavailable)',
     ]);
   });
 
-  it("(c) returns only the Kubernetes skip line when only Kubernetes is skipped via loader failure", () => {
+  it('(c) returns only the Kubernetes skip line when only Kubernetes is skipped via loader failure', () => {
     const resolved: ResolvedConfig = {};
-    const effectiveSkipped: SkippedMap = { kubernetes: "loader-failed" };
+    const effectiveSkipped: SkippedMap = { kubernetes: 'loader-failed' };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "Kubernetes: skipped (contexts unavailable)",
+      'Kubernetes: skipped (contexts unavailable)',
     ]);
   });
 
-  it("(d) emits only the switch-failed skip line even when resolved.kubernetes is set (regression test for F-1)", () => {
+  it('(d) emits only the switch-failed skip line even when resolved.kubernetes is set (regression test for F-1)', () => {
     const resolved: ResolvedConfig = {
-      kubernetes: { context: "prod-us-east" },
+      kubernetes: { context: 'prod-us-east' },
     };
-    const effectiveSkipped: SkippedMap = { kubernetes: "switch-failed" };
+    const effectiveSkipped: SkippedMap = { kubernetes: 'switch-failed' };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "Kubernetes: skipped (context switch failed)",
+      'Kubernetes: skipped (context switch failed)',
     ]);
     // Critically: no success line for the set kubernetes context must appear.
     assert.ok(
-      !lines.some((l) => l.startsWith("Kubernetes: prod-us-east")),
-      "must not emit a success line alongside the skip line",
+      !lines.some((l) => l.startsWith('Kubernetes: prod-us-east')),
+      'must not emit a success line alongside the skip line',
     );
   });
 
-  it("(e) emits all success lines first then all skip lines, both in canonical MCP order", () => {
+  it('(e) emits all success lines first then all skip lines, both in canonical MCP order', () => {
     // buildOutroLines emits all success lines first (canonical order), then all
     // skip lines (same canonical order). CloudWatch has no resolved value here
     // so it only appears as a skip line — after the three success lines.
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
-      gcpObservability: { project: "my-gcp-project" },
-      kubernetes: { context: "prod-us-east" },
+      gcpObservability: { project: 'my-gcp-project' },
+      kubernetes: { context: 'prod-us-east' },
     };
-    const effectiveSkipped: SkippedMap = { cloudwatch: "loader-failed" };
+    const effectiveSkipped: SkippedMap = { cloudwatch: 'loader-failed' };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "Grafana: Production US-East (viewer)",
-      "GCP Observability: my-gcp-project",
-      "Kubernetes: prod-us-east",
-      "CloudWatch: skipped (profiles unavailable)",
+      'Grafana: Production US-East (viewer)',
+      'GCP Observability: my-gcp-project',
+      'Kubernetes: prod-us-east',
+      'CloudWatch: skipped (profiles unavailable)',
     ]);
   });
 
-  it("(e2) success lines precede skip lines even when the skipped MCP ranks before the resolved one in canonical order", () => {
+  it('(e2) success lines precede skip lines even when the skipped MCP ranks before the resolved one in canonical order', () => {
     // Grafana is skipped (1st in canonical order); CloudWatch resolves (2nd).
     // "All-successes-first" → ["CloudWatch: ...", "Grafana: skipped (...)"].
     // "Per-MCP-interleaved" would produce the opposite: ["Grafana: skipped...", "CloudWatch: ..."].
     // This test distinguishes the two models.
     const resolved: ResolvedConfig = {
-      cloudwatch: { profile: "my-aws-profile" },
+      cloudwatch: { profile: 'my-aws-profile' },
     };
-    const effectiveSkipped: SkippedMap = { grafana: "loader-failed" };
+    const effectiveSkipped: SkippedMap = { grafana: 'loader-failed' };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
     assert.deepStrictEqual(lines, [
-      "CloudWatch: my-aws-profile",
-      "Grafana: skipped (clusters unavailable)",
+      'CloudWatch: my-aws-profile',
+      'Grafana: skipped (clusters unavailable)',
     ]);
   });
 
-  it("(f) returns empty array when no MCPs are configured and none are skipped", () => {
+  it('(f) returns empty array when no MCPs are configured and none are skipped', () => {
     const resolved: ResolvedConfig = {};
     const effectiveSkipped: SkippedMap = {};
 
@@ -139,25 +139,25 @@ describe("buildOutroLines", () => {
     assert.deepStrictEqual(lines, []);
   });
 
-  it("(g) renders success line when effectiveSkipped.<mcp> is false", () => {
+  it('(g) renders success line when effectiveSkipped.<mcp> is false', () => {
     // effectiveSkipped.grafana === false must NOT suppress the success line.
     // Only truthy discriminants suppress the success line.
     const resolved: ResolvedConfig = {
       grafana: {
         cluster: {
-          id: "prod-us-east",
-          name: "Production US-East",
-          url: "https://grafana.prod.example.com",
-          viewer_token: "viewer-token",
-          editor_token: "editor-token",
+          id: 'prod-us-east',
+          name: 'Production US-East',
+          url: 'https://grafana.prod.example.com',
+          viewer_token: 'viewer-token',
+          editor_token: 'editor-token',
         },
-        role: "viewer",
+        role: 'viewer',
       },
     };
     const effectiveSkipped: SkippedMap = { grafana: false };
 
     const lines = buildOutroLines(resolved, effectiveSkipped);
 
-    assert.deepStrictEqual(lines, ["Grafana: Production US-East (viewer)"]);
+    assert.deepStrictEqual(lines, ['Grafana: Production US-East (viewer)']);
   });
 });

--- a/src/launcher/outro.ts
+++ b/src/launcher/outro.ts
@@ -1,5 +1,5 @@
-import type { ResolvedConfig, SkippedMap } from "./types.js";
-import { registry } from "./mcp-command.js";
+import type { ResolvedConfig, SkippedMap } from './types.js';
+import { registry } from './mcp-command.js';
 
 export function buildOutroLines(
   resolved: ResolvedConfig,

--- a/src/launcher/prompts.ts
+++ b/src/launcher/prompts.ts
@@ -1,12 +1,12 @@
-import { multiselect } from "@clack/prompts";
-import { registry } from "./mcp-command.js";
-import { handleCancel } from "./cancel.js";
+import { multiselect } from '@clack/prompts';
+import { registry } from './mcp-command.js';
+import { handleCancel } from './cancel.js';
 
 export async function selectMcps(
   previousSelections: string[],
 ): Promise<string[]> {
   const value = await multiselect({
-    message: "Select MCPs to configure for this session:",
+    message: 'Select MCPs to configure for this session:',
     options: registry.map((c) => c.multiselectOption),
     initialValues: previousSelections,
     required: false,

--- a/src/launcher/resolve.test.ts
+++ b/src/launcher/resolve.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, before, after } from "node:test";
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { buildResolvedFromSaved } from "./resolve.js";
-import type { LauncherConfig } from "./types.js";
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { buildResolvedFromSaved } from './resolve.js';
+import type { LauncherConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Temp directory for fixture YAML files
 // ---------------------------------------------------------------------------
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tpk-resolve-test-"));
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-tpk-resolve-test-'));
 
 before(() => {
   // tmpDir already created above via mkdtempSync
@@ -33,7 +33,7 @@ function writeGrafanaFixture(
     editor_token: string;
   }>,
 ): string {
-  const lines = ["clusters:"];
+  const lines = ['clusters:'];
   for (const c of clusters) {
     lines.push(`  - id: "${c.id}"`);
     lines.push(`    name: "${c.name}"`);
@@ -42,82 +42,82 @@ function writeGrafanaFixture(
     lines.push(`    editor_token: "${c.editor_token}"`);
   }
   const filePath = path.join(tmpDir, `grafana-${Date.now()}.yaml`);
-  fs.writeFileSync(filePath, lines.join("\n"), {
+  fs.writeFileSync(filePath, lines.join('\n'), {
     mode: 0o600,
-    encoding: "utf8",
+    encoding: 'utf8',
   });
   return filePath;
 }
 
 const fakeCluster = {
-  id: "prod-eu",
-  name: "Production EU",
-  url: "https://grafana.prod-eu.example.com",
-  viewer_token: "viewer-tok-abc",
-  editor_token: "editor-tok-xyz",
+  id: 'prod-eu',
+  name: 'Production EU',
+  url: 'https://grafana.prod-eu.example.com',
+  viewer_token: 'viewer-tok-abc',
+  editor_token: 'editor-tok-xyz',
 };
 
 // ---------------------------------------------------------------------------
 // buildResolvedFromSaved
 // ---------------------------------------------------------------------------
 
-describe("buildResolvedFromSaved", () => {
-  it("returns {} when selectedMcps is empty", () => {
+describe('buildResolvedFromSaved', () => {
+  it('returns {} when selectedMcps is empty', () => {
     const config: LauncherConfig = { selectedMcps: [] };
     const result = buildResolvedFromSaved(config);
     assert.deepStrictEqual(result, {});
   });
 
-  it("returns { cloudwatch: { profile } } for cloudwatch-only config", () => {
+  it('returns { cloudwatch: { profile } } for cloudwatch-only config', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch"],
-      cloudwatch: { profile: "my-profile" },
+      selectedMcps: ['cloudwatch'],
+      cloudwatch: { profile: 'my-profile' },
     };
     const result = buildResolvedFromSaved(config);
-    assert.deepStrictEqual(result, { cloudwatch: { profile: "my-profile" } });
+    assert.deepStrictEqual(result, { cloudwatch: { profile: 'my-profile' } });
   });
 
-  it("returns { gcpObservability: { project } } for gcp-only config", () => {
+  it('returns { gcpObservability: { project } } for gcp-only config', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["gcp-observability"],
-      gcpObservability: { project: "my-gcp-project" },
-    };
-    const result = buildResolvedFromSaved(config);
-    assert.deepStrictEqual(result, {
-      gcpObservability: { project: "my-gcp-project" },
-    });
-  });
-
-  it("returns { kubernetes: { context } } for kubernetes-only config", () => {
-    const config: LauncherConfig = {
-      selectedMcps: ["kubernetes"],
-      kubernetes: { context: "staging-cluster" },
+      selectedMcps: ['gcp-observability'],
+      gcpObservability: { project: 'my-gcp-project' },
     };
     const result = buildResolvedFromSaved(config);
     assert.deepStrictEqual(result, {
-      kubernetes: { context: "staging-cluster" },
+      gcpObservability: { project: 'my-gcp-project' },
     });
   });
 
-  it("skips MCPs whose config sub-object is missing", () => {
+  it('returns { kubernetes: { context } } for kubernetes-only config', () => {
+    const config: LauncherConfig = {
+      selectedMcps: ['kubernetes'],
+      kubernetes: { context: 'staging-cluster' },
+    };
+    const result = buildResolvedFromSaved(config);
+    assert.deepStrictEqual(result, {
+      kubernetes: { context: 'staging-cluster' },
+    });
+  });
+
+  it('skips MCPs whose config sub-object is missing', () => {
     const config: LauncherConfig = {
       // cloudwatch in selectedMcps but no cloudwatch sub-object
-      selectedMcps: ["cloudwatch", "kubernetes"],
-      kubernetes: { context: "dev-cluster" },
+      selectedMcps: ['cloudwatch', 'kubernetes'],
+      kubernetes: { context: 'dev-cluster' },
     };
     const result = buildResolvedFromSaved(config);
     // cloudwatch skipped, kubernetes included
-    assert.deepStrictEqual(result, { kubernetes: { context: "dev-cluster" } });
+    assert.deepStrictEqual(result, { kubernetes: { context: 'dev-cluster' } });
   });
 
-  it("returns correct ResolvedConfig with grafana cluster when cluster is found in fixture", () => {
+  it('returns correct ResolvedConfig with grafana cluster when cluster is found in fixture', () => {
     const fixturePath = writeGrafanaFixture([fakeCluster]);
     const config: LauncherConfig = {
-      selectedMcps: ["grafana"],
-      grafana: { clusterId: "prod-eu", role: "viewer" },
+      selectedMcps: ['grafana'],
+      grafana: { clusterId: 'prod-eu', role: 'viewer' },
     };
     const result = buildResolvedFromSaved(config, fixturePath);
-    assert.ok(result !== null, "expected non-null result");
+    assert.ok(result !== null, 'expected non-null result');
     assert.deepStrictEqual(result!.grafana, {
       cluster: {
         id: fakeCluster.id,
@@ -126,42 +126,42 @@ describe("buildResolvedFromSaved", () => {
         viewer_token: fakeCluster.viewer_token,
         editor_token: fakeCluster.editor_token,
       },
-      role: "viewer",
+      role: 'viewer',
     });
   });
 
-  it("returns null when grafana cluster ID is not in fixture (stale ID)", () => {
+  it('returns null when grafana cluster ID is not in fixture (stale ID)', () => {
     const fixturePath = writeGrafanaFixture([fakeCluster]);
     const config: LauncherConfig = {
-      selectedMcps: ["grafana"],
-      grafana: { clusterId: "stale-cluster-id", role: "viewer" },
+      selectedMcps: ['grafana'],
+      grafana: { clusterId: 'stale-cluster-id', role: 'viewer' },
     };
     const result = buildResolvedFromSaved(config, fixturePath);
     assert.strictEqual(result, null);
   });
 
-  it("returns null when grafana YAML fixture file does not exist", () => {
-    const missingPath = path.join(tmpDir, "nonexistent-grafana.yaml");
+  it('returns null when grafana YAML fixture file does not exist', () => {
+    const missingPath = path.join(tmpDir, 'nonexistent-grafana.yaml');
     const config: LauncherConfig = {
-      selectedMcps: ["grafana"],
-      grafana: { clusterId: "prod-eu", role: "editor" },
+      selectedMcps: ['grafana'],
+      grafana: { clusterId: 'prod-eu', role: 'editor' },
     };
     const result = buildResolvedFromSaved(config, missingPath);
     assert.strictEqual(result, null);
   });
 
-  it("combines multiple MCPs in a single resolved config", () => {
+  it('combines multiple MCPs in a single resolved config', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch", "gcp-observability", "kubernetes"],
-      cloudwatch: { profile: "prod" },
-      gcpObservability: { project: "gcp-prod" },
-      kubernetes: { context: "prod-cluster" },
+      selectedMcps: ['cloudwatch', 'gcp-observability', 'kubernetes'],
+      cloudwatch: { profile: 'prod' },
+      gcpObservability: { project: 'gcp-prod' },
+      kubernetes: { context: 'prod-cluster' },
     };
     const result = buildResolvedFromSaved(config);
     assert.deepStrictEqual(result, {
-      cloudwatch: { profile: "prod" },
-      gcpObservability: { project: "gcp-prod" },
-      kubernetes: { context: "prod-cluster" },
+      cloudwatch: { profile: 'prod' },
+      gcpObservability: { project: 'gcp-prod' },
+      kubernetes: { context: 'prod-cluster' },
     });
   });
 });

--- a/src/launcher/resolve.ts
+++ b/src/launcher/resolve.ts
@@ -1,5 +1,5 @@
-import type { ResolvedConfig, LauncherConfig } from "./types.js";
-import { registry, StaleResourceError } from "./mcp-command.js";
+import type { ResolvedConfig, LauncherConfig } from './types.js';
+import { registry, StaleResourceError } from './mcp-command.js';
 
 export function buildResolvedFromSaved(
   config: LauncherConfig,

--- a/src/launcher/summary.test.ts
+++ b/src/launcher/summary.test.ts
@@ -1,136 +1,136 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { formatSummaryLines } from "./summary.js";
-import type { LauncherConfig } from "./types.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatSummaryLines } from './summary.js';
+import type { LauncherConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
 // formatSummaryLines
 // ---------------------------------------------------------------------------
 
-describe("formatSummaryLines", () => {
+describe('formatSummaryLines', () => {
   it("returns ['No MCPs configured.'] when selectedMcps is empty", () => {
     const config: LauncherConfig = { selectedMcps: [] };
-    assert.deepStrictEqual(formatSummaryLines(config), ["No MCPs configured."]);
+    assert.deepStrictEqual(formatSummaryLines(config), ['No MCPs configured.']);
   });
 
-  it("returns correct line for cloudwatch with profile", () => {
+  it('returns correct line for cloudwatch with profile', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch"],
-      cloudwatch: { profile: "prod" },
+      selectedMcps: ['cloudwatch'],
+      cloudwatch: { profile: 'prod' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "CloudWatch: profile prod",
+      'CloudWatch: profile prod',
     ]);
   });
 
-  it("returns correct line for grafana with clusterId and role", () => {
+  it('returns correct line for grafana with clusterId and role', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["grafana"],
-      grafana: { clusterId: "prod-eu", role: "viewer" },
+      selectedMcps: ['grafana'],
+      grafana: { clusterId: 'prod-eu', role: 'viewer' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "Grafana: cluster prod-eu, role viewer",
+      'Grafana: cluster prod-eu, role viewer',
     ]);
   });
 
-  it("returns correct line for gcp-observability with project", () => {
+  it('returns correct line for gcp-observability with project', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["gcp-observability"],
-      gcpObservability: { project: "my-project" },
+      selectedMcps: ['gcp-observability'],
+      gcpObservability: { project: 'my-project' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "GCP Observability: project my-project",
+      'GCP Observability: project my-project',
     ]);
   });
 
-  it("returns correct line for kubernetes with context", () => {
+  it('returns correct line for kubernetes with context', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["kubernetes"],
-      kubernetes: { context: "staging-cluster" },
+      selectedMcps: ['kubernetes'],
+      kubernetes: { context: 'staging-cluster' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "Kubernetes: context staging-cluster",
+      'Kubernetes: context staging-cluster',
     ]);
   });
 
-  it("returns one line per MCP in order when multiple MCPs are selected", () => {
+  it('returns one line per MCP in order when multiple MCPs are selected', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch", "kubernetes"],
-      cloudwatch: { profile: "dev" },
-      kubernetes: { context: "dev-cluster" },
+      selectedMcps: ['cloudwatch', 'kubernetes'],
+      cloudwatch: { profile: 'dev' },
+      kubernetes: { context: 'dev-cluster' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "CloudWatch: profile dev",
-      "Kubernetes: context dev-cluster",
+      'CloudWatch: profile dev',
+      'Kubernetes: context dev-cluster',
     ]);
   });
 
   it("returns '(not yet configured)' when grafana is in selectedMcps but sub-object is missing", () => {
-    const config: LauncherConfig = { selectedMcps: ["grafana"] };
+    const config: LauncherConfig = { selectedMcps: ['grafana'] };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "Grafana: (not yet configured)",
+      'Grafana: (not yet configured)',
     ]);
   });
 
   it("returns '(not yet configured)' when cloudwatch is in selectedMcps but sub-object is missing", () => {
-    const config: LauncherConfig = { selectedMcps: ["cloudwatch"] };
+    const config: LauncherConfig = { selectedMcps: ['cloudwatch'] };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "CloudWatch: (not yet configured)",
+      'CloudWatch: (not yet configured)',
     ]);
   });
 
   it("returns '(not yet configured)' when gcp-observability is in selectedMcps but sub-object is missing", () => {
-    const config: LauncherConfig = { selectedMcps: ["gcp-observability"] };
+    const config: LauncherConfig = { selectedMcps: ['gcp-observability'] };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "GCP Observability: (not yet configured)",
+      'GCP Observability: (not yet configured)',
     ]);
   });
 
   it("returns '(not yet configured)' when kubernetes is in selectedMcps but sub-object is missing", () => {
-    const config: LauncherConfig = { selectedMcps: ["kubernetes"] };
+    const config: LauncherConfig = { selectedMcps: ['kubernetes'] };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "Kubernetes: (not yet configured)",
+      'Kubernetes: (not yet configured)',
     ]);
   });
 
-  it("returns four correct lines when all four MCPs are configured", () => {
+  it('returns four correct lines when all four MCPs are configured', () => {
     const config: LauncherConfig = {
       selectedMcps: [
-        "grafana",
-        "cloudwatch",
-        "gcp-observability",
-        "kubernetes",
+        'grafana',
+        'cloudwatch',
+        'gcp-observability',
+        'kubernetes',
       ],
-      grafana: { clusterId: "prod-us", role: "editor" },
-      cloudwatch: { profile: "prod" },
-      gcpObservability: { project: "gcp-prod" },
-      kubernetes: { context: "prod-cluster" },
+      grafana: { clusterId: 'prod-us', role: 'editor' },
+      cloudwatch: { profile: 'prod' },
+      gcpObservability: { project: 'gcp-prod' },
+      kubernetes: { context: 'prod-cluster' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "Grafana: cluster prod-us, role editor",
-      "CloudWatch: profile prod",
-      "GCP Observability: project gcp-prod",
-      "Kubernetes: context prod-cluster",
+      'Grafana: cluster prod-us, role editor',
+      'CloudWatch: profile prod',
+      'GCP Observability: project gcp-prod',
+      'Kubernetes: context prod-cluster',
     ]);
   });
 
   it("returns '<name>: (unknown MCP)' for an unknown MCP name", () => {
-    const config: LauncherConfig = { selectedMcps: ["future-mcp"] };
+    const config: LauncherConfig = { selectedMcps: ['future-mcp'] };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "future-mcp: (unknown MCP)",
+      'future-mcp: (unknown MCP)',
     ]);
   });
 
-  it("handles a mix of known and unknown MCP names correctly", () => {
+  it('handles a mix of known and unknown MCP names correctly', () => {
     const config: LauncherConfig = {
-      selectedMcps: ["cloudwatch", "future-mcp", "kubernetes"],
-      cloudwatch: { profile: "staging" },
-      kubernetes: { context: "staging-cluster" },
+      selectedMcps: ['cloudwatch', 'future-mcp', 'kubernetes'],
+      cloudwatch: { profile: 'staging' },
+      kubernetes: { context: 'staging-cluster' },
     };
     assert.deepStrictEqual(formatSummaryLines(config), [
-      "CloudWatch: profile staging",
-      "future-mcp: (unknown MCP)",
-      "Kubernetes: context staging-cluster",
+      'CloudWatch: profile staging',
+      'future-mcp: (unknown MCP)',
+      'Kubernetes: context staging-cluster',
     ]);
   });
 });

--- a/src/launcher/summary.ts
+++ b/src/launcher/summary.ts
@@ -1,11 +1,11 @@
-import { note, select } from "@clack/prompts";
-import { handleCancel } from "./cancel.js";
-import type { LauncherConfig } from "./types.js";
-import { registry } from "./mcp-command.js";
+import { note, select } from '@clack/prompts';
+import { handleCancel } from './cancel.js';
+import type { LauncherConfig } from './types.js';
+import { registry } from './mcp-command.js';
 
 export function formatSummaryLines(config: LauncherConfig): string[] {
   if (config.selectedMcps.length === 0) {
-    return ["No MCPs configured."];
+    return ['No MCPs configured.'];
   }
 
   return config.selectedMcps.map((name) => {
@@ -17,21 +17,21 @@ export function formatSummaryLines(config: LauncherConfig): string[] {
 
 export async function promptSummaryAction(
   config: LauncherConfig,
-): Promise<"launch" | "configure"> {
+): Promise<'launch' | 'configure'> {
   const lines = formatSummaryLines(config);
-  note(lines.join("\n"), "Current Configuration");
+  note(lines.join('\n'), 'Current Configuration');
   const result = await select({
-    message: "What would you like to do?",
+    message: 'What would you like to do?',
     options: [
       {
-        value: "launch",
-        label: "Launch",
-        hint: "start Claude with current config",
+        value: 'launch',
+        label: 'Launch',
+        hint: 'start Claude with current config',
       },
-      { value: "configure", label: "Configure", hint: "change MCP settings" },
+      { value: 'configure', label: 'Configure', hint: 'change MCP settings' },
     ],
-    initialValue: "launch",
+    initialValue: 'launch',
   });
   handleCancel(result);
-  return result as "launch" | "configure";
+  return result as 'launch' | 'configure';
 }

--- a/src/launcher/types.ts
+++ b/src/launcher/types.ts
@@ -1,4 +1,4 @@
-export type GrafanaRole = "viewer" | "editor";
+export type GrafanaRole = 'viewer' | 'editor';
 
 export interface GrafanaCluster {
   id: string;
@@ -44,11 +44,11 @@ export interface ResolvedConfig {
 }
 
 export type SkippedMap = {
-  grafana?: false | "loader-failed";
-  cloudwatch?: false | "loader-failed";
-  gcp?: false | "loader-failed";
-  kubernetes?: false | "loader-failed" | "switch-failed";
-  argocd?: false | "loader-failed";
+  grafana?: false | 'loader-failed';
+  cloudwatch?: false | 'loader-failed';
+  gcp?: false | 'loader-failed';
+  kubernetes?: false | 'loader-failed' | 'switch-failed';
+  argocd?: false | 'loader-failed';
 };
 
 export interface LauncherConfig {

--- a/src/launcher/utils.test.ts
+++ b/src/launcher/utils.test.ts
@@ -1,84 +1,84 @@
-import { describe, it, mock } from "node:test";
-import assert from "node:assert/strict";
-import { log } from "@clack/prompts";
-import { errorMessage, tryLoad } from "./utils.js";
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { log } from '@clack/prompts';
+import { errorMessage, tryLoad } from './utils.js';
 
-describe("errorMessage", () => {
-  it("returns the message property when given an Error instance", () => {
-    assert.strictEqual(errorMessage(new Error("boom")), "boom");
+describe('errorMessage', () => {
+  it('returns the message property when given an Error instance', () => {
+    assert.strictEqual(errorMessage(new Error('boom')), 'boom');
   });
 
-  it("returns the string itself when given a plain string", () => {
+  it('returns the string itself when given a plain string', () => {
     assert.strictEqual(
-      errorMessage("something went wrong"),
-      "something went wrong",
+      errorMessage('something went wrong'),
+      'something went wrong',
     );
   });
 
-  it("returns a string representation when given a number", () => {
-    assert.strictEqual(errorMessage(42), "42");
+  it('returns a string representation when given a number', () => {
+    assert.strictEqual(errorMessage(42), '42');
   });
 
   it("returns 'null' when given null", () => {
-    assert.strictEqual(errorMessage(null), "null");
+    assert.strictEqual(errorMessage(null), 'null');
   });
 
   it("returns 'undefined' when given undefined", () => {
-    assert.strictEqual(errorMessage(undefined), "undefined");
+    assert.strictEqual(errorMessage(undefined), 'undefined');
   });
 });
 
-describe("tryLoad", () => {
-  it("returns the callback result and emits no warning on success", (t) => {
-    const warnMock = mock.method(log, "warn", () => {});
+describe('tryLoad', () => {
+  it('returns the callback result and emits no warning on success', (t) => {
+    const warnMock = mock.method(log, 'warn', () => {});
     t.after(() => warnMock.mock.restore());
 
-    const result = tryLoad(() => 42, "test-label");
+    const result = tryLoad(() => 42, 'test-label');
 
     assert.strictEqual(result, 42);
     assert.strictEqual(warnMock.mock.calls.length, 0);
   });
 
-  it("returns null and emits the default warning on failure", (t) => {
-    const warnMock = mock.method(log, "warn", () => {});
+  it('returns null and emits the default warning on failure', (t) => {
+    const warnMock = mock.method(log, 'warn', () => {});
     t.after(() => warnMock.mock.restore());
 
     const result = tryLoad(() => {
-      throw new Error("boom");
-    }, "test-label");
+      throw new Error('boom');
+    }, 'test-label');
 
     assert.strictEqual(result, null);
     assert.strictEqual(warnMock.mock.calls.length, 1);
     assert.strictEqual(
       warnMock.mock.calls[0].arguments[0],
-      "[test-label] boom",
+      '[test-label] boom',
     );
   });
 
-  it("emits the custom warning (not the default) when warningMessage is provided", (t) => {
-    const warnMock = mock.method(log, "warn", () => {});
+  it('emits the custom warning (not the default) when warningMessage is provided', (t) => {
+    const warnMock = mock.method(log, 'warn', () => {});
     t.after(() => warnMock.mock.restore());
 
     const result = tryLoad(
       () => {
-        throw new Error("boom");
+        throw new Error('boom');
       },
-      "test-label",
-      "custom message",
+      'test-label',
+      'custom message',
     );
 
     assert.strictEqual(result, null);
     assert.strictEqual(warnMock.mock.calls.length, 1);
-    assert.strictEqual(warnMock.mock.calls[0].arguments[0], "custom message");
+    assert.strictEqual(warnMock.mock.calls[0].arguments[0], 'custom message');
   });
 
-  it("returns the value and emits no warning on success even when warningMessage is supplied", (t) => {
-    const warnMock = mock.method(log, "warn", () => {});
+  it('returns the value and emits no warning on success even when warningMessage is supplied', (t) => {
+    const warnMock = mock.method(log, 'warn', () => {});
     t.after(() => warnMock.mock.restore());
 
-    const result = tryLoad(() => "hello", "test-label", "should not appear");
+    const result = tryLoad(() => 'hello', 'test-label', 'should not appear');
 
-    assert.strictEqual(result, "hello");
+    assert.strictEqual(result, 'hello');
     assert.strictEqual(warnMock.mock.calls.length, 0);
   });
 });

--- a/src/launcher/utils.ts
+++ b/src/launcher/utils.ts
@@ -1,4 +1,4 @@
-import { log } from "@clack/prompts";
+import { log } from '@clack/prompts';
 
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Editors and IDEs that lack shared configuration silently apply their own indent style, line-ending, and charset defaults, causing noisy diffs and inconsistency across contributor machines. This PR adds an `.editorconfig` file at the repo root to standardise those settings (2-space indent, LF line endings, UTF-8, trim trailing whitespace, insert final newline) for any editor that respects the EditorConfig standard.

The `.oxfmtrc.json` formatter configuration was updated to enforce single quotes in TypeScript and JavaScript files, aligning the formatter output with the EditorConfig-declared style and eliminating quote-style churn in diffs going forward. As a result, all 50 source files under `src/` were reformatted in a single mechanical pass — git blame on those files will point to this commit, which is worth noting before bisecting through that history.

The installation guide (`docs/INSTALLATION.md`) was updated to mention `.editorconfig` alongside the linting and formatting toolchain documentation.