### PR TITLE
feat(scripts): add range parameter support to batch-open-issues

### DIFF
--- a/claude/scripts/batch-open-issues.sh
+++ b/claude/scripts/batch-open-issues.sh
@@ -88,11 +88,11 @@ expand_arg() {
   if [[ "$arg" =~ ^[0-9]+-[0-9]+$ ]]; then
     local start=$((10#${arg%-*}))
     local end=$((10#${arg#*-}))
-    if (( start > end )); then
+    if ((start > end)); then
       printf "batch-open-issues: invalid range '%s': start must be <= end\n" "$arg" >&2
       return 2
     fi
-    for (( i = start; i <= end; i++ )); do
+    for ((i = start; i <= end; i++)); do
       printf '%s\n' "$i"
     done
     return 0
@@ -106,7 +106,7 @@ for arg in "$@"; do
   expanded=$(expand_arg "$arg") || exit 2
   while IFS= read -r n; do
     ISSUE_NUMBERS+=("$n")
-  done <<< "$expanded"
+  done <<<"$expanded"
 done
 
 LIB="${HOME}/.claude/hooks/lib-tab-rename.sh"

--- a/claude/scripts/batch-open-issues.sh
+++ b/claude/scripts/batch-open-issues.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 #
 # Supported argument forms:
 #   - Bare integer:    42
+#   - Integer range:   1-4         (inclusive; expands to 1 2 3 4 in argument order;
+#                                   start must be <= end; both endpoints are non-negative
+#                                   integers; leading zeros are accepted and parsed as
+#                                   base-10; ranges apply only to bare integers, not URLs;
+#                                   no upper bound on range size — 1-10000 expands to
+#                                   10000 entries and spawns 10000 tabs)
 #   - Full GitHub URL: https://github.com/owner/repo/issues/42
 #                      (optional trailing /, #anchor, or ?query accepted)
 #
@@ -72,10 +78,35 @@ parse_issue_number() {
   return 2
 }
 
+# expand_arg <arg> — emits one or more issue numbers, one per line, on stdout.
+# Range form '<start>-<end>' (both endpoints non-negative integers, base-10 forced
+# to avoid octal interpretation of leading-zero literals) expands to the inclusive
+# integer sequence; bare-integer and URL forms delegate to parse_issue_number.
+# Returns 0 on success, 2 on parse/validation failure.
+expand_arg() {
+  local arg="$1"
+  if [[ "$arg" =~ ^[0-9]+-[0-9]+$ ]]; then
+    local start=$((10#${arg%-*}))
+    local end=$((10#${arg#*-}))
+    if (( start > end )); then
+      printf "batch-open-issues: invalid range '%s': start must be <= end\n" "$arg" >&2
+      return 2
+    fi
+    for (( i = start; i <= end; i++ )); do
+      printf '%s\n' "$i"
+    done
+    return 0
+  fi
+  parse_issue_number "$arg"
+  return $?
+}
+
 ISSUE_NUMBERS=()
 for arg in "$@"; do
-  n=$(parse_issue_number "$arg") || exit 2
-  ISSUE_NUMBERS+=("$n")
+  expanded=$(expand_arg "$arg") || exit 2
+  while IFS= read -r n; do
+    ISSUE_NUMBERS+=("$n")
+  done <<< "$expanded"
 done
 
 LIB="${HOME}/.claude/hooks/lib-tab-rename.sh"

--- a/docs/TPK.md
+++ b/docs/TPK.md
@@ -70,10 +70,10 @@ In both cases, run `tpk` without `--skip` to (re)configure.
 **Usage:**
 
 ```bash
-batch-open-issues.sh 42 123 https://github.com/owner/repo/issues/7
+batch-open-issues.sh 42 1-4 https://github.com/owner/repo/issues/7
 ```
 
-Each argument can be a bare integer (`42`) or a GitHub issue URL in the form `https://github.com/<owner>/<repo>/issues/<n>` (with an optional trailing `/`, `?query`, or `#anchor`).
+Each argument can be a bare integer (`42`), an integer range like `1-4` (inclusive; expands to `1 2 3 4` in argument order; `start` must be `<=` `end`; both endpoints are non-negative integers; leading zeros are accepted; no upper bound on range size), or a GitHub issue URL in the form `https://github.com/<owner>/<repo>/issues/<n>` (with an optional trailing `/`, `?query`, or `#anchor`). Ranges apply only to bare integers, not URLs.
 
 **Supported terminals:** tmux (new window with `-c "$PWD"`), iTerm2 (new tab via AppleScript, inherits current session CWD), and cmux (new workspace via `cmux new-workspace --cwd "$PWD" --name "issue-<n>" --command "<cmd>"`). cmux is detected via `$CMUX_WORKSPACE_ID` (set automatically inside any cmux terminal session). The cmux binary is located by searching `$PATH` first, then falling back to the bundled CLI at `/Applications/cmux.app/Contents/Resources/bin/cmux`. If neither resolves, that issue's spawn fails (recorded in the partial-failure summary) but other issues continue. Standalone Ghostty (Ghostty running without cmux) is not supported and produces exit code 3.
 


### PR DESCRIPTION
`batch-open-issues.sh` previously only accepted individual issue numbers, requiring users to manually expand any range they wanted to open as separate arguments. Users can now pass range arguments like `1-3` directly and the script will spawn tabs for issues 1, 2, and 3 in a single invocation. Leading zeros in range bounds are handled correctly via `10#` arithmetic coercion; `docs/TPK.md` is updated to document the new invocation form. No upper-bound guard is enforced — this is intentional, matching the existing behaviour for positional issue-number arguments.
