### PR TITLE
feat(hooks): add OSC 6800 session-metadata emission

### DIFF
--- a/claude/commands/feature-issue.md
+++ b/claude/commands/feature-issue.md
@@ -16,6 +16,14 @@ Before invoking `gh`, perform the following checks:
 
 3. **Cross-repo URL guard:** If the argument is a full URL, compare the `<owner>/<repo>` segment against the worktree's `origin` remote. If they do not match, stop and ask the user to confirm intent before continuing.
 
+### Sidecar update (ISSUE_NUM): defer to the Worktree Creation Subroutine
+
+After validating that `<argument>` resolves to a positive integer issue number `N`, record `N` in DM's session context for later use by the Worktree Creation Subroutine. This command does NOT write the sidecar directly — at this point `/feature-issue` runs in the main checkout (the worktree does not yet exist; DM creates it later via the Worktree Creation Subroutine), and the worktree slug that keys the sidecar is therefore not yet knowable.
+
+**Implementation:** Have DM remember the parsed issue number in its session context under the name `SESSION_ISSUE_NUM`. When DM later runs the Worktree Creation Subroutine (step 4a of the worktree-creation-subroutine.md), it reads its remembered `SESSION_ISSUE_NUM` and substitutes it into the bash block as the literal value of `ISSUE_NUM_VALUE` (per the substitution-variable convention in that step). The Subroutine's bash block then writes the sidecar with the correct `ISSUE_NUM` integer field.
+
+This command performs NO direct sidecar write of its own. If DM does not run the Worktree Creation Subroutine after `/feature-issue` (an unsupported flow), `ISSUE_NUM` is simply lost — no sidecar is written. This is acceptable: the fallback is graceful (advisory-mode OSC 6800 still emits without `ISSUE_NUM`).
+
 Once all guards pass, invoke `gh issue view <argument> --json title,body,labels,number,url,comments` using the Bash tool. Use this exact flag set.
 
 **On gh failure:** If `gh` fails, surface the exact error message and ask the user to either fix the problem and retry, or provide the feature description manually.

--- a/claude/commands/open-pr.md
+++ b/claude/commands/open-pr.md
@@ -21,3 +21,24 @@ Populate the fields as follows:
 - **Next action:** a contextual suggestion, e.g., "Run /merge-pr when CI passes."
 
 This section is reached only on success. If `validate-before-pr` fails or `gh pr create` fails, the existing error-reporting behavior applies — no completion report is produced.
+
+## Sidecar update (PR_NUM)
+
+On successful PR creation (after `gh pr create` returns the PR number), update the session-context sidecar to include the PR number. The sidecar is keyed by worktree-slug (not by `${CLAUDE_SESSION_ID}`, which is unavailable in hook bash contexts). This command is the sole writer of `PR_NUM`.
+
+Use `jq` with `--argjson` (NOT `--arg`) to merge the new field as a JSON integer, preserving existing fields. Atomic `tmp-then-mv` write:
+
+```bash
+WORKTREE_SLUG=$(basename "$(git rev-parse --show-toplevel)")
+SIDECAR="$HOME/.ai-tpk/session-context/by-worktree/${WORKTREE_SLUG}.json"
+if [ -f "$SIDECAR" ] && [ -n "${PR_NUM:-}" ]; then
+  TMP="${SIDECAR}.tmp.$$"
+  jq --argjson pr "$PR_NUM" '. + {PR_NUM: $pr}' "$SIDECAR" > "$TMP" && mv "$TMP" "$SIDECAR" || rm -f "$TMP"
+fi
+```
+
+Notes:
+- `--argjson` (not `--arg`) is mandatory — `PR_NUM` must be a JSON integer per the sidecar schema. Using `--arg` would write a quoted string, failing consumer schema validation.
+- This update is fire-and-forget — failures (missing jq, missing sidecar, write error) do not abort `/open-pr`.
+- If the sidecar does not exist (pre-feature session or missing subroutine write), this block is a silent no-op — `/open-pr` does NOT create a sidecar by itself.
+- The next Stop hook run picks up `PR_NUM` from the sidecar and includes it in the OSC 6800 emit.

--- a/claude/hooks/lib-osc-session-metadata.sh
+++ b/claude/hooks/lib-osc-session-metadata.sh
@@ -7,6 +7,9 @@
 _osc_session_metadata_emit() {
   local CWD="${1:-$PWD}"
 
+  # Only emit when running inside the ai-dungeon terminal.
+  [ "${TERM_PROGRAM:-}" = "ai-dungeon" ] || return 0
+
   # Defensive: jq is re-checked here so lib-osc-session-metadata.sh is usable
   # standalone without session-start.sh / tab-rename-stop.sh as the caller.
   command -v jq >/dev/null 2>&1 || return 0

--- a/claude/hooks/lib-osc-session-metadata.sh
+++ b/claude/hooks/lib-osc-session-metadata.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# lib-osc-session-metadata.sh -- Shared functions for OSC 6800 session-metadata emission.
+# Sourced by session-start.sh and tab-rename-stop.sh.
+# Installed to: ~/.claude/hooks/lib-osc-session-metadata.sh
+# This file is NOT executable -- it is sourced, not run directly.
+
+_osc_session_metadata_emit() {
+  local CWD="${1:-$PWD}"
+
+  # Defensive: jq is re-checked here so lib-osc-session-metadata.sh is usable
+  # standalone without session-start.sh / tab-rename-stop.sh as the caller.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local working_directory="$CWD"
+  local mode worktree_slug sidecar
+  local toplevel
+  # Coupling: the */.worktrees/* glob below is coupled to the Worktree Creation
+  # Subroutine's ${REPO_ROOT}/.worktrees/ path convention. If that convention
+  # changes, update this hook in the same PR.
+  # Use git rev-parse --show-toplevel (not basename $CWD) so that subdirectory
+  # CDing (e.g. /repo/.worktrees/feat-foo/src) still resolves to the correct slug.
+  toplevel=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)
+  case "$toplevel" in
+    */.worktrees/*)
+      mode="worktree"
+      worktree_slug=$(basename "$toplevel")
+      sidecar="$HOME/.ai-tpk/session-context/by-worktree/${worktree_slug}.json"
+      ;;
+    *)
+      mode="advisory"
+      ;;
+  esac
+
+  local session_ts session_slug pr_num issue_num
+  if [ "$mode" = "worktree" ]; then
+    # Worktree mode: read from sidecar
+    [ -f "$sidecar" ] || return 0
+    session_ts=$(jq -r '.SESSION_TS // ""' "$sidecar" 2>/dev/null) || {
+      printf 'lib-osc-session-metadata: warning: failed to parse %s\n' "$sidecar" >&2
+      return 0
+    }
+    session_slug=$(jq -r '.SESSION_SLUG // ""' "$sidecar" 2>/dev/null)
+    # Read integer fields without -r flag to preserve numeric type (returns raw integer or empty)
+    pr_num=$(jq '.PR_NUM // empty' "$sidecar" 2>/dev/null)
+    issue_num=$(jq '.ISSUE_NUM // empty' "$sidecar" 2>/dev/null)
+    if [ -z "$session_ts" ] || [ -z "$session_slug" ]; then
+      printf 'lib-osc-session-metadata: warning: sidecar missing required fields (%s)\n' "$sidecar" >&2
+      return 0
+    fi
+  else
+    # Advisory mode: compute locally (no sidecar)
+    session_ts=$(date +%Y%m%d-%H%M%S)
+    session_slug=$(basename "$CWD")
+    pr_num=""
+    issue_num=""
+  fi
+
+  # Resolve BRANCH or WORKTREE (simplified — no awk parsing of git worktree list)
+  local branch worktree
+  branch=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$branch" = "HEAD" ]; then
+    # True detached HEAD -- emit WORKTREE (basename of worktree dir) instead of BRANCH
+    # "WORKTREE is the basename of the worktree directory, emitted only when HEAD is detached.
+    # BRANCH is the checked-out branch name, emitted in all normal cases."
+    worktree=$(basename "$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)")
+    branch=""
+  fi
+
+  # Resolve REPO (owner/name)
+  local repo
+  repo=$(cd "$CWD" 2>/dev/null && gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)
+  if [ -z "$repo" ]; then
+    local origin_url
+    origin_url=$(git -C "$CWD" remote get-url origin 2>/dev/null)
+    if [ -n "$origin_url" ]; then
+      repo=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##; s#\.git$##')
+    fi
+  fi
+
+  # Build JSON payload
+  # with_entries(select(.value != null)) drops null fields entirely.
+  # String fields are set to null in jq when empty; integer fields use --argjson with "null" literal.
+  # Required fields (SESSION_TS, SESSION_SLUG, WORKING_DIRECTORY) are validated non-empty above.
+  local payload pr_arg issue_arg
+  pr_arg="${pr_num:-null}"
+  issue_arg="${issue_num:-null}"
+  payload=$(jq -nc \
+    --arg ts "$session_ts" \
+    --arg slug "$session_slug" \
+    --arg wd "$working_directory" \
+    --arg branch "$branch" \
+    --arg worktree "$worktree" \
+    --arg repo "$repo" \
+    --argjson pr "$pr_arg" \
+    --argjson issue "$issue_arg" \
+    '{
+      SESSION_TS: $ts,
+      SESSION_SLUG: $slug,
+      WORKING_DIRECTORY: $wd,
+      BRANCH: (if $branch == "" then null else $branch end),
+      WORKTREE: (if $worktree == "" then null else $worktree end),
+      REPO: (if $repo == "" then null else $repo end),
+      PR_NUM: $pr,
+      ISSUE_NUM: $issue
+    } | with_entries(select(.value != null))' 2>/dev/null)
+  [ -z "$payload" ] && return 0
+
+  # Emit OSC 6800 to /dev/tty (mirrors >/dev/tty 2>/dev/null discipline from lib-tab-rename.sh)
+  printf '\033]6800;%s\007' "$payload" >/dev/tty 2>/dev/null
+  return 0
+}

--- a/claude/hooks/session-start.sh
+++ b/claude/hooks/session-start.sh
@@ -23,11 +23,16 @@ CWD="${CWD:-$PWD}"
 # Source shared tab-rename library
 # shellcheck source=lib-tab-rename.sh
 source "$(dirname "$0")/lib-tab-rename.sh"
+# shellcheck source=lib-osc-session-metadata.sh
+source "$(dirname "$0")/lib-osc-session-metadata.sh"
 
 # Check for --name override via process ancestry (walk up to 3 levels)
 if _tab_rename_check_name_override; then
   exit 0
 fi
+
+# Emit OSC 6800 session metadata (runs on every SessionStart, regardless of stored-title state)
+_osc_session_metadata_emit "$CWD"
 
 # Title restore: check if a stored title exists for this session
 TITLE_DIR="$HOME/.claude/session-titles"

--- a/claude/hooks/tab-rename-stop.sh
+++ b/claude/hooks/tab-rename-stop.sh
@@ -21,6 +21,20 @@ TRANSCRIPT_PATH=$(echo "$STDIN_DATA" | jq -r '.transcript_path // ""' 2>/dev/nul
 CWD=$(echo "$STDIN_DATA" | jq -r '.cwd // ""' 2>/dev/null)
 CWD="${CWD:-$PWD}"
 
+# OSC 6800 session-metadata emission (runs on every Stop, regardless of single-fire title guard)
+# Source both libraries early so we can call --name check + OSC 6800 emit before the TITLE_FILE guard.
+# shellcheck source=lib-tab-rename.sh
+source "$(dirname "$0")/lib-tab-rename.sh"
+# shellcheck source=lib-osc-session-metadata.sh
+source "$(dirname "$0")/lib-osc-session-metadata.sh"
+
+# Suppress OSC 6800 when --name is detected in process ancestry (mirrors tab-rename suppression).
+if ! _tab_rename_check_name_override; then
+  _osc_session_metadata_emit "$CWD"
+fi
+
+# --- existing single-fire TITLE_FILE guard, transcript validation, and tab-rename logic continues below ---
+
 # Single-fire guard: if a title file already exists for this session, exit immediately
 TITLE_DIR="$HOME/.claude/session-titles"
 TITLE_FILE="$TITLE_DIR/$SESSION_ID"
@@ -32,10 +46,6 @@ fi
 if [ -z "$TRANSCRIPT_PATH" ] || [ "$TRANSCRIPT_PATH" = "null" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   exit 0
 fi
-
-# Source shared tab-rename library
-# shellcheck source=lib-tab-rename.sh
-source "$(dirname "$0")/lib-tab-rename.sh"
 
 # Check for --name override via process ancestry (walk up to 3 levels)
 if _tab_rename_check_name_override; then

--- a/claude/references/worktree-creation-subroutine.md
+++ b/claude/references/worktree-creation-subroutine.md
@@ -53,10 +53,10 @@ This subroutine is **invoked explicitly** by routing branches in `claude/agents/
 4a. **Write the session-context sidecar.** Delegate a single Bash invocation to Bitsmith with the following body (after DM applies the substitutions described below). This write is fire-and-forget — a failure does not abort the subroutine.
 
    **DM substitution convention:** Before sending the bash block to Bitsmith, DM substitutes:
-   - `{SESSION_TS}` → the literal session-timestamp string (e.g., `20260427-190621`)
-   - `{SESSION_SLUG}` → the literal session-slug string (e.g., `send-osc-session-metadata`)
-   - `{WORKTREE_PATH}` → the literal absolute worktree path returned by step 2
-   - `ISSUE_NUM_VALUE` → DM assigns `""` if no `/feature-issue` was used, or the literal integer string (e.g., `"42"`) if DM's session context contains `SESSION_ISSUE_NUM` from a prior `/feature-issue` invocation. This is a bash variable assigned in the script body — NOT a `{...}` placeholder and NOT a runtime env var.
+- `{SESSION_TS}` → the literal session-timestamp string (e.g., `20260427-190621`)
+- `{SESSION_SLUG}` → the literal session-slug string (e.g., `send-osc-session-metadata`)
+- `{WORKTREE_PATH}` → the literal absolute worktree path returned by step 2
+- `ISSUE_NUM_VALUE` → DM assigns `""` if no `/feature-issue` was used, or the literal integer string (e.g., `"42"`) if DM's session context contains `SESSION_ISSUE_NUM` from a prior `/feature-issue` invocation. This is a bash variable assigned in the script body — NOT a `{...}` placeholder and NOT a runtime env var.
 
    **Authoritative sidecar-write block** (no `$ENV.*`, no dead `--argjson` flags, atomic `tmp-then-mv`):
 
@@ -85,13 +85,13 @@ This subroutine is **invoked explicitly** by routing branches in `claude/agents/
    ```
 
    Properties:
-   - `--arg` for string fields (`SESSION_TS`, `SESSION_SLUG`), `--argjson` for integer field (`ISSUE_NUM`) — satisfies the sidecar schema type contract.
-   - Atomic `tmp-then-mv` write — hook always sees either old or new sidecar, never a partial write.
-   - Idempotent merge via `jq '. + {…}'` — preserves pre-existing fields (e.g. `PR_NUM` if somehow written earlier).
-   - Sidecar path `~/.ai-tpk/session-context/by-worktree/{worktree-slug}.json` is session-namespaced (per-worktree-slug, unique per session). This is the mirror of the canonical anti-pattern from PR #187 (`~/.ai-tpk/session-context/current.json` — singleton, invalid); this design is per-worktree-slug, not singleton.
-   - Advisory sessions do NOT invoke this step — the hook handles advisory sessions locally without a sidecar.
+- `--arg` for string fields (`SESSION_TS`, `SESSION_SLUG`), `--argjson` for integer field (`ISSUE_NUM`) — satisfies the sidecar schema type contract.
+- Atomic `tmp-then-mv` write — hook always sees either old or new sidecar, never a partial write.
+- Idempotent merge via `jq '. + {…}'` — preserves pre-existing fields (e.g. `PR_NUM` if somehow written earlier).
+- Sidecar path `~/.ai-tpk/session-context/by-worktree/{worktree-slug}.json` is session-namespaced (per-worktree-slug, unique per session). This is the mirror of the canonical anti-pattern from PR #187 (`~/.ai-tpk/session-context/current.json` — singleton, invalid); this design is per-worktree-slug, not singleton.
+- Advisory sessions do NOT invoke this step — the hook handles advisory sessions locally without a sidecar.
 
-5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
+1. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 
 **After the subroutine completes, control returns to the routing branch that invoked it.**
 

--- a/claude/references/worktree-creation-subroutine.md
+++ b/claude/references/worktree-creation-subroutine.md
@@ -50,6 +50,47 @@ This subroutine is **invoked explicitly** by routing branches in `claude/agents/
 
 4. **Set session context:** The DM carries `WORKTREE_PATH`, `WORKTREE_BRANCH`, `SESSION_TS`, `SESSION_SLUG`, and `REPO_SLUG` in its conversation memory (the LLM's context window) and explicitly includes them in every delegation prompt to sub-agents for the remainder of the session. No external storage mechanism is needed or used. If a session is interrupted and context is lost, run `git worktree list` to recover `WORKTREE_PATH` and `WORKTREE_BRANCH`. Inspect `~/.ai-tpk/plans/{REPO_SLUG}/` to recover `SESSION_TS` and `SESSION_SLUG` from the plan filename. Recover `REPO_SLUG` via `basename $(git rev-parse --show-toplevel)`. If a prior worktree's variables are present in conversation memory (e.g., from a session that ended with `/open-pr` rather than `/merged`), overwrite them with the new values — the DM never tracks multiple active worktrees simultaneously.
 
+4a. **Write the session-context sidecar.** Delegate a single Bash invocation to Bitsmith with the following body (after DM applies the substitutions described below). This write is fire-and-forget — a failure does not abort the subroutine.
+
+   **DM substitution convention:** Before sending the bash block to Bitsmith, DM substitutes:
+   - `{SESSION_TS}` → the literal session-timestamp string (e.g., `20260427-190621`)
+   - `{SESSION_SLUG}` → the literal session-slug string (e.g., `send-osc-session-metadata`)
+   - `{WORKTREE_PATH}` → the literal absolute worktree path returned by step 2
+   - `ISSUE_NUM_VALUE` → DM assigns `""` if no `/feature-issue` was used, or the literal integer string (e.g., `"42"`) if DM's session context contains `SESSION_ISSUE_NUM` from a prior `/feature-issue` invocation. This is a bash variable assigned in the script body — NOT a `{...}` placeholder and NOT a runtime env var.
+
+   **Authoritative sidecar-write block** (no `$ENV.*`, no dead `--argjson` flags, atomic `tmp-then-mv`):
+
+   ```bash
+   # Substitution: DM substitutes {WORKTREE_PATH}, {SESSION_TS}, {SESSION_SLUG}
+   # as literal strings at delegation time. ISSUE_NUM_VALUE is set by DM in the
+   # script body — "" if no /feature-issue was used, or the literal integer (e.g. "42").
+   # These are NOT runtime env vars.
+   ISSUE_NUM_VALUE=""   # DM sets to e.g. "42" if /feature-issue was used
+
+   WORKTREE_SLUG=$(basename "{WORKTREE_PATH}")
+   SIDECAR="$HOME/.ai-tpk/session-context/by-worktree/${WORKTREE_SLUG}.json"
+   TMP="${SIDECAR}.tmp.$$"
+   mkdir -p "$(dirname "$SIDECAR")"
+   [ -f "$SIDECAR" ] || echo '{}' > "$SIDECAR"
+
+   if [ -n "$ISSUE_NUM_VALUE" ]; then
+     jq --arg ts "{SESSION_TS}" --arg slug "{SESSION_SLUG}" --argjson issue "$ISSUE_NUM_VALUE" \
+        '. + {SESSION_TS: $ts, SESSION_SLUG: $slug, ISSUE_NUM: $issue}' \
+        "$SIDECAR" > "$TMP" && mv "$TMP" "$SIDECAR" || rm -f "$TMP"
+   else
+     jq --arg ts "{SESSION_TS}" --arg slug "{SESSION_SLUG}" \
+        '. + {SESSION_TS: $ts, SESSION_SLUG: $slug}' \
+        "$SIDECAR" > "$TMP" && mv "$TMP" "$SIDECAR" || rm -f "$TMP"
+   fi
+   ```
+
+   Properties:
+   - `--arg` for string fields (`SESSION_TS`, `SESSION_SLUG`), `--argjson` for integer field (`ISSUE_NUM`) — satisfies the sidecar schema type contract.
+   - Atomic `tmp-then-mv` write — hook always sees either old or new sidecar, never a partial write.
+   - Idempotent merge via `jq '. + {…}'` — preserves pre-existing fields (e.g. `PR_NUM` if somehow written earlier).
+   - Sidecar path `~/.ai-tpk/session-context/by-worktree/{worktree-slug}.json` is session-namespaced (per-worktree-slug, unique per session). This is the mirror of the canonical anti-pattern from PR #187 (`~/.ai-tpk/session-context/current.json` — singleton, invalid); this design is per-worktree-slug, not singleton.
+   - Advisory sessions do NOT invoke this step — the hook handles advisory sessions locally without a sidecar.
+
 5. **Log to user:** "Session worktree created: `{WORKTREE_PATH}` on branch `{branch-name}`"
 
 **After the subroutine completes, control returns to the routing branch that invoked it.**

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -100,13 +100,15 @@ Auto-approved entries include the `[auto-approved]` marker; calls falling throug
 - Logged + normal dialog: `Write to /tmp/output.txt` (path not in allowed set — falls through to normal dialog)
 - Allowed: `echo -n hello`, `git log -n 5` (context-aware: `-n` only blocked in `git commit` context)
 
-#### SessionStart Hook - Terminal Tab Title Restore
+#### SessionStart Hook - Terminal Tab Title Restore and OSC 6800 Emit
 
 Runs at the start of every Claude Code session. For resumed sessions, restores the previously stored tab title. For fresh sessions (e.g., after `/new`), resets the tab to the repo or directory name so the previous session's stale title does not persist until the Stop hook generates a new one. Title generation from conversation content is handled by the Stop hook (`tab-rename-stop.sh`).
 
+On every SessionStart (before the title restore logic), the hook emits an OSC 6800 escape sequence carrying structured session metadata. See "OSC 6800 Session Metadata" below for the payload schema and emission rules.
+
 **Purpose:** Ensures the tab title always reflects the current session on startup — either a stored title for resumed sessions or a neutral repo/directory default for fresh sessions. Script: `claude/hooks/session-start.sh`.
 
-**Non-obvious behaviors:** `--name` override is detected via process ancestry (walks up to 3 levels); `-n` is intentionally excluded to avoid false positives. Fresh-session neutral title is derived from the git repo basename when inside a repo, or the directory basename otherwise — matching the context used by the Stop hook. The neutral default is not persisted to `~/.claude/session-titles/`, so the Stop hook's single-fire guard is not tripped and the AI-generated title replaces it after the first exchange.
+**Non-obvious behaviors:** `--name` override is detected via process ancestry (walks up to 3 levels); `-n` is intentionally excluded to avoid false positives. When `--name` is detected the hook exits immediately — OSC 6800 is suppressed along with the title restore. Fresh-session neutral title is derived from the git repo basename when inside a repo, or the directory basename otherwise — matching the context used by the Stop hook. The neutral default is not persisted to `~/.claude/session-titles/`, so the Stop hook's single-fire guard is not tripped and the AI-generated title replaces it after the first exchange.
 
 **Supported terminals and detection:**
 
@@ -161,14 +163,16 @@ Each JSONL line in `~/.ai-tpk/logs/{REPO_SLUG}/talekeeper-{session_id}.jsonl` co
 
 The `agent_transcript_path` field enables downstream tools (like Everwise Scout) to discover and read raw subagent transcripts for deeper analysis. The token fields enable Everwise to identify agents or sessions with disproportionate token consumption without requiring direct transcript access.
 
-#### Stop Hook - Terminal Tab Title Generation
+#### Stop Hook - Terminal Tab Title Generation and OSC 6800 Emit
 
-Runs after every Claude turn (Stop hook) to generate and store an AI-derived terminal tab title. Title generation fires once per session — subsequent Stop hook invocations are no-ops once a title file exists for the session.
+Runs after every Claude turn (Stop hook) to generate and store an AI-derived terminal tab title. Title generation fires once per session — subsequent Stop hook invocations are no-ops once a title file exists for the session. On every Stop invocation (before the single-fire title guard), the hook also emits an OSC 6800 escape sequence carrying structured session metadata. See "OSC 6800 Session Metadata" below for the payload schema and emission rules.
 
 **Purpose:** Generates an AI-derived terminal tab title after the first exchange and stores it for future session resume. Script: `claude/hooks/tab-rename-stop.sh`.
 
 **Non-obvious behaviors:**
-- Single-fire guard: once `~/.claude/session-titles/{session_id}` exists, the hook exits immediately — subsequent Stop invocations are no-ops.
+- OSC 6800 emission runs before the single-fire title guard, so the sidecar is always read and metadata is always broadcast on every turn regardless of whether a title already exists.
+- `--name` suppression for OSC 6800: emission is skipped (via the same `_tab_rename_check_name_override` function) when `--name` is detected. The single-fire title guard still runs independently — `--name` does not suppress that path.
+- Single-fire guard: once `~/.claude/session-titles/{session_id}` exists, the hook exits immediately after OSC 6800 emission — subsequent Stop invocations do not re-generate the title.
 - `--name` sentinel: if launched with `--name`, the hook writes an *empty* sentinel file. This locks the title to whatever the terminal already shows and causes `session-start.sh` to exit silently on resume.
 - Minimum 1 user message required before title generation — sessions that end before the first exchange produce no title.
 - Uses `claude -p --bare --model haiku` in pipe mode to generate the title; pipe mode (`-p`) does not fire session hooks, preventing recursive invocation.
@@ -176,3 +180,61 @@ Runs after every Claude turn (Stop hook) to generate and store an AI-derived ter
 **Supported terminals and detection:** Same table as the SessionStart hook above.
 
 **Async and timeout:** The hook runs asynchronously with a 30-second timeout so that title generation does not block the user between turns.
+
+---
+
+## OSC 6800 Session Metadata
+
+`lib-osc-session-metadata.sh` is a shared library sourced by both `session-start.sh` and `tab-rename-stop.sh`. It exports a single function, `_osc_session_metadata_emit`, which writes an OSC 6800 escape sequence to `/dev/tty` carrying a JSON payload of session context. The ai-dungeon terminal app listens for this sequence to receive structured session state without polling or IPC.
+
+**When it fires:**
+
+| Hook | Fires | Suppressed by |
+|------|-------|---------------|
+| SessionStart | Every SessionStart | `--name` flag detected in process ancestry |
+| Stop (`tab-rename-stop.sh`) | Every Stop turn | `--name` flag detected in process ancestry |
+
+The sequence is emitted before the tab-rename single-fire guard in the Stop hook, so it broadcasts on every turn, not just the first.
+
+**Modes:**
+
+The function operates in one of two modes based on whether the `cwd` is inside a `.worktrees/` path:
+
+- **Worktree mode:** Reads `SESSION_TS`, `SESSION_SLUG`, `PR_NUM`, and `ISSUE_NUM` from the session-context sidecar (`~/.ai-tpk/session-context/by-worktree/{worktree-slug}.json`). If the sidecar is missing or lacks the required fields, the function returns silently — no sequence is emitted.
+- **Advisory mode:** Computes `SESSION_TS` and `SESSION_SLUG` locally (current timestamp and directory basename). `PR_NUM` and `ISSUE_NUM` are omitted.
+
+**Escape sequence format:**
+
+```
+ESC ] 6800 ; {JSON} BEL
+```
+
+The JSON payload uses `with_entries(select(.value != null))` — fields that are null or empty are omitted entirely. Required fields (`SESSION_TS`, `SESSION_SLUG`, `WORKING_DIRECTORY`) are validated non-empty before emission.
+
+**Payload schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SESSION_TS` | string | Session timestamp in `YYYYMMDD-HHmmss` format; from sidecar in worktree mode, computed locally in advisory mode |
+| `SESSION_SLUG` | string | Session slug (worktree slug in worktree mode, directory basename in advisory mode) |
+| `WORKING_DIRECTORY` | string | Absolute path of `cwd` passed to the hook |
+| `BRANCH` | string | Current git branch; omitted when HEAD is detached |
+| `WORKTREE` | string | Basename of the worktree directory; emitted only when HEAD is detached (replaces `BRANCH`) |
+| `REPO` | string | `owner/name` from `gh repo view`; falls back to remote URL parsing; omitted if neither resolves |
+| `PR_NUM` | integer | Pull request number; written by `/open-pr` on successful PR creation; omitted until then |
+| `ISSUE_NUM` | integer | GitHub issue number; written by the Worktree Creation Subroutine when `/feature-issue` was used; omitted otherwise |
+
+**Sidecar file (`~/.ai-tpk/session-context/by-worktree/{worktree-slug}.json`):**
+
+This file is the source of truth for fields that cannot be derived at hook-fire time. It is written atomically (`tmp-then-mv`) by two writers:
+
+- **Worktree Creation Subroutine (step 4a):** writes `SESSION_TS`, `SESSION_SLUG`, and optionally `ISSUE_NUM` when the worktree is created. The subroutine's bash block is authored by DM (using literal-string substitution for `{SESSION_TS}`, `{SESSION_SLUG}`, and `{WORKTREE_PATH}`) and delegated to Bitsmith for execution.
+- **`/open-pr` command:** writes `PR_NUM` after `gh pr create` returns successfully.
+
+Both writers use `jq '. + {…}'` to merge fields, preserving any pre-existing keys. Advisory sessions do not create a sidecar; the hook handles them locally.
+
+**`ISSUE_NUM` recording flow:** `/feature-issue` does not write the sidecar directly — the worktree does not yet exist when the command runs. Instead, DM stores the parsed issue number in its session context as `SESSION_ISSUE_NUM`. When DM later runs the Worktree Creation Subroutine, it substitutes `SESSION_ISSUE_NUM` into the sidecar-write bash block as the literal value of `ISSUE_NUM_VALUE`. See `claude/commands/feature-issue.md` and `claude/references/worktree-creation-subroutine.md` step 4a for the authoritative bash block.
+
+**Dependencies:** Requires `jq`. Both `session-start.sh` and `tab-rename-stop.sh` guard on `jq` availability before sourcing this library, so it is effectively jq-gated. The library also performs its own `command -v jq` guard for standalone use.
+
+**Script:** `claude/hooks/lib-osc-session-metadata.sh` (sourced, not executed directly).


### PR DESCRIPTION
Emits the OSC 6800 escape sequence on every SessionStart and Stop hook so
the ai-dungeon terminal receives structured JSON session metadata (session
timestamp, slug, working directory, branch, repo, optional PR/issue numbers).

Extends the existing tab-rename hook pair via a new shared library
(`lib-osc-session-metadata.sh`) — no new settings.json registrations
required. A session-namespaced sidecar at
`~/.ai-tpk/session-context/by-worktree/{slug}.json` bridges DM-computed
session variables (SESSION_TS, SESSION_SLUG) to the shell hook environment.