### PR TITLE
feat(shell): add ShellCheck linting and shfmt formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
       - name: Format check
         run: pnpm run format:check
 
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Install shfmt
+        run: curl -sSfL https://raw.githubusercontent.com/mvdan/sh/master/install.sh | sh -s -- -b /usr/local/bin v3.8.0
+
+      - name: Lint shell
+        run: pnpm run lint:sh
+
+      - name: Format check shell
+        run: pnpm run format:check:sh
+
       - name: Build
         run: pnpm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
       - name: Install shfmt
-        run: curl -sSfL https://raw.githubusercontent.com/mvdan/sh/master/install.sh | sh -s -- -b /usr/local/bin v3.8.0
+        run: curl -sSfL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
 
       - name: Lint shell
         run: pnpm run lint:sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# Project-wide ShellCheck configuration.
+# external-sources=true: resolves SC1091 for scripts that source external files
+# (e.g. tab-rename-stop.sh sources lib-tab-rename.sh).
+external-sources=true
+# source-path=SCRIPTDIR: tells ShellCheck to look for sourced files relative to
+# the directory of the script being analysed, so `source ./lib-tab-rename.sh`
+# resolves correctly when shellcheck is invoked from the repo root.
+source-path=SCRIPTDIR

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When modifying agents, skills, commands, hooks, references, CLAUDE.md, or settin
 
 ## Documentation
 
-- [docs/INSTALLATION.md](/docs/INSTALLATION.md) — Install lifecycle: clone, run install.sh, set up a dev environment, update, recover and clean backups, clean agent artifacts.
+- [docs/INSTALLATION.md](/docs/INSTALLATION.md) — Install lifecycle: clone, run install.sh, set up a dev environment (including JS and shell tooling), update, recover and clean backups, clean agent artifacts.
 - [docs/DEMO.md](/docs/DEMO.md) — A short, screenshot-driven tour of what an AI TPK session looks like in practice.
 - [docs/HOOKS.md](/docs/HOOKS.md) — Settings, marketplaces, and the four Claude Code hooks (PermissionRequest, SessionStart, SubagentStop, Stop).
 - [docs/INSTRUCTIONS.md](/docs/INSTRUCTIONS.md) — How user-global (`claude/CLAUDE.md`) and project-level (`.claude/CLAUDE.md`) instructions interact.

--- a/claude/hooks/permission-learn.sh
+++ b/claude/hooks/permission-learn.sh
@@ -28,15 +28,15 @@ COMMAND=$(echo "$STDIN_DATA" | jq -r '.tool_input.command // ""' 2>/dev/null)
 is_allowed_claude_read_path() {
   local p="$1"
   case "$p" in
-    "$HOME/.claude/agents/"*)   return 0 ;;
-    "$HOME/.claude/skills/"*)   return 0 ;;
+    "$HOME/.claude/agents/"*) return 0 ;;
+    "$HOME/.claude/skills/"*) return 0 ;;
     "$HOME/.claude/references/"*) return 0 ;;
     "$HOME/.claude/commands/"*) return 0 ;;
-    "$HOME/.claude/hooks/"*)    return 0 ;;
+    "$HOME/.claude/hooks/"*) return 0 ;;
     "$HOME/.claude/wrappers/"*) return 0 ;;
     "$HOME/.claude/settings.json") return 0 ;;
-    "$HOME/.claude/CLAUDE.md")  return 0 ;;
-    *)                          return 1 ;;
+    "$HOME/.claude/CLAUDE.md") return 0 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -76,7 +76,7 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "
       LOG_LABEL="write_path"
       if [ "$TOOL_NAME" = "Read" ]; then LOG_LABEL="read_path"; fi
       printf '%s | agent_type=%s | agent_id=%s | [auto-approved] %s=%s\n' \
-        "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$LOG_LABEL" "$NORMALIZED" >> "$LOG_FILE"
+        "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$LOG_LABEL" "$NORMALIZED" >>"$LOG_FILE"
       jq -n '{
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
@@ -99,10 +99,10 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "
       if [ -L "$NORMALIZED" ]; then
         RESOLVED=$(readlink -f "$NORMALIZED" 2>/dev/null)
         if [ -z "$RESOLVED" ]; then
-          exit 0  # readlink failed — fall through to manual approval
+          exit 0 # readlink failed — fall through to manual approval
         fi
         if ! is_allowed_claude_read_path "$RESOLVED"; then
-          exit 0  # Symlink target is outside allowed prefixes — fall through
+          exit 0 # Symlink target is outside allowed prefixes — fall through
         fi
       fi
       TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -110,7 +110,7 @@ if [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "
       AGENT_ID=$(echo "$STDIN_DATA" | jq -r '.agent_id // "none"' 2>/dev/null)
       AGENT_TYPE=$(echo "$STDIN_DATA" | jq -r '.agent_type // "none"' 2>/dev/null)
       printf '%s | agent_type=%s | agent_id=%s | [auto-approved] read_path=%s\n' \
-        "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$NORMALIZED" >> "$LOG_FILE"
+        "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$NORMALIZED" >>"$LOG_FILE"
       jq -n '{
         hookSpecificOutput: {
           hookEventName: "PermissionRequest",
@@ -154,27 +154,27 @@ SECURITY_STRIPPED=$(printf '%s' "$COMMAND" | sed "s/'[^']*'//g")
 matches_allowed_tools() {
   local cmd="$1"
   case "$cmd" in
-    git\ *)              return 0 ;;
-    gh\ pr\ *)           return 0 ;;
-    gh\ issue\ *)        return 0 ;;
-    gh\ run\ *)          return 0 ;;
-    gh\ repo\ view\ *)   return 0 ;;
-    gh\ repo\ clone\ *)  return 0 ;;
+    git\ *) return 0 ;;
+    gh\ pr\ *) return 0 ;;
+    gh\ issue\ *) return 0 ;;
+    gh\ run\ *) return 0 ;;
+    gh\ repo\ view\ *) return 0 ;;
+    gh\ repo\ clone\ *) return 0 ;;
     gh\ release\ view\ *) return 0 ;;
     gh\ auth\ switch\ *) return 0 ;;
-    mkdir\ *)            return 0 ;;
-    rm\ *)               return 0 ;;
-    cp\ *)               return 0 ;;
-    mv\ *)               return 0 ;;
-    touch\ *)            return 0 ;;
-    ls\ *)               return 0 ;;
-    cd\ *)               return 0 ;;
-    npm\ *)              return 0 ;;
-    npx\ *)              return 0 ;;
-    pnpm\ *)             return 0 ;;
-    yarn\ *)             return 0 ;;
-    python\ *)           return 0 ;;
-    python3\ *)          return 0 ;;
+    mkdir\ *) return 0 ;;
+    rm\ *) return 0 ;;
+    cp\ *) return 0 ;;
+    mv\ *) return 0 ;;
+    touch\ *) return 0 ;;
+    ls\ *) return 0 ;;
+    cd\ *) return 0 ;;
+    npm\ *) return 0 ;;
+    npx\ *) return 0 ;;
+    pnpm\ *) return 0 ;;
+    yarn\ *) return 0 ;;
+    python\ *) return 0 ;;
+    python3\ *) return 0 ;;
     bash\ /home/placeholder/.claude/scripts/*.sh)
       # Guard: reject path traversal (.. component)
       [[ "$cmd" == */../* || "$cmd" == */.. ]] && return 1
@@ -190,9 +190,10 @@ matches_allowed_tools() {
       _script_path="${_script_path//\/home\/placeholder\//$HOME/}"
       _real="$(readlink -f "$_script_path" 2>/dev/null)" || return 1
       [[ "$_real" == "$HOME/.claude/scripts/"* ]] || return 1
-      _rel_real="${_real#$HOME/.claude/scripts/}"
+      _rel_real="${_real#"$HOME"/.claude/scripts/}"
       [[ "$_rel_real" == */* ]] && return 1
-      return 0 ;;
+      return 0
+      ;;
     bash\ /home/placeholder/.claude/scripts/*.sh\ *)
       # Guard: reject path traversal (.. component)
       [[ "$cmd" == */../* || "$cmd" == */.. ]] && return 1
@@ -208,12 +209,13 @@ matches_allowed_tools() {
       _script_path="${_script_path//\/home\/placeholder\//$HOME/}"
       _real="$(readlink -f "$_script_path" 2>/dev/null)" || return 1
       [[ "$_real" == "$HOME/.claude/scripts/"* ]] || return 1
-      _rel_real="${_real#$HOME/.claude/scripts/}"
+      _rel_real="${_real#"$HOME"/.claude/scripts/}"
       [[ "$_rel_real" == */* ]] && return 1
-      return 0 ;;
-    *\ --help)           return 0 ;;
-    *\ --version)        return 0 ;;
-    *)                   return 1 ;;
+      return 0
+      ;;
+    *\ --help) return 0 ;;
+    *\ --version) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -233,6 +235,7 @@ is_simple_expansion_only() {
   fi
 
   # Reject $(...) command substitution
+  # shellcheck disable=SC2016  # '$(' is a literal search pattern, not an expansion
   if printf '%s' "$cmd" | grep -qF '$('; then
     return 1
   fi
@@ -436,7 +439,7 @@ if matches_allowed_tools "$NEUTRALIZED"; then
     TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     LOG_FILE="$HOME/.claude/permission-requests.log"
     printf '%s | agent_type=%s | agent_id=%s | [auto-approved] command=%s\n' \
-      "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >> "$LOG_FILE"
+      "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >>"$LOG_FILE"
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PermissionRequest",
@@ -454,6 +457,6 @@ fi
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 LOG_FILE="$HOME/.claude/permission-requests.log"
 printf '%s | agent_type=%s | agent_id=%s | command=%s\n' \
-  "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >> "$LOG_FILE"
+  "$TIMESTAMP" "$AGENT_TYPE" "$AGENT_ID" "$COMMAND" >>"$LOG_FILE"
 
 exit 0

--- a/claude/hooks/tab-rename-stop.sh
+++ b/claude/hooks/tab-rename-stop.sh
@@ -79,6 +79,7 @@ TITLE=$(claude -p --bare --model haiku \
   --system-prompt "Respond with ONLY 2-5 words. No punctuation, no quotes, no explanation. Generate a short natural-language title summarizing this coding session based on the user's request and the assistant's work." \
   "Project: ${REPO_NAME}, User asked: ${FIRST_PROMPT}, Assistant did: ${LAST_RESPONSE}" \
   </dev/null 2>/dev/null)
+# shellcheck disable=SC2181  # $? intentionally captured after assignment; compound condition requires separate check
 if [ $? -ne 0 ] || [ -z "$TITLE" ]; then
   exit 0
 fi
@@ -92,7 +93,7 @@ fi
 
 # Store title (atomic enough for this use case)
 mkdir -p "$TITLE_DIR"
-printf '%s' "$TITLE" > "$TITLE_FILE"
+printf '%s' "$TITLE" >"$TITLE_FILE"
 
 # Detect terminal and apply title
 _tab_rename_detect_terminal

--- a/claude/hooks/talekeeper-capture.sh
+++ b/claude/hooks/talekeeper-capture.sh
@@ -32,10 +32,10 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Use jq if available, else fall back to a minimal entry
 if command -v jq &>/dev/null; then
-  echo "$STDIN_DATA" | jq -c --arg ts "$TIMESTAMP" '. + {"_captured_at": $ts}' >> "$LOG_FILE" 2>/dev/null
+  echo "$STDIN_DATA" | jq -c --arg ts "$TIMESTAMP" '. + {"_captured_at": $ts}' >>"$LOG_FILE" 2>/dev/null
 else
   # Fallback: write a minimal JSON line with timestamp only
-  printf '{"_captured_at":"%s","_raw_unavailable":true}\n' "$TIMESTAMP" >> "$LOG_FILE" 2>/dev/null
+  printf '{"_captured_at":"%s","_raw_unavailable":true}\n' "$TIMESTAMP" >>"$LOG_FILE" 2>/dev/null
 fi
 
 # Always exit 0 -- logging must never block the session

--- a/claude/hooks/talekeeper-enrich.sh
+++ b/claude/hooks/talekeeper-enrich.sh
@@ -28,7 +28,7 @@ VALID_ENTRIES=$(jq -c 'select(
 
 if [ -z "$VALID_ENTRIES" ]; then
   # No valid entries — still clear the raw log
-  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' > "$RAW_LOG"
+  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' >"$RAW_LOG"
   exit 0
 fi
 
@@ -59,16 +59,12 @@ echo "$VALID_ENTRIES" | while IFS= read -r entry; do
   cache_creation_input_tokens=0
   cache_read_input_tokens=0
 
-  if [ -n "$agent_transcript_path" ]
-  then
-    if [ -f "$agent_transcript_path" ]
-    then
-      file_size=$(wc -c < "$agent_transcript_path" 2>/dev/null || echo "0")
-      if [ "$file_size" -le 52428800 ]
-      then
+  if [ -n "$agent_transcript_path" ]; then
+    if [ -f "$agent_transcript_path" ]; then
+      file_size=$(wc -c <"$agent_transcript_path" 2>/dev/null || echo "0")
+      if [ "$file_size" -le 52428800 ]; then
         token_json=$(jq -s '[.[] | select(.type == "assistant") | .message.usage // {}] | { input_tokens: (map(.input_tokens // 0) | add // 0), output_tokens: (map(.output_tokens // 0) | add // 0), cache_creation_input_tokens: (map(.cache_creation_input_tokens // 0) | add // 0), cache_read_input_tokens: (map(.cache_read_input_tokens // 0) | add // 0) }' "$agent_transcript_path" 2>/dev/null)
-        if [ -n "$token_json" ]
-        then
+        if [ -n "$token_json" ]; then
           input_tokens=$(echo "$token_json" | jq -r '.input_tokens // 0' 2>/dev/null || echo "0")
           output_tokens=$(echo "$token_json" | jq -r '.output_tokens // 0' 2>/dev/null || echo "0")
           cache_creation_input_tokens=$(echo "$token_json" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null || echo "0")
@@ -113,11 +109,11 @@ echo "$VALID_ENTRIES" | while IFS= read -r entry; do
     --argjson cache_read_input_tokens "$cache_read_input_tokens" \
     '{timestamp: $ts, event_type: $event_type, agent_type: $agent_type, agent_id: $agent_id, session_id: $session_id, summary: $summary, verdict: $verdict, agent_transcript_path: $agent_transcript_path, input_tokens: $input_tokens, output_tokens: $output_tokens, cache_creation_input_tokens: $cache_creation_input_tokens, cache_read_input_tokens: $cache_read_input_tokens}'
 
-done >> "$OUTPUT_FILE" 2>/dev/null
+done >>"$OUTPUT_FILE" 2>/dev/null
 
 # Only clear the raw log if output was actually written
 if [ -s "$OUTPUT_FILE" ]; then
-  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' > "$RAW_LOG"
+  truncate -s 0 "$RAW_LOG" 2>/dev/null || printf '' >"$RAW_LOG"
 fi
 
 # Pre-compute token summary for fast-path reads by token-summary.sh
@@ -126,7 +122,7 @@ fi
 if [ -s "$OUTPUT_FILE" ] && command -v jq &>/dev/null; then
   TOKEN_SUMMARY=$(jq -rs '[.[] | select(has("input_tokens"))] | reduce .[] as $r ({input:0,output:0,cw:0,cr:0}; .input += ($r.input_tokens // 0) | .output += ($r.output_tokens // 0) | .cw += ($r.cache_creation_input_tokens // 0) | .cr += ($r.cache_read_input_tokens // 0)) | "\(.input/1000 | floor)k in / \(.output/1000 | floor)k out / \(.cw/1000 | floor)k cache-write / \(.cr/1000 | floor)k cache-read"' "$OUTPUT_FILE" 2>/dev/null || true)
   if [ -n "$TOKEN_SUMMARY" ]; then
-    printf '%s\n' "$TOKEN_SUMMARY" > "$LOG_DIR/latest-token-summary.txt" 2>/dev/null || true
+    printf '%s\n' "$TOKEN_SUMMARY" >"$LOG_DIR/latest-token-summary.txt" 2>/dev/null || true
   fi
 fi
 

--- a/claude/hooks/test-permission-learn.sh
+++ b/claude/hooks/test-permission-learn.sh
@@ -4,6 +4,8 @@
 # Usage: bash claude/hooks/test-permission-learn.sh  (from repo root)
 #        bash test-permission-learn.sh               (from hooks directory)
 # Exits 1 if any test fails.
+# shellcheck disable=SC2016  # Single-quoted strings are intentional test payloads — $ must not expand
+# shellcheck disable=SC2088  # Tilde-in-quotes is intentional — these are test path literals passed to jq
 
 HOOK="$(dirname "$0")/permission-learn.sh"
 

--- a/claude/scripts/clean-the-desk-discover.sh
+++ b/claude/scripts/clean-the-desk-discover.sh
@@ -5,10 +5,14 @@
 
 set -euo pipefail
 
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'Error: not inside a git repository\n' >&2
+  exit 1
+}
 
 # Verify GitHub authentication.
 if ! gh auth status >/dev/null 2>&1; then
+  # shellcheck disable=SC2016  # backtick inside single-quoted printf is intentional (literal output)
   printf 'GitHub authentication is required. Run `gh auth login` and try again.\n' >&2
   exit 1
 fi
@@ -52,7 +56,7 @@ while IFS= read -r wt_line; do
     wt_path="${wt_line#worktree }"
     wt_branch=""
     wt_prunable=false
-    (( block_count++ )) || true
+    ((block_count++)) || true
   elif [[ "$wt_line" == branch\ * ]]; then
     raw_branch="${wt_line#branch }"
     wt_branch="${raw_branch#refs/heads/}"
@@ -61,7 +65,7 @@ while IFS= read -r wt_line; do
   elif [[ "$wt_line" == "prunable"* ]]; then
     wt_prunable=true
   fi
-done <<< "$worktree_raw"
+done <<<"$worktree_raw"
 
 # Flush the final block.
 if [[ $block_count -gt 1 && -n "$wt_path" && "$wt_prunable" == false ]]; then

--- a/claude/scripts/merged-discover.sh
+++ b/claude/scripts/merged-discover.sh
@@ -6,7 +6,10 @@
 
 set -euo pipefail
 
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'Error: not inside a git repository\n' >&2
+  exit 1
+}
 
 # ---------------------------------------------------------------------------
 # git fetch --prune
@@ -31,7 +34,7 @@ worktree_output="$(git worktree list --porcelain)"
 #   prunable                   (present when the worktree is stale/prunable)
 # ---------------------------------------------------------------------------
 main_path=""
-worktrees_json="[]"   # JSON array built incrementally via jq
+worktrees_json="[]" # JSON array built incrementally via jq
 block_path=""
 block_branch=""
 block_prunable=false
@@ -78,7 +81,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   elif [[ "$line" == "prunable"* ]]; then
     block_prunable=true
   fi
-done <<< "$worktree_output"
+done <<<"$worktree_output"
 
 # Flush the last block (no trailing blank line at EOF).
 flush_block

--- a/claude/scripts/pr-comments-fetch.sh
+++ b/claude/scripts/pr-comments-fetch.sh
@@ -6,7 +6,10 @@
 
 set -euo pipefail
 
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'Error: not inside a git repository\n' >&2
+  exit 1
+}
 
 # Arg validation: require a positive integer PR number.
 pr_number="${1:-}"
@@ -17,6 +20,7 @@ fi
 
 # Verify GitHub authentication.
 if ! gh auth status >/dev/null 2>&1; then
+  # shellcheck disable=SC2016  # backtick inside single-quoted printf is intentional (literal output)
   printf 'GitHub authentication is required. Run `gh auth login` and try again.\n' >&2
   exit 1
 fi
@@ -42,6 +46,7 @@ fi
 # The GraphQL query string and the jq merge filter are stored in variables so that
 # single-quote characters do not conflict with the surrounding $(...) command substitution.
 
+# shellcheck disable=SC2016  # GraphQL variables like $owner are not shell expansions
 graphql_query='
 query($owner: String!, $repo: String!, $prNumber: Int!, $endCursor: String) {
   repository(owner: $owner, name: $repo) {
@@ -80,6 +85,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $endCursor: String) {
 }
 '
 
+# shellcheck disable=SC2016  # jq variables like $pr are not shell expansions
 jq_merge_filter='
   if length == 0 then null
   else

--- a/claude/scripts/pr-comments-reply.sh
+++ b/claude/scripts/pr-comments-reply.sh
@@ -12,7 +12,10 @@
 
 set -euo pipefail
 
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'Error: not inside a git repository\n' >&2
+  exit 1
+}
 
 # Error contract (F-004):
 #   - Exit 2 ONLY for arg-validation (no JSON emitted — the only case where stdout is empty).

--- a/claude/scripts/pr-review-setup.sh
+++ b/claude/scripts/pr-review-setup.sh
@@ -6,7 +6,10 @@
 
 set -euo pipefail
 
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { printf 'Error: not inside a git repository\n' >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'Error: not inside a git repository\n' >&2
+  exit 1
+}
 
 # Arg validation: require a positive integer PR number.
 pr_number="${1:-}"

--- a/claude/scripts/token-summary.sh
+++ b/claude/scripts/token-summary.sh
@@ -31,6 +31,7 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
+# shellcheck disable=SC2010  # ls | grep deferred: see open-questions; filenames use fixed timestamp format with no spaces
 LATEST=$(ls -t "$LOG_DIR"/talekeeper-*.jsonl 2>/dev/null | grep -v '/talekeeper-raw\.jsonl$' | head -n1 || true)
 if [[ -z "$LATEST" ]]; then
   printf 'unavailable\n'

--- a/claude/scripts/token-summary.sh
+++ b/claude/scripts/token-summary.sh
@@ -31,7 +31,7 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-# shellcheck disable=SC2010  # ls | grep deferred: see open-questions; filenames use fixed timestamp format with no spaces
+# shellcheck disable=SC2010  # ls | grep is acceptable here: filenames use a fixed timestamp format with no spaces or newlines
 LATEST=$(ls -t "$LOG_DIR"/talekeeper-*.jsonl 2>/dev/null | grep -v '/talekeeper-raw\.jsonl$' | head -n1 || true)
 if [[ -z "$LATEST" ]]; then
   printf 'unavailable\n'

--- a/claude/skills/validate-before-pr/SKILL.md
+++ b/claude/skills/validate-before-pr/SKILL.md
@@ -50,12 +50,24 @@ Run the following as a standalone Bash call, using the `<lint_cmd>` value captur
 <lint_cmd>
 ```
 
-- If lint **passes** (exit code 0): proceed to Step 2.
+- If lint **passes** (exit code 0): proceed to Step 1b.
 - If lint **fails** (non-zero exit): stop immediately. Do not proceed to format check or PR creation. Report the full lint output to the user and request that the errors be fixed before retrying.
+
+### Step 1b — Run shell lint
+
+Run the following probe as a standalone Bash call:
+
+```
+node -e "process.exit(require('./package.json').scripts?.['lint:sh'] ? 0 : 1)" 2>/dev/null && npm run lint:sh
+```
+
+- If the `node -e` probe exits non-zero (script not declared in package.json) or if `package.json` does not exist: skip with note "No `lint:sh` script declared in package.json — skipping shell lint." This is not a failure.
+- If the probe passes and `npm run lint:sh` **passes** (exit code 0): proceed to Step 2.
+- If the probe passes and `npm run lint:sh` **fails** (non-zero exit): stop immediately. Do not proceed to format check or PR creation. Report the full lint output to the user and request that the errors be fixed before retrying.
 
 ### Step 2 — Run format check
 
-If `<format_check_cmd>` is empty (e.g., a Makefile repo with only a `fmt` target that modifies files), skip this step with the note: "No format check is configured for this stack." Proceed directly to Step 3.
+If `<format_check_cmd>` is empty (e.g., a Makefile repo with only a `fmt` target that modifies files), skip this step with the note: "No format check is configured for this stack." Proceed directly to Step 2b.
 
 Otherwise, run the following as a standalone Bash call, using the `<format_check_cmd>` value captured in Step 0:
 
@@ -63,18 +75,35 @@ Otherwise, run the following as a standalone Bash call, using the `<format_check
 <format_check_cmd>
 ```
 
-- If format check **passes** (exit code 0): proceed to Step 3.
+- If format check **passes** (exit code 0): proceed to Step 2b.
 - If format check **fails** (non-zero exit): stop immediately. Do not open the PR. Report the full output to the user and request that the formatting issues be fixed before retrying.
+
+### Step 2b — Run shell format check
+
+Run the following probe as a standalone Bash call:
+
+```
+node -e "process.exit(require('./package.json').scripts?.['format:check:sh'] ? 0 : 1)" 2>/dev/null && npm run format:check:sh
+```
+
+- If the `node -e` probe exits non-zero (script not declared in package.json) or if `package.json` does not exist: skip with note "No `format:check:sh` script declared in package.json — skipping shell format check." This is not a failure.
+- If the probe passes and `npm run format:check:sh` **passes** (exit code 0): proceed to Step 3.
+- If the probe passes and `npm run format:check:sh` **fails** (non-zero exit): stop immediately. Do not open the PR. Report the full output to the user and request that the formatting issues be fixed before retrying.
 
 ### Step 3 — Proceed to open-pull-request
 
-Only after **both** Step 1 and Step 2 pass (or after Step 0 short-circuits to here on `stack == "unknown"`, or after Step 2 is skipped due to empty `<format_check_cmd>`) may you proceed to the `open-pull-request` skill to create the pull request.
+Only after all of Steps 1, 1b, 2, and 2b pass (or are legitimately skipped) may you proceed to the `open-pull-request` skill to create the pull request.
 
 ## Fail-Fast Behavior
 
-- Stop on the first failure. Do not run Step 2 if Step 1 failed.
+- Stop on the first failure. Do not run Step 2 if Step 1 failed; do not run Step 2b if Step 2 failed.
 - Report which check failed and include its full output so the user can act on it.
 - Do not attempt to open the PR until all checks pass.
+- The presence-check skip in Steps 1b and 2b (when `lint:sh` or `format:check:sh` is absent from `package.json`) is NOT a failure — it is a graceful no-op.
+
+## Note on Shell Tooling Sub-Steps
+
+Optional shell-tooling sub-steps (Steps 1b and 2b) use a `node -e` probe against `package.json.scripts` to detect whether the relevant script is declared. This skill installs to `~/.claude/skills/` and runs in any repository; the probe ensures the gate degrades cleanly in repos without these scripts. `npm run` is used (not `pnpm run`) for package-manager-agnostic compatibility.
 
 ## Relationship to Other Skills
 

--- a/clean-backups.sh
+++ b/clean-backups.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
-RED='\033[0;31m'
 NC='\033[0m'
 
 SCAN_DIRS=("$HOME/.claude" "$HOME/.cursor")
@@ -24,6 +23,7 @@ done < <(
 )
 
 if [ "${#all_backups[@]}" -eq 0 ]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${YELLOW}No backups found in ${SCAN_DIRS[*]}.${NC}\n"
   exit 0
 fi
@@ -42,7 +42,7 @@ flush_group() {
   if [ "$count" -ge 2 ]; then
     # Keep the last element (newest); mark the rest for deletion.
     local i
-    for (( i = 0; i < count - 1; i++ )); do
+    for ((i = 0; i < count - 1; i++)); do
       to_delete+=("${current_group[$i]}")
     done
   fi
@@ -67,10 +67,12 @@ if [ -n "$current_original" ]; then
 fi
 
 if [ "${#to_delete[@]}" -eq 0 ]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${GREEN}Nothing to clean — every original path has at most one backup.${NC}\n"
   exit 0
 fi
 
+# shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
 printf "${YELLOW}The following backup files will be deleted (oldest copies only):${NC}\n\n"
 for f in "${to_delete[@]}"; do
   printf "  %s\n" "$f"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -85,6 +85,26 @@ Before committing code, run `pnpm run format` to auto-format your changes. This 
 
 Lefthook runs lint, format, and Markdown lint checks on every push. JS/TS file changes trigger `pnpm run lint` and `pnpm run format:check`; Markdown file changes trigger `pnpm run lint:md`. If any check fails, the push is blocked. Run `pnpm run format` to auto-fix TypeScript formatting issues. Markdown violations must be fixed manually. Hook configuration lives in `lefthook.yml`.
 
+### Code Quality: Shell Linting and Formatting
+
+In addition to the JavaScript/TypeScript toolchain above, this repository lints and formats its shell scripts (`.sh` files under `claude/hooks/`, `claude/scripts/`, `src/launcher/`, `src/mcp/wrappers/`, and the repo root) with **ShellCheck** and **shfmt**.
+
+**Install both locally** before running shell checks (lefthook runs them on pre-push):
+
+```bash
+brew install shellcheck shfmt
+```
+
+**pnpm scripts:**
+
+- `pnpm run lint:sh` — Run ShellCheck across all 28 `.sh` files
+- `pnpm run format:sh` — Apply `shfmt -i 2 -ci -bn` formatting to all 28 `.sh` files
+- `pnpm run format:check:sh` — Check shfmt formatting without modifying files (used in CI and pre-push)
+
+**CI version pin:** CI pins `shfmt` to `v3.8.0`. Minor version drift between local and CI is generally acceptable, but if `pnpm run format:check:sh` produces different output locally vs CI, install the pinned version via `mise use shfmt@3.8.0` or download the v3.8.0 binary from `https://github.com/mvdan/sh/releases/tag/v3.8.0`. `shellcheck` is not pinned; the latest Homebrew or apt version is fine.
+
+**Pre-Push Hook:** The same Lefthook hook that runs the JS lint/format checks also runs `pnpm run lint:sh` and `pnpm run format:check:sh`. Hook configuration lives in `lefthook.yml`.
+
 ### Development Workflow
 
 When making changes to this repository:

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 if ! command -v node >/dev/null 2>&1; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${RED}Error: node is not installed or not in PATH. Please install Node.js >= 18.18.0.${NC}\n" >&2
   exit 1
 fi
@@ -15,6 +16,7 @@ NODE_MAJOR="${NODE_VERSION%%.*}"
 NODE_MINOR="${NODE_VERSION#*.}"
 NODE_MINOR="${NODE_MINOR%%.*}"
 if [[ "$NODE_MAJOR" -lt 18 ]] || [[ "$NODE_MAJOR" -eq 18 && "$NODE_MINOR" -lt 18 ]]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${RED}Error: Node.js >= 18.18.0 required (found ${NODE_VERSION}).${NC}\n" >&2
   exit 1
 fi
@@ -24,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUNDLE="${SCRIPT_DIR}/dist/installer.js"
 
 if [[ ! -f "$BUNDLE" ]]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${RED}Error: dist/installer.js not found. The repository may be incomplete. Try: git pull to restore the missing file.${NC}\n" >&2
   exit 1
 fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,9 @@ pre-push:
     lint-md:
       glob: "**/*.md"
       run: pnpm run lint:md
+    lint-sh:
+      glob: "**/*.sh"
+      run: pnpm run lint:sh
+    format-check-sh:
+      glob: "**/*.sh"
+      run: pnpm run format:check:sh

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "lint": "oxlint src/installer/ src/launcher/",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache'",
     "format": "oxfmt --write src/installer/ src/launcher/",
-    "format:check": "oxfmt --check src/installer/ src/launcher/"
+    "format:check": "oxfmt --check src/installer/ src/launcher/",
+    "lint:sh": "shellcheck claude/hooks/*.sh claude/scripts/*.sh src/launcher/*.sh src/mcp/wrappers/*.sh clean-backups.sh install.sh recover.sh",
+    "format:sh": "shfmt -i 2 -ci -bn -w claude/hooks/*.sh claude/scripts/*.sh src/launcher/*.sh src/mcp/wrappers/*.sh clean-backups.sh install.sh recover.sh",
+    "format:check:sh": "shfmt -i 2 -ci -bn -d claude/hooks/*.sh claude/scripts/*.sh src/launcher/*.sh src/mcp/wrappers/*.sh clean-backups.sh install.sh recover.sh"
   }
 }

--- a/recover.sh
+++ b/recover.sh
@@ -22,10 +22,12 @@ done < <(
 )
 
 if [ "${#backups[@]}" -eq 0 ]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${YELLOW}No backups found in ${SCAN_DIRS[*]}.${NC}\n"
   exit 0
 fi
 
+# shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
 printf "${BLUE}Discovered backups (newest first):${NC}\n\n"
 
 for i in "${!backups[@]}"; do
@@ -48,10 +50,12 @@ for i in "${!backups[@]}"; do
     "$((i + 1))" "$backup" "$original" "$human_ts"
 done
 
+# shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
 printf "${BLUE}Enter the number of the backup to restore (or press Enter to cancel):${NC} "
 read -r input || true
 
 if [ -z "$input" ]; then
+  # shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
   printf "${YELLOW}No selection made. Exiting.${NC}\n"
   exit 0
 fi
@@ -75,4 +79,5 @@ if [ -e "$original_path" ] || [ -L "$original_path" ]; then
 fi
 
 mv "$selected_backup" "$original_path"
+# shellcheck disable=SC2059  # ANSI colour escape mixed with format specifiers
 printf "${GREEN}Restored successfully.${NC}\n"

--- a/src/mcp/wrappers/mcp-argocd.sh
+++ b/src/mcp/wrappers/mcp-argocd.sh
@@ -13,7 +13,7 @@ if [[ ! -f "$DOTFILE" ]] || [[ ! -s "$DOTFILE" ]]; then
 fi
 
 # --- Read and trim cluster id ---
-IFS= read -r ARGOCD_CLUSTER_ID < "$DOTFILE"
+IFS= read -r ARGOCD_CLUSTER_ID <"$DOTFILE"
 ARGOCD_CLUSTER_ID="${ARGOCD_CLUSTER_ID#"${ARGOCD_CLUSTER_ID%%[! $'\t']*}"}"
 ARGOCD_CLUSTER_ID="${ARGOCD_CLUSTER_ID%"${ARGOCD_CLUSTER_ID##*[! $'\t']}"}"
 export ARGOCD_CLUSTER_ID
@@ -56,7 +56,8 @@ fi
 # Use `if !` form to bypass set -e cleanly (no set +e/set -e toggle dance).
 # The python heredoc reads the accounts file, looks up the cluster by id,
 # and extracts url and token. It exits non-zero on any missing or null/empty value.
-if ! read -r ARGOCD_BASE_URL ARGOCD_API_TOKEN < <(python3 - <<'PY'
+if ! read -r ARGOCD_BASE_URL ARGOCD_API_TOKEN < <(
+  python3 - <<'PY'
 import json, os, sys
 accounts_file = os.environ["ACCOUNTS_FILE"]
 cluster_id = os.environ["ARGOCD_CLUSTER_ID"]

--- a/src/mcp/wrappers/mcp-cloudwatch.sh
+++ b/src/mcp/wrappers/mcp-cloudwatch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Resolve AWS profile: dotfile takes priority over env var
 DOTFILE="$HOME/.claude/.current-aws-profile"
 if [[ -f "$DOTFILE" ]] && [[ -s "$DOTFILE" ]]; then
-  IFS= read -r AWS_PROFILE < "$DOTFILE"
+  IFS= read -r AWS_PROFILE <"$DOTFILE"
   # Trim leading/trailing whitespace (bash-native, since we already require bash for [[ ]])
   AWS_PROFILE="${AWS_PROFILE#"${AWS_PROFILE%%[! $'\t']*}"}"
   AWS_PROFILE="${AWS_PROFILE%"${AWS_PROFILE##*[! $'\t']}"}"

--- a/src/mcp/wrappers/mcp-gcp-observability.sh
+++ b/src/mcp/wrappers/mcp-gcp-observability.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Resolve GCP project: dotfile takes priority over env var
 DOTFILE="$HOME/.claude/.current-gcp-project"
 if [[ -f "$DOTFILE" ]] && [[ -s "$DOTFILE" ]]; then
-  IFS= read -r GOOGLE_CLOUD_PROJECT < "$DOTFILE"
+  IFS= read -r GOOGLE_CLOUD_PROJECT <"$DOTFILE"
   # Trim leading/trailing whitespace
   GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT#"${GOOGLE_CLOUD_PROJECT%%[! $'\t']*}"}"
   GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT%"${GOOGLE_CLOUD_PROJECT##*[! $'\t']}"}"

--- a/src/mcp/wrappers/mcp-github.sh
+++ b/src/mcp/wrappers/mcp-github.sh
@@ -57,7 +57,8 @@ fi
 # even with set -euo pipefail, because command substitution failures inside
 # local/export/simple assignments do NOT trigger set -e exit; the explicit if!
 # boundary is what makes the failure abort the script.
-if ! TOKEN="$(python3 - <<'PY'
+if ! TOKEN="$(
+  python3 - <<'PY'
 import json, os, sys
 try:
     with open(os.path.expanduser("~/.config/tpk/github-pats.json")) as f:


### PR DESCRIPTION
Shell scripts account for 28 files across this repository but had zero linting or formatting coverage. This PR wires ShellCheck and shfmt into the existing quality gates: pnpm scripts (`lint:sh`, `format:sh`, `format:check:sh`), lefthook pre-push, GitHub Actions CI, and the globally-installed `validate-before-pr` skill (with a graceful skip for repos without these scripts). All 28 `.sh` files now pass both checks; a handful of deferred findings (SC2010, SC2181) are tracked in the open-questions file for a follow-up.