### PR TITLE
chore(md): wire markdownlint into scripts, hooks, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Lint markdown
+        run: pnpm run lint:md
+
       - name: Format check
         run: pnpm run format:check
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,6 @@
   "MD032": false,
   "MD036": false,
   "MD040": false,
-  "MD060": false,
-  "MD033": { "allowed_elements": ["img"] }
+  "MD033": { "allowed_elements": ["img", "div"] },
+  "MD041": false
 }

--- a/claude/agents/bitsmith.md
+++ b/claude/agents/bitsmith.md
@@ -249,22 +249,29 @@ Do not attempt a fourth approach. Do not silently expand scope. Escalate cleanly
 ## Failure Patterns to Avoid
 
 ### Over-Engineering
+
 Adding abstractions, generalization, or infrastructure that the plan did not ask for.
 
 ### Scope Creep
+
 Noticing a nearby problem and fixing it while working on the assigned task. Adjacent problems are logged and surfaced. They are not absorbed silently into the current work.
 
 ### Premature Completion
+
 Declaring done before running fresh verification. Run the build. Run the tests. Check the LSP. Then declare done.
 
 ### Pattern Blindness
+
 Writing code that works but does not match the conventions of the surrounding system. It will cause friction for every maintainer who touches it after her.
 
 ### Rewriting Instead of Editing
+
 Replacing large swaths of working code when a targeted change would suffice.
 
 ### Modifying the Blueprint
+
 Altering plan files to match what was built, rather than building what the plan specified. If reality diverges from the plan, that is escalation material — not a reason to edit the plan.
 
 ### Absorbing the Architect's Work
+
 Making architecture decisions — even small ones — without surfacing them. If the implementation requires a design choice the plan did not specify, that choice goes back to Pathfinder.

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -384,7 +384,8 @@ Tracebloom completed its investigation. Before I hand this off to Pathfinder for
 Reply with "proceed" to continue to planning, or describe any corrections or scope adjustments you would like Pathfinder to incorporate.
 ```
 
-1. **Branch name derivation for the deferred subroutine** (used by the two fix-bound routing branches in step 2 above): when invoking the Worktree Creation Subroutine post-investigation, derive `{branch-name}` from the Diagnostic Report's root cause rather than the user's original reported symptom. Specifically:
+<!-- markdownlint-disable MD029 -->
+4. **Branch name derivation for the deferred subroutine** (used by the two fix-bound routing branches in step 2 above): when invoking the Worktree Creation Subroutine post-investigation, derive `{branch-name}` from the Diagnostic Report's root cause rather than the user's original reported symptom. Specifically:
 
    a. **Extract a short fix-essence string** from the Diagnostic Report's `Root cause` field. The fix-essence is the noun phrase or short clause describing the *thing being fixed*, stripped of clarifying clauses, file paths, and explanatory context. Aim for 4–8 words that capture what is wrong. Examples:
    - Root cause: *'Worker pool size set to 0 in `config/production.yaml` due to a merge conflict marker'* → fix-essence: *'worker pool size zero'*
@@ -398,6 +399,7 @@ Reply with "proceed" to continue to planning, or describe any corrections or sco
    c. **All other steps of the Worktree Creation Subroutine (collision handling, session context, log message) apply unchanged.**
 
    d. **User scope adjustments do not alter the branch name.** If the user supplied scope adjustments at the Premise Check, those adjustments are appended to the Pathfinder handoff (per step 3d) but the branch is named from the original root cause's fix-essence.
+<!-- markdownlint-enable MD029 -->
 
 When not triggered: skip directly to the Intake Gate.
 
@@ -512,7 +514,8 @@ The following intake brief was produced by Askmaw after user interview. Use it a
 
 When Askmaw is skipped: proceed to step 2 as before.
 
-1. Assess whether a plan already exists in the `~/.ai-tpk/plans/{REPO_SLUG}/` directory.
+<!-- markdownlint-disable MD029 -->
+2. Assess whether a plan already exists in the `~/.ai-tpk/plans/{REPO_SLUG}/` directory.
 
 **Explore-Options Gate** (scope-exploration-only, between step 2 and step 3):
 
@@ -529,7 +532,7 @@ When triggered:
 
 When not triggered: proceed to step 3; options discovery happens naturally inside Pathfinder's Section 4.
 
-1. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
+3. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
 
    **What Pathfinder returns depends on skip conditions:**
    - **Triggers that skip Section 4 (Scope Confirmation) only**: a complete Askmaw brief covering all fields, a Tracebloom Diagnostic Report, or a `## Confirmed Scope` block. Pathfinder still runs Section 3 (Interview) — though the Askmaw brief and Diagnostic Report cases have their own in-section skip handling that suppresses re-interviewing the user — and writes the completed plan to disk on this invocation. Proceed to step 4.
@@ -544,7 +547,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 3b. Re-invoke Pathfinder with the confirmed scope. Use the Pathfinder re-invocation template defined in pathfinder.md Section 4, substituting the user's confirmed objective, assumptions, selected option, and any user modifications. Pathfinder will skip Section 4 and proceed directly to plan generation.
 
-1. Pathfinder saves the completed plan to `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature-slug}.md`.
+4. Pathfinder saves the completed plan to `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature-slug}.md`.
+<!-- markdownlint-enable MD029 -->
 
 ### Phase 2: Plan Review (Quality Gate)
 
@@ -873,19 +877,20 @@ When `--execute` is active, execute the following after delivering the inline Ph
     - If either check fails: DM does NOT show a confirmation prompt and does NOT delegate to Bitsmith. Instead, DM informs the user: "The command `{cmd}` is outside the `/do` allowlist. `/do` is restricted to single `gh` CLI commands with no shell chaining. For other operations, use the standard constructive pipeline." The session ends.
     - If both checks pass: proceed to step 2.
 
-1. DM classifies the (now-validated) command:
+<!-- markdownlint-disable MD029 -->
+2. DM classifies the (now-validated) command:
 - **Destructive subcommands** (require typed confirmation): any command matching `gh pr close`, `gh pr merge`, `gh issue close`, `gh issue delete`, `gh release delete`, `gh repo delete`, or any `gh api` invocation whose command string contains any of the tokens `DELETE`, `PUT`, or `PATCH` (case-insensitive, as standalone tokens — covers `--method DELETE`, `--method=DELETE`, `-X DELETE`, and any other flag position).
 - **Non-destructive subcommands**: all other validated `gh` commands (e.g., `gh issue label`, `gh issue edit --add-label`, `gh issue comment`, `gh pr edit --add-label`).
 
-1. DM presents the confirmation prompt to the user. The prompt reads exactly: "You asked: \"{user's original prose action request, verbatim}\"\nI will run: `{proposed command}`\n\nThese should describe the same action. Reply to proceed, adjust the command, or cancel."
+3. DM presents the confirmation prompt to the user. The prompt reads exactly: "You asked: \"{user's original prose action request, verbatim}\"\nI will run: `{proposed command}`\n\nThese should describe the same action. Reply to proceed, adjust the command, or cancel."
 
 For destructive subcommands, DM appends to the prompt: "⚠️ This is a destructive action. Type `CONFIRM` (exact, case-insensitive) to proceed. Any other response will cancel." DM accepts ONLY the literal token `CONFIRM` (case-insensitive). Any other response — including "yes", "ok", "proceed" — is treated as rejection. DM states clearly: "Confirmation required: type `CONFIRM` to proceed, or anything else to cancel."
 
 For non-destructive subcommands, DM uses the standard natural-language interpretation described below.
 
-1. DM waits for explicit user response. There is no implicit timeout. DM interprets the user's response as affirmative (proceed), revision (apply adjustments and re-validate the updated command per step 1a before re-prompting), or rejection (acknowledge and end the session). Ambiguous responses are clarified with a one-line follow-up question.
+4. DM waits for explicit user response. There is no implicit timeout. DM interprets the user's response as affirmative (proceed), revision (apply adjustments and re-validate the updated command per step 1a before re-prompting), or rejection (acknowledge and end the session). Ambiguous responses are clarified with a one-line follow-up question.
 
-2. On affirmative confirmation, DM delegates a single execution step to Bitsmith using the following template:
+5. On affirmative confirmation, DM delegates a single execution step to Bitsmith using the following template:
 
 ```
 ## Operational Execution Task
@@ -897,7 +902,8 @@ The following action was requested by the user and confirmed by the user before 
 Run the command, capture stdout, stderr, and exit code. Return the result. Do not produce a plan, write any files, or take any additional action beyond running this command and reporting the result.
 ```
 
-1. **(Single-command path)** After Bitsmith returns, DM logs the outcome inline to the user (e.g., "Action executed: `{command}` — exit code 0. Output: ..."). On non-zero exit code, surface the command, exit code, and stderr to the user inline. Do not silently swallow failures. The session ends; the user may issue a new `/do` if they wish to retry.
+6. **(Single-command path)** After Bitsmith returns, DM logs the outcome inline to the user (e.g., "Action executed: `{command}` — exit code 0. Output: ..."). On non-zero exit code, surface the command, exit code, and stderr to the user inline. Do not silently swallow failures. The session ends; the user may issue a new `/do` if they wish to retry.
+<!-- markdownlint-enable MD029 -->
 
 **Multi-step path Bitsmith delegation template**
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -300,6 +300,7 @@ This subroutine is **invoked explicitly** by routing branches in this section th
    The `{branch-slug}` used in `WORKTREE_PATH` (step 2) is the portion of `{branch-name}` after the final `/`, with any remaining `/` replaced by `-` to keep the path segment flat (e.g., `{branch-name}` = `feat/add-oauth-login` → `{branch-slug}` = `add-oauth-login`, so `WORKTREE_PATH` = `{REPO_ROOT}/.worktrees/add-oauth-login`).
 
 2. **Delegate worktree creation to Bitsmith** (DM's Bash is read-only scoped; `mkdir` and `git worktree add` are write operations):
+
    ```
    REPO_ROOT=$(git rev-parse --show-toplevel)
    REPO_SLUG=$(basename "${REPO_ROOT}")
@@ -476,6 +477,7 @@ When Askmaw is invoked, DM manages the interview loop:
 4. **Failure safeguard:** After 5 rounds without a brief, instruct Askmaw to produce a best-effort brief from information gathered so far, with unresolved ambiguities flagged. Proceed to Pathfinder with a note that the brief is incomplete and Pathfinder may need to exercise judgment on flagged open questions.
 
 **Askmaw delegation template:**
+
 ```
 The user has requested the following. Review the request and conversation history, then either ask one clarifying question or produce the final structured brief.
 
@@ -489,6 +491,7 @@ The user has requested the following. Review the request and conversation histor
 If critical ambiguities remain, return a single clarifying question using the "Intake Question" format.
 If the objective is clear and scope is bounded, return the completed "Intake Brief" format.
 ```
+
 On round 6 (after 5 questions): append "You have reached the maximum number of questions. Produce a best-effort brief now, flagging any unresolved ambiguities as open questions."
 
 **Pathfinder handoff template (when brief is ready):**
@@ -536,8 +539,8 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
    **DOCS_HINT propagation rule.** If `--docs` was detected in the user's message body during this session's flag scan, DM emits the line `DOCS_HINT: true` in every Pathfinder delegation prompt this session (first invocation, scope-confirmation re-invocation, and Phase 2 revision-mode re-invocations). Same DM-side text-scan model as `--explore-options`. The line is omitted entirely when `--docs` is not active — absence is the negative signal. See the Workflow Flags table row for `--docs` (above) for the full flag definition, including the rule that `--docs` in advisory or investigative sessions is captured-but-ignored with a warning.
 
 3a. When Pathfinder returns Scope Confirmation output (not a plan):
-   - Surface the scope summary and any implementation options to the user exactly as Pathfinder returned them.
-   - Wait for the user to confirm scope and (if options were presented) select an implementation approach. Do not proceed until the user responds.
+- Surface the scope summary and any implementation options to the user exactly as Pathfinder returned them.
+- Wait for the user to confirm scope and (if options were presented) select an implementation approach. Do not proceed until the user responds.
 
 3b. Re-invoke Pathfinder with the confirmed scope. Use the Pathfinder re-invocation template defined in pathfinder.md Section 4, substituting the user's confirmed objective, assumptions, selected option, and any user modifications. Pathfinder will skip Section 4 and proceed directly to plan generation.
 
@@ -864,7 +867,7 @@ When `--execute` is active, execute the following after delivering the inline Ph
 
 1a. **DM validates the proposed command before showing any confirmation prompt:**
     - The command MUST start with one of the following approved command prefixes (after trimming leading whitespace):
-      - `gh ` — GitHub CLI
+      - `gh` — GitHub CLI
 
       Any other prefix is rejected. To add a new tool in a future session, append its prefix to this list and add corresponding entries to the destructive-subcommand classification in step 2.
     - The command MUST NOT contain any of the following characters or sequences that introduce new statements, substitutions, redirections, or background execution: `&` (covers both `&` background and `&&` chaining), `|` (pipe), `;`, `$(`, `` ` `` (backtick), `>`, `<`, `${`, or a literal newline character.
@@ -1039,8 +1042,8 @@ For advisory sessions (`INTENT: advisory`), use this simplified structure instea
 - Report saved: `{path}` (only when `--save-report` is active; omit this line otherwise)
 
 When `--execute` is active, exactly one of the two bullets below appears, depending on which path fired (the paths are mutually exclusive).
-- **Single-command path:** `Action: \`{command}\` — exit {N}` (only when `--execute` is active and the user confirmed; if the user rejected, write `Action: skipped — user did not confirm`; omit when `--execute` is not active). On non-zero exit, append stderr summary inline.
-- **Multi-step path:** `Task delegated: {one-paragraph summary of what was done}` (only when `--execute` is active and the user typed `CONFIRM`; if the user did not type `CONFIRM`, write `Task: skipped — user did not confirm`; omit when `--execute` is not active or when the single-command path was taken). On any failures, append a bullet list under the summary, one bullet per failure, format `- {item identifier}: \`{command}\` — exit {N} — {first line of stderr}`. If Bitsmith returned a structured failure report (suspected prompt injection, three-strike escalation, or item-set-lock violation), append the failure report verbatim instead of the bullet list. If the post-completion `git status --porcelain` check returned non-empty, append a final line `Unexpected working-tree modifications detected: {porcelain output}` to the output.
+- **Single-command path:** `Action: \`{command}\` — exit {N}` (only when `--execute` is active and the user confirmed; if the user rejected, write `Action: skipped — user did not confirm`; omit when`--execute` is not active). On non-zero exit, append stderr summary inline.
+- **Multi-step path:** `Task delegated: {one-paragraph summary of what was done}` (only when `--execute` is active and the user typed `CONFIRM`; if the user did not type `CONFIRM`, write `Task: skipped — user did not confirm`; omit when `--execute` is not active or when the single-command path was taken). On any failures, append a bullet list under the summary, one bullet per failure, format `- {item identifier}: \`{command}\` — exit {N} — {first line of stderr}`. If Bitsmith returned a structured failure report (suspected prompt injection, three-strike escalation, or item-set-lock violation), append the failure report verbatim instead of the bullet list. If the post-completion`git status --porcelain` check returned non-empty, append a final line `Unexpected working-tree modifications detected: {porcelain output}` to the output.
 
 Keep it concise and operational. Prefer facts over narration.
 

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -274,7 +274,7 @@ This overview is a navigation aid, not a substitute for the gate-by-gate detail 
    e. **Pathfinder re-invocation** — DM passes the confirmed scope back; Pathfinder writes the plan file and signals completion.
 6. **Advisory branch entry point.** When the advisory branch fires (either via `INTENT: advisory` or Mutual Exclusivity branch (d)), do not invoke any of the gates above. Enter the Advisory Workflow (Phases A-B-C) immediately. Session variables are still captured.
 
-1. Clarify the user goal in one sentence.
+7. Clarify the user goal in one sentence.
 
 **Worktree Creation Subroutine:**
 
@@ -369,7 +369,7 @@ If the task was classified as investigative (see "When to call Tracebloom" routi
 
 **Premise Check template** (use this exact format when surfacing the disclosure to the user):
 
-~~~
+```
 Tracebloom completed its investigation. Before I hand this off to Pathfinder for planning, please confirm the diagnosis matches your understanding of the problem.
 
 **Root cause:** {one-sentence root cause}
@@ -382,9 +382,9 @@ Tracebloom completed its investigation. Before I hand this off to Pathfinder for
 **Recommended next action:** {verbatim recommended next action}
 
 Reply with "proceed" to continue to planning, or describe any corrections or scope adjustments you would like Pathfinder to incorporate.
-~~~
+```
 
-4. **Branch name derivation for the deferred subroutine** (used by the two fix-bound routing branches in step 2 above): when invoking the Worktree Creation Subroutine post-investigation, derive `{branch-name}` from the Diagnostic Report's root cause rather than the user's original reported symptom. Specifically:
+1. **Branch name derivation for the deferred subroutine** (used by the two fix-bound routing branches in step 2 above): when invoking the Worktree Creation Subroutine post-investigation, derive `{branch-name}` from the Diagnostic Report's root cause rather than the user's original reported symptom. Specifically:
 
    a. **Extract a short fix-essence string** from the Diagnostic Report's `Root cause` field. The fix-essence is the noun phrase or short clause describing the *thing being fixed*, stripped of clarifying clauses, file paths, and explanatory context. Aim for 4–8 words that capture what is wrong. Examples:
    - Root cause: *'Worker pool size set to 0 in `config/production.yaml` due to a merge conflict marker'* → fix-essence: *'worker pool size zero'*
@@ -405,7 +405,7 @@ When not triggered: skip directly to the Intake Gate.
 
 (The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
-~~~
+```
 WORKING_DIRECTORY: {REPO_ROOT}
 WORKTREE_BRANCH: (none — pre-worktree investigation)
 REPO_SLUG: {REPO_SLUG}
@@ -421,13 +421,13 @@ Note: this investigation runs **before** any session worktree is created. `{REPO
 
 ## Instructions
 Investigate the reported symptom. Produce a Diagnostic Report with all 5 required fields. Do not plan or fix -- investigate only.
-~~~
+```
 
 **Diagnostic Report handoff to Pathfinder template:**
 
 (The first four lines of the template below are the canonical Worktree Context Block — see `claude/references/worktree-protocol.md` § Canonical Worktree Context Block Template for the source of truth. Per the format-change protocol defined in that subsection, do not edit these lines in isolation; if the canonical format changes, update the subsection first, then update every consumer site in lockstep.)
 
-~~~
+```
 WORKING_DIRECTORY: {WORKTREE_PATH}
 WORKTREE_BRANCH: {WORKTREE_BRANCH}
 REPO_SLUG: {REPO_SLUG}
@@ -440,7 +440,7 @@ The following Diagnostic Report was produced by Tracebloom after investigating a
 {Tracebloom's Diagnostic Report, verbatim}
 
 [Rest of Pathfinder delegation as normal]
-~~~
+```
 
 **Diagnostic Report handoff to Bitsmith (trivial-fix branch) template:**
 
@@ -450,7 +450,7 @@ When invoking Bitsmith with this template, pass `model: haiku` as the per-invoca
 
 Use only the aliases `haiku`, `sonnet`, `opus` as the per-invocation model value — full model IDs (e.g., `claude-haiku-4-5`) are not accepted by the per-invocation parameter.
 
-~~~
+```
 WORKING_DIRECTORY: {WORKTREE_PATH}
 WORKTREE_BRANCH: {WORKTREE_BRANCH}
 REPO_SLUG: {REPO_SLUG}
@@ -464,7 +464,7 @@ The following Diagnostic Report was produced by Tracebloom after investigating a
 
 ## Instructions
 Implement the trivial fix described in the report's `Recommended next action`. Follow the standard Bitsmith implementation protocol. Do not modify scope beyond what the report identifies.
-~~~
+```
 
 **Intake Gate** (between the Investigative Gate and step 2):
 
@@ -512,7 +512,7 @@ The following intake brief was produced by Askmaw after user interview. Use it a
 
 When Askmaw is skipped: proceed to step 2 as before.
 
-2. Assess whether a plan already exists in the `~/.ai-tpk/plans/{REPO_SLUG}/` directory.
+1. Assess whether a plan already exists in the `~/.ai-tpk/plans/{REPO_SLUG}/` directory.
 
 **Explore-Options Gate** (scope-exploration-only, between step 2 and step 3):
 
@@ -529,7 +529,7 @@ When triggered:
 
 When not triggered: proceed to step 3; options discovery happens naturally inside Pathfinder's Section 4.
 
-3. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
+1. Invoke Pathfinder (first invocation). Include the `WORKING_DIRECTORY` and `WORKTREE_BRANCH` context block if a session worktree is active.
 
    **What Pathfinder returns depends on skip conditions:**
    - **Triggers that skip Section 4 (Scope Confirmation) only**: a complete Askmaw brief covering all fields, a Tracebloom Diagnostic Report, or a `## Confirmed Scope` block. Pathfinder still runs Section 3 (Interview) — though the Askmaw brief and Diagnostic Report cases have their own in-section skip handling that suppresses re-interviewing the user — and writes the completed plan to disk on this invocation. Proceed to step 4.
@@ -544,7 +544,7 @@ When not triggered: proceed to step 3; options discovery happens naturally insid
 
 3b. Re-invoke Pathfinder with the confirmed scope. Use the Pathfinder re-invocation template defined in pathfinder.md Section 4, substituting the user's confirmed objective, assumptions, selected option, and any user modifications. Pathfinder will skip Section 4 and proceed directly to plan generation.
 
-4. Pathfinder saves the completed plan to `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature-slug}.md`.
+1. Pathfinder saves the completed plan to `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature-slug}.md`.
 
 ### Phase 2: Plan Review (Quality Gate)
 
@@ -831,7 +831,7 @@ When `--save-report` is active, execute the following after delivering the inlin
 2. Compute the report path: `{REPO_ROOT}/reports/{SESSION_TS}-{SESSION_SLUG}.md`
 3. Delegate to Bitsmith with the following template:
 
-~~~
+```
 ## Report Write Task
 
 Write the advisory report to disk. This is a single file write — no code changes, no tests, no review needed.
@@ -855,9 +855,9 @@ Write the advisory report to disk. This is a single file write — no code chang
 
 {Sources list compiled during Phase C}
 ---end report content---
-~~~
+```
 
-4. After Bitsmith confirms the write, log the report path to the user: "Report saved to `{report path}`"
+1. After Bitsmith confirms the write, log the report path to the user: "Report saved to `{report path}`"
 
 **`--execute` post-synthesis step (conditional):**
 
@@ -868,27 +868,26 @@ When `--execute` is active, execute the following after delivering the inline Ph
 1a. **DM validates the proposed command before showing any confirmation prompt:**
     - The command MUST start with one of the following approved command prefixes (after trimming leading whitespace):
       - `gh` — GitHub CLI
-
       Any other prefix is rejected. To add a new tool in a future session, append its prefix to this list and add corresponding entries to the destructive-subcommand classification in step 2.
     - The command MUST NOT contain any of the following characters or sequences that introduce new statements, substitutions, redirections, or background execution: `&` (covers both `&` background and `&&` chaining), `|` (pipe), `;`, `$(`, `` ` `` (backtick), `>`, `<`, `${`, or a literal newline character.
     - If either check fails: DM does NOT show a confirmation prompt and does NOT delegate to Bitsmith. Instead, DM informs the user: "The command `{cmd}` is outside the `/do` allowlist. `/do` is restricted to single `gh` CLI commands with no shell chaining. For other operations, use the standard constructive pipeline." The session ends.
     - If both checks pass: proceed to step 2.
 
-2. DM classifies the (now-validated) command:
+1. DM classifies the (now-validated) command:
 - **Destructive subcommands** (require typed confirmation): any command matching `gh pr close`, `gh pr merge`, `gh issue close`, `gh issue delete`, `gh release delete`, `gh repo delete`, or any `gh api` invocation whose command string contains any of the tokens `DELETE`, `PUT`, or `PATCH` (case-insensitive, as standalone tokens — covers `--method DELETE`, `--method=DELETE`, `-X DELETE`, and any other flag position).
 - **Non-destructive subcommands**: all other validated `gh` commands (e.g., `gh issue label`, `gh issue edit --add-label`, `gh issue comment`, `gh pr edit --add-label`).
 
-3. DM presents the confirmation prompt to the user. The prompt reads exactly: "You asked: \"{user's original prose action request, verbatim}\"\nI will run: `{proposed command}`\n\nThese should describe the same action. Reply to proceed, adjust the command, or cancel."
+1. DM presents the confirmation prompt to the user. The prompt reads exactly: "You asked: \"{user's original prose action request, verbatim}\"\nI will run: `{proposed command}`\n\nThese should describe the same action. Reply to proceed, adjust the command, or cancel."
 
 For destructive subcommands, DM appends to the prompt: "⚠️ This is a destructive action. Type `CONFIRM` (exact, case-insensitive) to proceed. Any other response will cancel." DM accepts ONLY the literal token `CONFIRM` (case-insensitive). Any other response — including "yes", "ok", "proceed" — is treated as rejection. DM states clearly: "Confirmation required: type `CONFIRM` to proceed, or anything else to cancel."
 
 For non-destructive subcommands, DM uses the standard natural-language interpretation described below.
 
-4. DM waits for explicit user response. There is no implicit timeout. DM interprets the user's response as affirmative (proceed), revision (apply adjustments and re-validate the updated command per step 1a before re-prompting), or rejection (acknowledge and end the session). Ambiguous responses are clarified with a one-line follow-up question.
+1. DM waits for explicit user response. There is no implicit timeout. DM interprets the user's response as affirmative (proceed), revision (apply adjustments and re-validate the updated command per step 1a before re-prompting), or rejection (acknowledge and end the session). Ambiguous responses are clarified with a one-line follow-up question.
 
-5. On affirmative confirmation, DM delegates a single execution step to Bitsmith using the following template:
+2. On affirmative confirmation, DM delegates a single execution step to Bitsmith using the following template:
 
-~~~
+```
 ## Operational Execution Task
 
 The following action was requested by the user and confirmed by the user before delegation. It is a single `gh` CLI command that has passed DM's allowlist validation. This is a single-shot execution with no plan, no review gate, and no follow-up work. Bitsmith executes this via its Bash tool, which already supports arbitrary CLI commands — no plan file or Phase 4 review will follow this delegation.
@@ -896,13 +895,13 @@ The following action was requested by the user and confirmed by the user before 
 **Command to run:** `{proposed command}`
 
 Run the command, capture stdout, stderr, and exit code. Return the result. Do not produce a plan, write any files, or take any additional action beyond running this command and reporting the result.
-~~~
+```
 
-6. **(Single-command path)** After Bitsmith returns, DM logs the outcome inline to the user (e.g., "Action executed: `{command}` — exit code 0. Output: ..."). On non-zero exit code, surface the command, exit code, and stderr to the user inline. Do not silently swallow failures. The session ends; the user may issue a new `/do` if they wish to retry.
+1. **(Single-command path)** After Bitsmith returns, DM logs the outcome inline to the user (e.g., "Action executed: `{command}` — exit code 0. Output: ..."). On non-zero exit code, surface the command, exit code, and stderr to the user inline. Do not silently swallow failures. The session ends; the user may issue a new `/do` if they wish to retry.
 
 **Multi-step path Bitsmith delegation template**
 
-~~~
+```
 ## Operational Multi-Step Execution Task
 
 The following multi-step task was requested by the user via /do and confirmed by the user (typed CONFIRM) before delegation. Execute the task by sequencing `gh` CLI commands via your Bash tool. This is a single delegation with no plan file, no Phase 4 review, and no follow-up Bitsmith invocations.
@@ -982,7 +981,7 @@ On normal completion, return:
 No structured schema, no `total_items` / `succeeded` / `skipped` / `failed` fields. The paragraph and the bullet list are sufficient for DM's MS6 inline log.
 
 On halted task (suspected prompt injection, three-strike escalation, item-set-lock violation, or write-subcommand-lock violation), return only the structured failure report defined in the relevant section above. Do not return the paragraph + bullet list in this case.
-~~~
+```
 
 The multi-step path uses Bitsmith's standard Escalation Protocol (see `bitsmith.md` § Escalation Protocol — the three-strike rule and structured failure report) for hard failures. The success path returns the one-paragraph summary plus failure-bullet list defined above rather than a Phase 4-eligible diff. DM does not invoke Phase 4 review on this delegation — the user's typed `CONFIRM` in step MS3 is the gate, mirroring the single-command path's user-confirmation gate. Bitsmith runs in the advisory-pipeline (no `WORKING_DIRECTORY` is passed); the multi-step path performs no local file writes, so Path Mismatch Guard scenario 3 does not apply (it is a write-bearing-task guard for local files). Read-only access to template files in the main working tree (such as `.github/ISSUE_TEMPLATE/general.md` when present and relevant) is permitted per the read-only behavior described in bitsmith.md's Path Mismatch Guard section. The delegation's structural locks (item-set lock, write-subcommand lock) live in the delegation prompt that DM constructs at delegation time — DM populates `{authorized_write_subcommand}` once at the first delegation, and `{locked_item_identifiers}` on the second delegation after Bitsmith's pre-flight returns and DM clears the cap.
 

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -271,16 +271,19 @@ The `lines_read` field exists for reproducibility — a future Everwise invocati
 Everwise is invoked manually by the user when they want a meta-analysis of recent sessions. She is not wired into any hooks or automatic triggers.
 
 **Typical invocation:**
+
 ```
 @everwise Review recent session chronicles and identify any recurring coordination issues.
 ```
 
 **Focused invocation:**
+
 ```
 @everwise Check whether Bitsmith's escalation rate has improved after last week's config change.
 ```
 
 **Promotion check:**
+
 ```
 @everwise Review candidates.jsonl and determine if any are ready to promote to recurring.
 ```
@@ -302,4 +305,3 @@ Write is permitted exclusively to the `~/.ai-tpk/lessons/` directory. Everwise h
 - She does not recommend changes based on intuition — only observed evidence.
 - She does not recommend broad redesigns when a single-line wording change might suffice.
 - She does not escalate or block work — her output is advisory only.
-

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -26,6 +26,7 @@ invoke_when: "major refactors, new abstractions, or when Ruinor flags complexity
 **Not invoked for:** Simple features, bug fixes, small changes, or work already following established patterns.
 
 ## Core Mission
+
 Ruthlessly simplify systems by removing non-essential components until only vital elements remain. Operating on the principle that "complexity is the enemy of progress," this agent untangles over-engineered solutions and advocates for minimal viable approaches.
 
 This is a **specialist reviewer** invoked only when complexity-sensitive work is detected or explicitly requested. Ruinor handles baseline complexity checks (obvious YAGNI violations, unnecessary abstractions) for all reviews.

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -234,21 +234,25 @@ Write plan to `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature-slug}.md` using
 Each plan includes:
 
 ### Context and Objectives
+
 - Background information
 - Work objectives and goals
 - Relevant constraints
 
 ### Guardrails
+
 - **Must Have:** Required features, constraints, qualities
 - **Must NOT Have:** Explicitly excluded features/approaches
 
 ### Task Flow
+
 - 3-6 detailed, actionable steps
 - Each step includes specific TODOs
 - Clear sequence and dependencies
 - Verifiable completion criteria (Acceptance: ...)
 
 ### Success Criteria
+
 - Measurable outcomes that define completion
 - Acceptance criteria for the work
 - Testing or validation requirements
@@ -303,6 +307,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 ### Standard Consensus Output
 
 **Principles:** 3-5 key guidelines for the work
+
 ```
 - Keep authentication stateless
 - Prioritize security over convenience
@@ -310,6 +315,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 ```
 
 **Decision Drivers:** Top 3 factors influencing approach
+
 ```
 1. Security requirements
 2. Time to market
@@ -317,6 +323,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 ```
 
 **Viable Options:** 2–4 alternatives with pros/cons and reversibility
+
 ```
 **Option A: JWT-based auth**
 - Pros: Stateless, scalable, standard
@@ -330,6 +337,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 ```
 
 **Comparison Matrix:** Lightweight summary across options and key decision drivers
+
 ```
 | Driver          | Option A (JWT) | Option B (Sessions) |
 |-----------------|---------------|---------------------|
@@ -340,6 +348,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 ```
 
 **ADR Fields:** Architecture Decision Record structure
+
 ```
 **Status:** Proposed
 **Context:** {Why this decision is needed}
@@ -352,6 +361,7 @@ When `--consensus` is present — either passed by DM delegation or included dir
 For deliberate or high-risk work, add:
 
 **Pre-mortem Analysis:**
+
 ```
 What could go wrong:
 - Password hashing misconfiguration
@@ -441,16 +451,19 @@ Before considering a plan complete, verify:
 ## Examples
 
 ### Good Questions (Ask Users)
+
 - "Do you prefer simplicity or performance for this feature?"
 - "Should we support multiple authentication providers or just email/password for now?"
 - "What's more important: fast implementation or extensive testing?"
 
 ### Bad Questions (Research Instead)
+
 - "Where is the authentication code?" → Use Explore agent
 - "What database are we using?" → Use Grep/Read to find config
 - "How is error handling currently done?" → Delegate to explore agent
 
 ### Good Plan Steps
+
 ```
 ### Step 2: Registration Endpoint
 - [ ] Implement POST /api/register with email/password validation
@@ -460,6 +473,7 @@ Before considering a plan complete, verify:
 ```
 
 ### Bad Plan Steps (Too Vague)
+
 ```
 ### Step 2: Registration
 - [ ] Implement registration
@@ -467,6 +481,7 @@ Before considering a plan complete, verify:
 ```
 
 ### Bad Plan Steps (Too Granular)
+
 ```
 ### Step 2a: Define registration route
 - [ ] Add route definition

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -419,7 +419,7 @@ Track unresolved questions in `~/.ai-tpk/plans/{REPO_SLUG}/{SESSION_TS}-{feature
 - Before finalizing plan if assumptions need validation
 - When user explicitly defers a decision
 
-## Success Criteria
+## Pathfinder Quality Gates
 
 Before considering a plan complete, verify:
 

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -11,6 +11,7 @@ permissionMode: acceptEdits
 # Quill - Documentation Specialist Agent
 
 ## Core Mission
+
 Transform intricate codebases and system designs into accessible documentation that expedites developer onboarding while decreasing support overhead.
 
 ## Documentation Style

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -158,7 +158,7 @@ Expand A02 (Cryptographic Failures) with:
 - **Double-spend / double-submit**: Can a state-changing operation be triggered concurrently, bypassing idempotency guards?
 - **Atomicity**: Are multi-step authorization flows atomic, or can an attacker exploit partial completion?
 
-5. **Prioritize and Deliver Remediation**
+1. **Prioritize and Deliver Remediation**
    - Rank findings by severity × exploitability × blast radius
    - Provide location-specific fixes with secure code examples
 
@@ -170,7 +170,7 @@ Permitted tools include Grep for pattern detection, Bash for dependency audits, 
 
 **For plan reviews, structure output as:**
 
-### Security Review Summary
+### Plan Review Summary
 
 - **Artifact**: Plan file reviewed
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
@@ -191,13 +191,13 @@ For each gap:
 
 Recommended additions to the plan (threat modeling, security testing, hardening steps).
 
-### Verdict Rationale
+### Plan Verdict Rationale
 
 Why this verdict was chosen based on identified security risks.
 
 **For implementation reviews, structure output as:**
 
-### Security Review Summary
+### Implementation Review Summary
 
 - **Scope**: Components, files, and attack surface reviewed
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
@@ -232,7 +232,7 @@ For each vulnerability:
 - [x] Error handling reviewed
 - [x] OWASP Top 10 evaluated
 
-### Verdict Rationale
+### Implementation Verdict Rationale
 
 Why this verdict was chosen based on security posture.
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -158,7 +158,8 @@ Expand A02 (Cryptographic Failures) with:
 - **Double-spend / double-submit**: Can a state-changing operation be triggered concurrently, bypassing idempotency guards?
 - **Atomicity**: Are multi-step authorization flows atomic, or can an attacker exploit partial completion?
 
-1. **Prioritize and Deliver Remediation**
+<!-- markdownlint-disable-next-line MD029 -->
+5. **Prioritize and Deliver Remediation**
    - Rank findings by severity × exploitability × blast radius
    - Provide location-specific fixes with secure code examples
 

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -26,6 +26,7 @@ invoke_when: "security-sensitive features or when Ruinor flags security concerns
 **Not invoked for:** Simple UI changes, configuration updates, documentation, or features with no security implications.
 
 ## Core Mission
+
 The Riskmancer agent identifies and prioritizes security vulnerabilities before production deployment, focusing on OWASP Top 10 analysis, secrets detection, input validation, and authentication checks.
 
 This is a **specialist reviewer** invoked only when security-sensitive work is detected or explicitly requested. Ruinor handles baseline security checks (obvious injection, exposed secrets) for all reviews.
@@ -57,6 +58,7 @@ See `claude/references/review-gates.md` for the shared gate framework and operat
 - Validate input handling, auth, and encryption
 
 ## Key Responsibilities
+
 - Review plans for security gaps and missing threat considerations
 - Evaluate all applicable OWASP Top 10 categories in code
 - Conduct secrets scanning for hardcoded credentials
@@ -161,6 +163,7 @@ Expand A02 (Cryptographic Failures) with:
    - Provide location-specific fixes with secure code examples
 
 ## Tool Usage
+
 Permitted tools include Grep for pattern detection, Bash for dependency audits, and Read for code examination.
 
 ## Output Standards
@@ -168,12 +171,14 @@ Permitted tools include Grep for pattern detection, Bash for dependency audits, 
 **For plan reviews, structure output as:**
 
 ### Security Review Summary
+
 - **Artifact**: Plan file reviewed
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Risk Level**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X security gaps identified
 
 ### Security Gaps in Plan
+
 For each gap:
 - **ID**: SG-{number}
 - **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -183,20 +188,24 @@ For each gap:
 - **Recommendation**: Specific security steps to add to the plan
 
 ### Security Enhancements
+
 Recommended additions to the plan (threat modeling, security testing, hardening steps).
 
 ### Verdict Rationale
+
 Why this verdict was chosen based on identified security risks.
 
 **For implementation reviews, structure output as:**
 
 ### Security Review Summary
+
 - **Scope**: Components, files, and attack surface reviewed
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Overall Risk Level**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X CRITICAL, Y HIGH, Z MEDIUM vulnerabilities
 
 ### Vulnerability Findings
+
 For each vulnerability:
 - **ID**: V-{number}
 - **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -208,12 +217,15 @@ For each vulnerability:
 - **Remediation**: Specific fix with secure code example
 
 ### Secrets Scan Results
+
 - Hardcoded credentials, API keys, tokens found
 
 ### Dependency Audit Results
+
 - Vulnerable dependencies with CVE IDs and patch recommendations
 
 ### Security Checklist
+
 - [x] Input validation reviewed
 - [x] Authentication/authorization reviewed
 - [x] Secrets management reviewed
@@ -221,6 +233,7 @@ For each vulnerability:
 - [x] OWASP Top 10 evaluated
 
 ### Verdict Rationale
+
 Why this verdict was chosen based on security posture.
 
 ## Verdict and Severity Reference

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -83,6 +83,7 @@ See `claude/references/implementation-standards.md` for shared behavioral norms 
 ## Investigation Protocol
 
 ### Phase 1: Pre-commitment
+
 Before reviewing, establish:
 - What is being reviewed (plan, code change, design document)?
 - What are the stated objectives and acceptance criteria?
@@ -91,6 +92,7 @@ Before reviewing, establish:
 - Read all relevant artifacts thoroughly before forming any opinion.
 
 ### Phase 2: Verification
+
 Verify factual claims and assumptions:
 - Do file paths, function names, and references actually exist?
 - Are stated behaviors accurate based on actual code?
@@ -123,11 +125,13 @@ For plan reviews:
 - **Sequencing check**: Can steps be executed in the stated order? Are there circular dependencies?
 
 ### Phase 4: Gap Analysis, Self-Audit, and Realist Check
+
 - **Gap Analysis**: What is missing that should be present? What scenarios are unaddressed? What assumptions are unstated?
 - **Self-Audit**: Challenge your own findings. Are you being fair? Is each finding actionable and justified? Remove any finding that is speculative or nitpicky without substance. Distinguish genuine flaws from stylistic preferences.
 - **Realist Check**: Given real-world constraints (time, team size, project stage), are your expectations reasonable? Distinguish between "must fix" and "ideally would fix." Pressure-test severity against realistic worst-case scenarios and mitigating factors.
 
 ### Phase 5: Specialist Assessment
+
 After completing the multi-perspective review, assess whether specialist-level concerns warrant deeper investigation:
 
 Note: The Dungeon Master's heuristic-fallback specialist-routing keyword list is maintained in `claude/references/specialist-triggering.md`. The criteria below are Ruinor's own prose-based specialist-flagging logic and are intentionally distinct from that keyword list, but the two should remain semantically aligned — when adding or removing a specialist-flagging condition here, consider whether the corresponding keyword list also needs an update.
@@ -170,6 +174,7 @@ Note: The Dungeon Master's heuristic-fallback specialist-routing keyword list is
 - The risk or complexity justifies the additional review cost
 
 ### Phase 6: Synthesis
+
 - Compare findings against pre-commitment predictions
 - Compile all validated findings
 - Assign severity to each finding
@@ -198,6 +203,7 @@ In ADVERSARIAL mode:
 Structure every review as follows:
 
 ### Review Summary
+
 - **Artifact**: What was reviewed
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Mode**: Standard | Adversarial
@@ -205,6 +211,7 @@ Structure every review as follows:
 - **Specialist Review Recommended**: None | Riskmancer | Windwarden | Knotcutter | Truthhammer | Multiple (comma-separated)
 
 ### Pre-commitment Predictions
+
 What you predicted you would find vs. what you actually found.
 
 ### Findings
@@ -219,6 +226,7 @@ For each finding:
 - **Recommendation**: Specific, actionable fix
 
 ### Gap Analysis
+
 What is missing or unaddressed.
 
 ### Specialist Recommendations (if applicable)
@@ -234,6 +242,7 @@ What is missing or unaddressed.
 *Note: Only include specialists that are actually recommended. Omit this section entirely if no specialist reviews are needed.*
 
 ### Verdict Rationale
+
 Brief explanation of why this verdict was chosen.
 
 ## Verdict and Severity Reference

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -127,6 +127,7 @@ graph LR
 ```
 
 ---
+
 ```
 
 **Session ID display rules:**
@@ -210,4 +211,3 @@ Unlike the old hook-based Talekeeper, this agent is user-facing. Errors should b
 | `Write` | Append to `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrative.md` and `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-narrated-sessions.json` |
 
 No other tools are used. `Bash`, `Grep`, and sub-agents are not available to Talekeeper and must not be invoked.
-

--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -131,16 +131,21 @@ If confirming a hypothesis requires running a prohibited command, note this in t
 ## Anti-patterns
 
 ### Scope Creep
+
 Investigating tangential issues beyond the specific question asked. The investigation boundary is the reported symptom. Adjacent anomalies are noted in the report, not pursued.
 
 ### Premature Diagnosis
+
 Declaring a root cause before gathering sufficient evidence. A hypothesis is not a diagnosis. Tracebloom does not close the report until the evidence confirms or eliminates candidates.
 
 ### Hypothesis Without External Data
+
 Forming hypotheses from code analysis alone without querying available runtime data sources (logs, metrics, Kubernetes state). This is distinct from Premature Diagnosis: a report can satisfy the Premature Diagnosis check — it may be formally complete with well-supported candidates — while never having touched an MCP tool. The report looks thorough but lacks runtime grounding. Premature Diagnosis guards against closing too early; this anti-pattern guards against investigating with the wrong inputs. Code analysis identifies candidates; logs and metrics confirm or rule them out.
 
 ### Fix Drift
+
 Slipping from investigation into suggesting implementation details. The Diagnostic Report recommends a *next action*, not a *solution design*. The how of fixing belongs to Pathfinder and Bitsmith.
 
 ### Write Temptation
+
 Attempting to use Write or Edit tools, or running write-bearing Bash commands. Read only. Always. The forest teaches by being observed, not by being rearranged.

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -124,7 +124,7 @@ Every Truthhammer review must include the following footer disclaimer verbatim:
 
 ## Investigation Protocol
 
-### For plan reviews:
+### For plan reviews
 
 1. **Scan for factual claims**: Read the plan in full. Identify every claim that asserts specific behavior, configuration, or compatibility of an external system. Catalog each claim with its location in the plan.
 
@@ -139,7 +139,7 @@ Every Truthhammer review must include the following footer disclaimer verbatim:
 
 5. **Synthesize findings**: Compile all classified claims. Apply severity levels. Determine verdict.
 
-### For implementation reviews:
+### For implementation reviews
 
 1. **Scan code for external system interactions**: Identify API calls, config value reads/writes, CLI invocations, and env var references that involve external systems.
 
@@ -183,6 +183,7 @@ See `claude/references/verdict-taxonomy.md` for the level definitions and the ra
 Structure every review as follows:
 
 ### Factual Validation Summary
+
 - **Artifact**: What was reviewed (plan file or code files)
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Confidence Level**: HIGH (multiple sources confirmed) | MEDIUM (single source confirmed) | LOW (limited verification possible)
@@ -207,9 +208,11 @@ For each CONTRADICTED or UNVERIFIABLE claim:
 - **Recommendation**: Specific correction or verification action required
 
 ### Verification Coverage
+
 Summary of how many claims were identified and what percentage were verifiable.
 
 ### Verdict Rationale
+
 Brief explanation of why this verdict was chosen based on classification results.
 
 ---

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -150,30 +150,32 @@ Classify the feature as read-heavy, write-heavy, or mixed, then apply the approp
 
 **Mixed:** Assess whether CQRS separation would reduce contention or add unjustified complexity.
 
-1. **Analyze Database Performance**
+<!-- markdownlint-disable MD029 -->
+2. **Analyze Database Performance**
    - Run EXPLAIN on queries to check execution plans
    - Identify missing indexes (full table scans)
    - Detect N+1 query patterns
    - Check for SELECT * when specific fields suffice
    - Validate proper use of eager loading vs. lazy loading
 
-2. **Assess Resource Usage**
+3. **Assess Resource Usage**
    - Memory allocations in loops
    - File handles, connections not properly closed
    - Large objects held in memory unnecessarily
    - Inefficient serialization/deserialization
 
-3. **Check Caching & Optimization**
+4. **Check Caching & Optimization**
    - Expensive operations cached appropriately
    - Cache TTL and invalidation strategy
    - Memoization opportunities
    - Computed values vs. repeated calculations
 
-4. **Validate Scalability Patterns**
+5. **Validate Scalability Patterns**
    - Pagination implemented correctly
    - Rate limiting and throttling in place
    - Bulk operations batched appropriately
    - Background jobs for heavy processing
+<!-- markdownlint-enable MD029 -->
 
 ### Capacity Modeling and Cost Awareness
 

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -112,13 +112,13 @@ See `claude/references/review-gates.md` for the shared gate framework and operat
    - Map API call chains and external dependencies
    - Locate synchronous operations that could be async
 
-#### Bottleneck Identification (Amdahl's Law)
+### Bottleneck Identification (Amdahl's Law)
 
 1. Classify each component in the request path as **I/O-bound** (database, network, disk) or **CPU-bound** (computation, serialization, encryption).
 2. Identify the single highest-latency or highest-cost component — this is the bottleneck.
 3. Apply Amdahl's Law: optimizing non-bottleneck components yields diminishing returns. State explicitly: _"The bottleneck is [X]. Optimizing [Y] will not meaningfully improve end-to-end performance until [X] is addressed."_
 
-#### Latency Budget Decomposition
+### Latency Budget Decomposition
 
 For latency-sensitive features:
 - Define the end-to-end latency target (e.g., P99 < 200ms)
@@ -126,7 +126,7 @@ For latency-sensitive features:
 - Flag components whose actual or estimated latency exceeds their budget
 - Identify high-variance components (P99/P50 ratio > 5×) — these are SLO risk even if P50 is acceptable
 
-#### Concurrency and Contention Analysis
+### Concurrency and Contention Analysis
 
 - **Connection pool sizing**: Is the pool size matched to expected concurrent requests? Undersized pools cause queueing; oversized pools can exhaust database connections.
 - **Lock contention**: Identify database row-level locks, mutex usage, and distributed locks that could become bottlenecks under concurrency.
@@ -134,7 +134,7 @@ For latency-sensitive features:
 - **Concurrency strategy fitness**: Is optimistic concurrency (compare-and-swap, versioning) or pessimistic locking (SELECT FOR UPDATE) appropriate given the conflict rate?
 - **Async/thread starvation**: Can blocking operations starve the thread pool or event loop?
 
-#### Read Path vs Write Path Analysis
+### Read Path vs Write Path Analysis
 
 Classify the feature as read-heavy, write-heavy, or mixed, then apply the appropriate lens:
 
@@ -150,26 +150,26 @@ Classify the feature as read-heavy, write-heavy, or mixed, then apply the approp
 
 **Mixed:** Assess whether CQRS separation would reduce contention or add unjustified complexity.
 
-2. **Analyze Database Performance**
+1. **Analyze Database Performance**
    - Run EXPLAIN on queries to check execution plans
    - Identify missing indexes (full table scans)
    - Detect N+1 query patterns
    - Check for SELECT * when specific fields suffice
    - Validate proper use of eager loading vs. lazy loading
 
-3. **Assess Resource Usage**
+2. **Assess Resource Usage**
    - Memory allocations in loops
    - File handles, connections not properly closed
    - Large objects held in memory unnecessarily
    - Inefficient serialization/deserialization
 
-4. **Check Caching & Optimization**
+3. **Check Caching & Optimization**
    - Expensive operations cached appropriately
    - Cache TTL and invalidation strategy
    - Memoization opportunities
    - Computed values vs. repeated calculations
 
-5. **Validate Scalability Patterns**
+4. **Validate Scalability Patterns**
    - Pagination implemented correctly
    - Rate limiting and throttling in place
    - Bulk operations batched appropriately

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -190,7 +190,7 @@ Windwarden uses **Scale B (CRITICAL / HIGH / MEDIUM / LOW)** for performance rev
 
 ### Domain-Specific Severity Application — Performance Examples
 
-Windwarden uses Scale B (CRITICAL / HIGH / MEDIUM / LOW) as defined in `claude/references/verdict-taxonomy.md`. The examples below illustrate what each level looks like in the performance domain — they are *examples of application*, not redefinitions of what the levels mean.
+Windwarden uses Scale B (CRITICAL / HIGH / MEDIUM / LOW) as defined in `claude/references/verdict-taxonomy.md`. The examples below illustrate what each level looks like in the performance domain — they are _examples of application_, not redefinitions of what the levels mean.
 
 **CRITICAL:**
 - Unbounded loops over large datasets
@@ -222,12 +222,14 @@ Windwarden uses Scale B (CRITICAL / HIGH / MEDIUM / LOW) as defined in `claude/r
 Structure every review as follows:
 
 ### Performance Review Summary
+
 - **Artifact**: What was reviewed (plan file or code files)
 - **Verdict**: One of the four verdicts defined in `claude/references/verdict-taxonomy.md`
 - **Performance Impact**: CRITICAL | HIGH | MEDIUM | LOW
 - **Findings**: X CRITICAL, Y HIGH, Z MEDIUM, W LOW
 
 ### Performance Analysis
+
 Brief overview of the performance characteristics and main concerns.
 
 ### Findings
@@ -243,12 +245,15 @@ For each finding:
 - **Optimization**: Specific fix with improved approach or code example
 
 ### Performance Gaps
+
 What performance considerations are missing or unaddressed.
 
 ### Benchmark Recommendations
+
 Suggested performance tests or metrics to validate the fix.
 
 ### Verdict Rationale
+
 Brief explanation of why this verdict was chosen based on performance impact.
 
 ## Critical Constraints

--- a/claude/commands/review-pr.md
+++ b/claude/commands/review-pr.md
@@ -118,6 +118,7 @@ Print a consolidated review report inline. Do NOT delegate further, enter Phase 
 DM's normal review-revise loop. The summary IS the outcome.
 
 **PR header:**
+
 ```
 PR #<pr-number> — <pr-title>
 <pr-url>

--- a/claude/references/bash-style.md
+++ b/claude/references/bash-style.md
@@ -11,6 +11,7 @@ Never chain commands using `&&` or `;` as sequential execution operators. Always
 Pipes (`|`) are permitted **only for data transformation** (feeding the output of one command into a filter). Do not use pipes as a substitute for sequential control flow.
 
 **Wrong — sequential chaining:**
+
 ```bash
 mkdir -p foo && cd foo && git init
 ```
@@ -21,6 +22,7 @@ mkdir -p foo && cd foo && git init
 3. `git init`
 
 **Wrong — pipe as control flow:**
+
 ```bash
 git stash && git pull | grep "Already up to date"
 ```
@@ -31,6 +33,7 @@ git stash && git pull | grep "Already up to date"
 3. `git log --oneline -5`  ← prefer `-5` flag over `git log | head -5`
 
 **Acceptable — pipe for data transformation (no tool-native alternative):**
+
 ```bash
 grep "ERROR" app.log | wc -l
 ```
@@ -42,6 +45,7 @@ Never use process substitution (`<(cmd)` or `>(cmd)`). Each substitution spawns 
 **Enforcement:** This rule is enforced automatically by the `PermissionRequest` hook (`permission-learn.sh`). Any command containing `<(` or `>(` outside of quoted strings will be denied.
 
 **Wrong — process substitution:**
+
 ```bash
 diff <(sort file1.txt) <(sort file2.txt)
 ```
@@ -52,6 +56,7 @@ diff <(sort file1.txt) <(sort file2.txt)
 3. `diff /tmp/sorted1.txt /tmp/sorted2.txt`
 
 **Wrong — output process substitution:**
+
 ```bash
 tee >(grep ERROR > errors.log) < app.log
 ```
@@ -77,6 +82,7 @@ Use multiple `-m` flags on a single `git commit` command instead. Git allows `-m
 **Enforcement:** `permission-learn.sh` Guard 5 (`is_simple_expansion_only`) blocks auto-approval for any command containing `$(`. The command falls through to the interactive permission dialog instead of being auto-approved. (This is not a hard deny -- the dialog still allows manual approval, but it breaks unattended operation.)
 
 **Wrong -- command substitution in commit:**
+
 ```bash
 git commit -m "$(cat <<'EOF'
 feat(api): add batch endpoint
@@ -87,6 +93,7 @@ EOF
 ```
 
 **Wrong -- heredoc temp-file pattern (also triggers permission dialogs):**
+
 ```bash
 cat > /tmp/claude-commit-msg.txt <<'EOF'
 feat(api): add batch endpoint
@@ -94,6 +101,7 @@ feat(api): add batch endpoint
 Implements batch processing for bulk operations.
 EOF
 ```
+
 ```bash
 git commit -F /tmp/claude-commit-msg.txt
 ```
@@ -101,16 +109,19 @@ git commit -F /tmp/claude-commit-msg.txt
 The temp-file approach fails for three reasons: `cat` is not in the auto-approve allowlist, `>` redirection fails Guard 5, and the multi-line heredoc body triggers the compound-command hard deny (newline count > 0).
 
 **Right -- multiple `-m` flags (subject only):**
+
 ```bash
 git commit -m "feat(api): add batch endpoint"
 ```
 
 **Right -- multiple `-m` flags (subject + body):**
+
 ```bash
 git commit -m "feat(api): add batch endpoint" -m "Implements batch processing for bulk operations."
 ```
 
 **Right -- multiple `-m` flags (subject + body + footer):**
+
 ```bash
 git commit -m "feat(api): add batch endpoint" -m "Implements batch processing for bulk operations." -m "BREAKING CHANGE: removes legacy single-item endpoint"
 ```

--- a/claude/skills/skill-creator/SKILL.md
+++ b/claude/skills/skill-creator/SKILL.md
@@ -256,7 +256,7 @@ Put each with_skill version before its baseline counterpart.
 
 Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
 
-5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+1. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
 
 ### What the user sees in the viewer
 

--- a/claude/skills/skill-creator/SKILL.md
+++ b/claude/skills/skill-creator/SKILL.md
@@ -256,7 +256,8 @@ Put each with_skill version before its baseline counterpart.
 
 Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
 
-1. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+<!-- markdownlint-disable-next-line MD029 -->
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
 
 ### What the user sees in the viewer
 

--- a/claude/skills/skill-creator/SKILL.md
+++ b/claude/skills/skill-creator/SKILL.md
@@ -98,6 +98,7 @@ These word counts are approximate and you can feel free to go longer if needed.
 - For large reference files (>300 lines), include a table of contents
 
 **Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+
 ```
 cloud-deploy/
 ├── SKILL.md (workflow + selection)
@@ -106,6 +107,7 @@ cloud-deploy/
     ├── gcp.md
     └── azure.md
 ```
+
 Claude reads only the relevant reference file.
 
 #### Principle of Lack of Surprise
@@ -117,6 +119,7 @@ This goes without saying, but skills must not contain malware, exploit code, or 
 Prefer using the imperative form in instructions.
 
 **Defining output formats** - You can do it like this:
+
 ```markdown
 ## Report structure
 ALWAYS use this exact template:
@@ -127,6 +130,7 @@ ALWAYS use this exact template:
 ```
 
 **Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+
 ```markdown
 ## Commit message format
 **Example 1:**
@@ -225,15 +229,18 @@ Once all runs are done:
 1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
 
 2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+
    ```bash
    python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
    ```
+
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
 Put each with_skill version before its baseline counterpart.
 
 3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
 
 4. **Launch the viewer** with both qualitative outputs and quantitative data:
+
    ```bash
    nohup python <skill-creator-path>/eval-viewer/generate_review.py \
      <workspace>/iteration-N \
@@ -242,6 +249,7 @@ Put each with_skill version before its baseline counterpart.
      > /dev/null 2>&1 &
    VIEWER_PID=$!
    ```
+
    For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
 
    **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -60,6 +60,7 @@ All guards operate on single-quote-stripped input so that dangerous constructs i
 - Requires `jq`; fails gracefully if unavailable
 
 **Log format** (`~/.claude/permission-requests.log`):
+
 ```
 2026-04-09T14:27:44Z | agent_type=Bitsmith | agent_id=abc123 | [auto-approved] command=git log --format=$FORMAT
 2026-04-09T14:27:50Z | agent_type=Bitsmith | agent_id=abc123 | command=docker ps

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -73,6 +73,7 @@ The project uses **oxlint** (TypeScript linter) and **oxfmt** (code formatter) t
 **pnpm scripts:**
 
 - `pnpm run lint` — Run oxlint to check for TypeScript errors and code quality issues
+- `pnpm run lint:md` — Run markdownlint across all Markdown files (ignores `node_modules`, `plans`, `lessons`, `docs/superpowers`, `claude/cache`)
 - `pnpm run format` — Apply oxfmt formatting to all TypeScript files in `src/`
 - `pnpm run format:check` — Check formatting without modifying files (used in CI)
 
@@ -82,7 +83,7 @@ Before committing code, run `pnpm run format` to auto-format your changes. This 
 
 **Pre-Push Hook:**
 
-Lefthook runs lint and format checks on every push when JS/TS files have changed. If either check fails, the push is blocked. Run `pnpm run format` to auto-fix formatting issues. Hook configuration lives in `lefthook.yml`.
+Lefthook runs lint, format, and Markdown lint checks on every push. JS/TS file changes trigger `pnpm run lint` and `pnpm run format:check`; Markdown file changes trigger `pnpm run lint:md`. If any check fails, the push is blocked. Run `pnpm run format` to auto-fix TypeScript formatting issues. Markdown violations must be fixed manually. Hook configuration lives in `lefthook.yml`.
 
 ### Development Workflow
 
@@ -92,7 +93,7 @@ When making changes to this repository:
 2. **Make changes** — Edit TypeScript files in `src/installer/` or `src/launcher/`, or configuration files in `claude/`
 3. **Build and reinstall** — Run `pnpm run build` to rebuild the installer bundle, then `./install.sh` to deploy to `~/.claude/`, then `./clean-backups.sh` to remove stale backups. The `/build-and-install` repo-scope slash command automates all three steps in sequence.
 4. **Test** — Run `pnpm test` to execute the test suite
-5. **Lint and format** — Run `pnpm run format` to auto-fix formatting, then `pnpm run lint` to verify code quality
+5. **Lint and format** — Run `pnpm run format` to auto-fix TypeScript formatting, then `pnpm run lint` to verify code quality, and `pnpm run lint:md` to verify Markdown style
 6. **Commit and push** — The pre-push hook (Lefthook) automatically runs linting and format checks; they must pass before pushing
 
 ## Updating

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,6 +9,7 @@ Node.js >= 18.18.0 is required to run `install.sh`. The installer is implemented
 ## Quick Install
 
 Clone the repository:
+
 ```bash
 git clone git@github.com:alkofu/ai-tpk.git
 cd ai-tpk

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -12,9 +12,11 @@ Currently configured servers:
 - **AWS CloudWatch MCP Server** (`awslabs.cloudwatch-mcp-server@0.0.19`) — CloudWatch Metrics, Alarms, and Logs access via `~/.aws` credentials. Uses `src/mcp/wrappers/mcp-cloudwatch.sh` for dynamic AWS profile selection (set with `/set-aws-profile`). Requires `uvx`. Skips setup gracefully if `~/.aws/credentials` does not exist.
 - **Grafana MCP Server** (`mcp-grafana`) — Grafana dashboards, datasources, and incident access. Uses `src/mcp/wrappers/mcp-grafana.sh`, which requires `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` in the shell environment.
 - **GitHub MCP Server** (`@modelcontextprotocol/server-github@2025.4.8`) — Multi-account GitHub repository, issue, PR, and code search access via `~/.config/tpk/github-pats.json`. Define your accounts as a flat JSON object mapping account names to PATs:
+
   ```json
   {"personal": "ghp_xxx", "work": "ghp_yyy"}
   ```
+
   **Set the file mode to `0600` immediately after creation: `chmod 600 ~/.config/tpk/github-pats.json`.** The file holds long-lived GitHub PATs in plaintext; on multi-user hosts a default umask (`022`) leaves it world-readable. The wrapper refuses to read the file at MCP-server boot if the mode is broader than `0600`, and the installer prints a warning.
 
   Each key becomes the suffix of a registered MCP server (`github-personal`, `github-work`) and a tool namespace (`mcp__github-personal__*`, `mcp__github-work__*`). Account keys must match `^[a-zA-Z0-9_.-]+$`.
@@ -25,9 +27,11 @@ Currently configured servers:
 
   If `~/.config/tpk/github-pats.json` is missing or empty (`{}`) at install time, GitHub MCP setup is skipped with a yellow warning and installation continues. On each run, the installer also removes the legacy `github` (no suffix) registration, removes stale `github-<key>` registrations, and removes stale `mcp__github-<key>__*` allow-list entries for keys no longer present in the PATs file.
 - **ArgoCD MCP Server** (`argocd-mcp@0.5.0`) — Multi-cluster ArgoCD access via `~/.config/tpk/argocd-accounts.json`. Define your clusters as a JSON object mapping cluster names to `{ url, token }` pairs:
+
   ```json
   { "prod": { "url": "https://argocd.prod.example.com", "token": "..." }, "staging": { "url": "https://argocd.staging.example.com", "token": "..." } }
   ```
+
   **Set the file mode to `0600` immediately after creation: `chmod 600 ~/.config/tpk/argocd-accounts.json`.** ArgoCD tokens are equivalent in sensitivity to GitHub PATs; the wrapper refuses to read the file if the mode is broader than `0600`.
 
   Cluster names (keys) must match `^[a-zA-Z0-9_.-]+$`. The selected cluster is written to `~/.claude/.current-argocd-cluster` by the launcher and read at wrapper boot time. Rotating a token in `~/.config/tpk/argocd-accounts.json` takes effect on the next MCP server boot without re-running `install.sh`.

--- a/docs/TPK.md
+++ b/docs/TPK.md
@@ -48,10 +48,13 @@ This is useful for scripts, hot-key launches, and users who never want to see th
 **Strict failure behaviour** — `--skip` never falls back to the interactive flow. Instead it exits non-zero with a clear error message in two cases:
 
 - **No saved config:** If `~/.config/tpk/config.json` contains no MCP selections, the launcher prints to stderr and exits with code 1:
+
   ```
   No saved config found — run tpk without --skip first to configure.
   ```
+
 - **Stale saved config:** If the saved config cannot be resolved (e.g. the saved Grafana cluster ID no longer exists in `~/.config/tpk/grafana-clusters.yaml`), the launcher prints to stderr and exits with code 1:
+
   ```
   Saved config could not be resolved (e.g. Grafana cluster is no longer valid) — re-run tpk without --skip to reconfigure.
   ```
@@ -162,6 +165,7 @@ When "ArgoCD" is selected, the launcher reads this file and prompts you to selec
 ## Environment Variables Set by tpk
 
 When you select Grafana with Viewer role, the launcher sets:
+
 ```
 GRAFANA_URL={cluster_url}
 GRAFANA_SERVICE_ACCOUNT_TOKEN={viewer_token}
@@ -169,22 +173,26 @@ GRAFANA_DISABLE_WRITE=true
 ```
 
 When you select Grafana with Editor role:
+
 ```
 GRAFANA_URL={cluster_url}
 GRAFANA_SERVICE_ACCOUNT_TOKEN={editor_token}
 ```
 
 When you select CloudWatch:
+
 ```
 AWS_PROFILE={profile}
 ```
 
 When you select GCP Observability:
+
 ```
 GOOGLE_CLOUD_PROJECT={project_id}
 ```
 
 When you select Kubernetes:
+
 ```
 K8S_CONTEXT={context_name}
 ```

--- a/docs/adrs/REVIEW_WORKFLOW.md
+++ b/docs/adrs/REVIEW_WORKFLOW.md
@@ -261,6 +261,7 @@ claude --agent dungeonmaster "Major feature overhaul --review-all"
 Ruinor's 6-phase investigation protocol includes **Phase 5: Specialist Assessment**, where it evaluates whether concerns extend beyond baseline checks.
 
 **Example Ruinor output:**
+
 ```
 ### Specialist Recommendations
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,3 +6,6 @@ pre-push:
     format-check:
       glob: "**/*.{js,jsx,ts,tsx,mjs,cjs}"
       run: pnpm run format:check
+    lint-md:
+      glob: "**/*.md"
+      run: pnpm run lint:md

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^25.6.0",
     "esbuild": "^0.28.0",
     "lefthook": "^2.1.6",
+    "markdownlint-cli": "0.45.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
     "tsx": "^4.21.0",
@@ -26,6 +27,7 @@
     "launch": "tsx src/launcher/main.ts",
     "test": "node --import tsx/esm --test 'src/installer/**/*.test.ts' 'src/launcher/**/*.test.ts'",
     "lint": "oxlint src/installer/ src/launcher/",
+    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache'",
     "format": "oxfmt --write src/installer/ src/launcher/",
     "format:check": "oxfmt --check src/installer/ src/launcher/"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
+      markdownlint-cli:
+        specifier: 0.45.0
+        version: 0.45.0
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0
@@ -357,6 +360,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     resolution: {integrity: sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -601,8 +616,71 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -623,6 +701,10 @@ packages:
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -630,6 +712,54 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
 
   lefthook-darwin-arm64@2.1.6:
     resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
@@ -685,6 +815,118 @@ packages:
     resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  markdownlint-cli@0.45.0:
+    resolution: {integrity: sha512-GiWr7GfJLVfcopL3t3pLumXCYs8sgWppjIA1F/Cc3zIMgD3tmkpyZ1xkm1Tej8mw53B93JsDjgA3KOftuYcfOw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  markdownlint@0.38.0:
+    resolution: {integrity: sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ==}
+    engines: {node: '>=20'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   oxfmt@0.45.0:
     resolution: {integrity: sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -700,11 +942,53 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  run-con@1.3.2:
+    resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  smol-toml@1.3.4:
+    resolution: {integrity: sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==}
+    engines: {node: '>= 18'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
@@ -720,8 +1004,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -898,6 +1190,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@9.0.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     optional: true
 
@@ -1012,9 +1312,55 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.60.0':
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/katex@0.16.8': {}
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/unist@2.0.11': {}
+
+  argparse@2.0.1: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  commander@13.1.0: {}
+
+  commander@8.3.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  deep-extend@0.6.0: {}
+
+  dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  entities@4.5.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1084,12 +1430,59 @@ snapshots:
     dependencies:
       fast-string-width: 1.1.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.0.3
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  ignore@7.0.5: {}
+
+  ini@4.1.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsonc-parser@3.3.1: {}
+
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
 
   lefthook-darwin-arm64@2.1.6:
     optional: true
@@ -1133,6 +1526,234 @@ snapshots:
       lefthook-openbsd-x64: 2.1.6
       lefthook-windows-arm64: 2.1.6
       lefthook-windows-x64: 2.1.6
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  lru-cache@11.3.5: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdownlint-cli@0.45.0:
+    dependencies:
+      commander: 13.1.0
+      glob: 11.0.3
+      ignore: 7.0.5
+      js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
+      markdown-it: 14.1.1
+      markdownlint: 0.38.0
+      minimatch: 10.0.3
+      run-con: 1.3.2
+      smol-toml: 1.3.4
+    transitivePeerDependencies:
+      - supports-color
+
+  markdownlint@0.38.0:
+    dependencies:
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-extension-directive: 4.0.0
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-math: 3.1.0
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdurl@2.0.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.45
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.1
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
 
   oxfmt@0.45.0:
     dependencies:
@@ -1180,9 +1801,49 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.60.0
       '@oxlint/binding-win32-x64-msvc': 1.60.0
 
+  package-json-from-dist@1.0.1: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
+
+  punycode.js@2.3.1: {}
+
   resolve-pkg-maps@1.0.0: {}
 
+  run-con@1.3.2:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 4.1.3
+      minimist: 1.2.8
+      strip-json-comments: 3.1.1
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
   sisteransi@1.0.5: {}
+
+  smol-toml@1.3.4: {}
+
+  strip-json-comments@3.1.1: {}
 
   tinypool@2.1.0: {}
 
@@ -1195,6 +1856,12 @@ snapshots:
 
   typescript@6.0.2: {}
 
+  uc.micro@2.1.0: {}
+
   undici-types@7.19.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   yaml@2.8.3: {}

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -192,7 +192,7 @@ Users with the legacy `~/bin/grafana-mcp` script can continue using it or switch
 
 ## GCP Observability Configuration
 
-### Prerequisites
+### GCP Observability Prerequisites
 
 Authenticate with Application Default Credentials (ADC) before running the launcher:
 
@@ -232,7 +232,7 @@ If the dotfile is absent or empty, and no project was set another way, the wrapp
 
 ## Kubernetes Configuration
 
-### Prerequisites
+### Kubernetes Prerequisites
 
 `kubectx` must be installed and on `PATH`. A valid `~/.kube/config` with at least one context must exist. The launcher does not install `kubectx` — if it is absent, the launcher logs a warning, skips the Kubernetes MCP, and continues launching Claude with the remaining selections.
 


### PR DESCRIPTION
The `.markdownlint.json` config existed but was not wired to any execution path. This PR connects it: adds a `pnpm run lint:md` npm script, a lefthook `pre-push` hook entry, and a CI step in `.github/workflows/ci.yml`. It also remediates all 166 pre-existing markdown violations across agent definitions, commands, references, skills, and docs so the gate passes immediately on merge.

Closes #289.