### PR TITLE
chore(deps): add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    versioning-strategy: 'lockfile-only'
     commit-message:
       prefix: 'chore(deps)'
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      npm-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(actions)'
+    groups:
+      actions-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,6 +6,10 @@ This document covers the Continuous Integration setup and the configuration upda
 
 Pull requests targeting `main` are validated by a GitHub Actions workflow at `.github/workflows/ci.yml`. See the workflow file for the specific checks that run. For formatting failures, run `pnpm run format` and commit the result.
 
+## Dependency Updates
+
+Dependency updates are automated via Dependabot (`.github/dependabot.yml`). On a weekly Monday schedule, Dependabot opens PRs for both the npm (pnpm-managed) and GitHub Actions ecosystems. Minor and patch updates are grouped into a single PR per ecosystem; major updates arrive as individual PRs so breaking changes can be reviewed in isolation. No manual action is required — review and merge the Dependabot PRs as they appear.
+
 ## Configuration Updates
 
 When updating Claude configurations (agents, skills, commands, hooks, references, or settings):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Pull requests targeting `main` are validated by a GitHub Actions workflow at `.g
 
 ## Dependency Updates
 
-Dependency updates are automated via Dependabot (`.github/dependabot.yml`). On a weekly Monday schedule, Dependabot opens PRs for both the npm (pnpm-managed) and GitHub Actions ecosystems. Minor and patch updates are grouped into a single PR per ecosystem; major updates arrive as individual PRs so breaking changes can be reviewed in isolation. No manual action is required — review and merge the Dependabot PRs as they appear.
+Dependency updates are automated via Dependabot (`.github/dependabot.yml`). On a weekly Monday schedule, Dependabot opens PRs for both the npm (pnpm-managed) and GitHub Actions ecosystems. Minor and patch updates are grouped into a single PR per ecosystem; major updates arrive as individual PRs so breaking changes can be reviewed in isolation. For the npm ecosystem, Dependabot uses `versioning-strategy: lockfile-only`, so its PRs update only `pnpm-lock.yaml` and leave `package.json` version ranges unchanged. No manual action is required — review and merge the Dependabot PRs as they appear.
 
 ## Configuration Updates
 


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable weekly automated dependency-update PRs for the npm (pnpm-managed) and GitHub Actions ecosystems. Minor and patch updates are grouped into a single PR per ecosystem; major updates open as individual PRs for scrutiny. The npm entry uses `versioning-strategy: lockfile-only` so Dependabot updates only `pnpm-lock.yaml` — `package.json` version ranges are left unchanged. Closes #294.