### PR TITLE
refactor(agents): compress Project Constitution Injection section in dungeonmaster.md

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -155,17 +155,7 @@ Ruinor and other reviewer agents do not receive this block — instead, pass wor
 
 **Detection path (single, deterministic):** At the start of every Pathfinder, Bitsmith, or Ruinor delegation, DM checks whether the file at `${WORKING_DIRECTORY:-$(git rev-parse --show-toplevel)}/.claude/constitution.md` exists. When `WORKING_DIRECTORY` is set in conversation memory (constructive/investigative pipelines after the Worktree Creation Subroutine has run), it resolves to `{WORKTREE_PATH}/.claude/constitution.md`. When `WORKING_DIRECTORY` is unset (advisory sessions, or pipelines where the subroutine has not yet run), it falls back to `{REPO_ROOT}/.claude/constitution.md` derived from `git rev-parse --show-toplevel`. There is no other detection path. If both resolutions fail (e.g., DM is not inside a git repository), DM skips injection silently.
 
-**Bootstrap exception:** The very first session in this repository that creates `.claude/constitution.md` (e.g., the session executing the bootstrap plan that introduced this file) will not see injection during its own Pathfinder and Bitsmith delegations, because the file does not exist on the branch the worktree was cut from at the moment those delegations are issued. Injection begins to fire as soon as the step that creates `.claude/constitution.md` completes — meaning Ruinor reviewing the bootstrap implementation will see the constitution injected, even though Pathfinder and Bitsmith producing it did not. This is an accepted bootstrap asymmetry; subsequent sessions in the same worktree (or any worktree cut from a branch where the file exists) will see injection from the first delegation onward.
-
-**Mid-session amendment behavior:** If `.claude/constitution.md` is created or modified mid-session, subsequent delegations in the same session re-read the file at delegation time and pick up the latest contents — DM does not cache the file body across delegations.
-
-**Conditional/no-op behavior:** If the resolved constitution path does not exist (bootstrap session before the file is created; DM operating in a different repo; file deleted), DM skips injection silently — no warning, no error.
-
 **Agents that receive injection:** Pathfinder, Bitsmith, and Ruinor. Do NOT inject into Quill, Tracebloom, Askmaw, Reisannin, or specialist reviewer delegations — none of these agents author plans, code, or constitution-bearing reviews.
-
-**Injection placement:**
-- For Pathfinder and Bitsmith delegations: insert the injected block **after** the Worktree Context Block (`WORKING_DIRECTORY:` / `WORKTREE_BRANCH:` / `REPO_SLUG:` lines and the trailing scope sentence) and **before** the task-specific delegation content (e.g., `## Investigation Request`, `## Confirmed Scope`, `## Plan to Revise`, or the equivalent task header for the delegation type). When `DOCS_HINT: true` is also being emitted (because `--docs` was detected in the user's message body — per the DOCS_HINT propagation rule in Phase 1 step 3), it is placed **after** the Project Constitution Injection block and **before** the task-specific delegation content. Full delegation-prompt order for Pathfinder and Bitsmith is therefore: Worktree Context Block → Project Constitution Injection (when present) → `DOCS_HINT: true` (when present) → task-specific content. Both Constitution Injection and `DOCS_HINT: true` are composed by DM at delegation time; neither is part of any static template.
-- For Ruinor delegations: Ruinor does not receive the Worktree Context Block (per the rule above). Insert the injected block at the very top of the delegation prompt, before any task-specific content.
 
 **Injected block format:** Wrap the file's contents under a `## Project Constitution` heading and follow with this exact reminder line so the receiving agent knows to apply it:
 
@@ -176,6 +166,8 @@ Ruinor and other reviewer agents do not receive this block — instead, pass wor
 
 These principles govern this repository. Plans and implementations that violate either principle will be rejected by Ruinor.
 ```
+
+For implementation mechanics — bootstrap exception, mid-session amendment behavior, conditional/no-op behavior, and full injection-placement ordering rules (including the Pathfinder/Bitsmith vs Ruinor distinction and the placement of `DOCS_HINT: true`) — see `claude/references/constitution-injection-mechanics.md`.
 
 ## Specialist Review Triggering
 

--- a/claude/references/constitution-injection-mechanics.md
+++ b/claude/references/constitution-injection-mechanics.md
@@ -1,0 +1,20 @@
+# Project Constitution Injection — Implementation Mechanics
+
+This file documents the implementation mechanics of project-constitution injection, complementing the always-on invariants defined in the `### Project Constitution Injection` section of `claude/agents/dungeonmaster.md`.
+
+## Bootstrap exception
+
+**Bootstrap exception:** The very first session in this repository that creates `.claude/constitution.md` (e.g., the session executing the bootstrap plan that introduced this file) will not see injection during its own Pathfinder and Bitsmith delegations, because the file does not exist on the branch the worktree was cut from at the moment those delegations are issued. Injection begins to fire as soon as the step that creates `.claude/constitution.md` completes — meaning Ruinor reviewing the bootstrap implementation will see the constitution injected, even though Pathfinder and Bitsmith producing it did not. This is an accepted bootstrap asymmetry; subsequent sessions in the same worktree (or any worktree cut from a branch where the file exists) will see injection from the first delegation onward.
+
+## Mid-session amendment behavior
+
+**Mid-session amendment behavior:** If `.claude/constitution.md` is created or modified mid-session, subsequent delegations in the same session re-read the file at delegation time and pick up the latest contents — DM does not cache the file body across delegations.
+
+## Conditional/no-op behavior
+
+**Conditional/no-op behavior:** If the resolved constitution path does not exist (bootstrap session before the file is created; DM operating in a different repo; file deleted), DM skips injection silently — no warning, no error.
+
+## Injection placement (full ordering rules)
+
+- For Pathfinder and Bitsmith delegations: insert the injected block **after** the Worktree Context Block (`WORKING_DIRECTORY:` / `WORKTREE_BRANCH:` / `REPO_SLUG:` lines and the trailing scope sentence) and **before** the task-specific delegation content (e.g., `## Investigation Request`, `## Confirmed Scope`, `## Plan to Revise`, or the equivalent task header for the delegation type). When `DOCS_HINT: true` is also being emitted (because `--docs` was detected in the user's message body — per the DOCS_HINT propagation rule in Phase 1 step 3 of claude/agents/dungeonmaster.md), it is placed **after** the Project Constitution Injection block and **before** the task-specific delegation content. Full delegation-prompt order for Pathfinder and Bitsmith is therefore: Worktree Context Block → Project Constitution Injection (when present) → `DOCS_HINT: true` (when present) → task-specific content. Both Constitution Injection and `DOCS_HINT: true` are composed by DM at delegation time; neither is part of any static template.
+- For Ruinor delegations: Ruinor does not receive the Worktree Context Block (per the rule above). Insert the injected block at the very top of the delegation prompt, before any task-specific content.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -41,6 +41,8 @@ Reference files contain shared behavioral vocabulary loaded by agents at runtime
 
 - **`conflict-resolution-rebase.md`** — Canonical algorithm for resolving merge conflicts during a `git rebase`. Covers conflict detection, per-file resolution strategy (preserving the incoming branch's intent), round-limit guardrails, abort conditions, and the rebase-continue loop. Consumed by the `open-pull-request` skill (sub-step 6c) and the `/resolve-conflicts` command as thin pointers to this single authoritative source.
 
+- **`constitution-injection-mechanics.md`** — Implementation mechanics for project-constitution injection in Dungeon Master delegations. Covers the bootstrap exception (when injection begins firing relative to file creation), mid-session amendment behavior (re-reading the file at each delegation), conditional/no-op behavior (silent skip when the file is absent), and the full injection placement ordering rules for Pathfinder, Bitsmith, and Ruinor delegation prompts. Loaded on-demand by DM; extracted from `dungeonmaster.md` to reduce always-on token cost.
+
 When updating a reference file, changes apply automatically to all agents that load it — no individual agent files need modification.
 
 ## Skills (`claude/skills/`)


### PR DESCRIPTION
The `### Project Constitution Injection` section in `dungeonmaster.md` contributed ~2,500–3,000 tokens to the DM's always-on prefix; roughly half of that was implementation mechanics consulted only at delegation-construction time. This PR extracts the four mechanics paragraphs (bootstrap exception, mid-session amendment behavior, conditional/no-op behavior, injection-placement ordering rules) verbatim into a new sibling reference file `claude/references/constitution-injection-mechanics.md` and replaces them with a single pointer line. No change to injection runtime behavior. Closes #312.