### PR TITLE
chore(settings): add Read allowedTools entry for ~/.ai-tpk/**

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,6 +2,7 @@
   "allowedTools": [
     "Write(~/.ai-tpk/**)",
     "Edit(~/.ai-tpk/**)",
+    "Read(~/.ai-tpk/**)",
     "Read(~/.claude/agents/**)",
     "Read(~/.claude/skills/**)",
     "Read(~/.claude/references/**)",


### PR DESCRIPTION
Adds Read(~/.ai-tpk/**) to allowedTools so the declared permission matches the existing Write and Edit grants for the same path. Without this entry, tightening defaultMode from dontAsk to ask would prompt for reads to ~/.ai-tpk/ while writes would not — an asymmetry. The permission-learn.sh hook already auto-approves reads here; this aligns the settings declaration with the runtime behavior.