### PR TITLE
feat(launcher): add -S short alias for --skip in tpk argv parser

### DIFF
--- a/claude/scripts/batch-open-issues.sh
+++ b/claude/scripts/batch-open-issues.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 # batch-open-issues.sh
 # Spawns one new terminal tab/window per GitHub issue, each running tpk --skip '/feature-issue <n>'
+# (the script invokes the long form '--skip'; the launcher also accepts the short alias '-S' interchangeably)
 #
 # Usage: batch-open-issues.sh <issue> [<issue> ...]
 #

--- a/docs/TPK.md
+++ b/docs/TPK.md
@@ -65,7 +65,7 @@ This is useful for scripts, hot-key launches, and users who never want to see th
 
 In both cases, run `tpk` without `--skip` to (re)configure.
 
-**Unknown flags** are rejected with exit code 2. Any token other than `--skip` prints `Unknown flag: <flag>. Usage: tpk [--skip]` to stderr and exits immediately.
+**Unknown flags** are rejected with exit code 2. Any token other than `--skip` or `-S` prints `Unknown flag: <flag>. Usage: tpk [--skip]` to stderr and exits immediately.
 
 ### `batch-open-issues.sh`: open one tab per issue
 

--- a/docs/TPK.md
+++ b/docs/TPK.md
@@ -37,10 +37,14 @@ The wizard will present a multi-step flow:
 
 ### `--skip`: launch immediately with saved config
 
-Pass `--skip` to bypass the interactive summary screen and launch Claude immediately using whatever is currently saved in `~/.config/tpk/config.json`:
+Pass `--skip` to bypass the interactive summary screen and launch Claude immediately using whatever is currently saved in `~/.config/tpk/config.json`. The short alias `-S` (uppercase) is fully equivalent to `--skip` and may be used interchangeably.
 
 ```bash
 tpk --skip
+```
+
+```bash
+tpk -S
 ```
 
 This is useful for scripts, hot-key launches, and users who never want to see the summary screen.

--- a/src/launcher/README.md
+++ b/src/launcher/README.md
@@ -32,6 +32,8 @@ To launch Claude with an initial prompt (bypasses the wizard):
 tpk --skip "/feature-issue 42"
 ```
 
+The short alias `-S` is equivalent to `--skip` (e.g. `tpk -S "/feature-issue 42"`).
+
 Launches Claude with the given string as its first prompt. Requires `--skip` (the wizard cannot also forward an initial message).
 
 ## Startup Behavior
@@ -60,7 +62,7 @@ Launches Claude with the given string as its first prompt. Requires `--skip` (th
 
 If the saved Grafana cluster ID no longer exists in `~/.config/tpk/grafana-clusters.yaml`, the launch path is skipped and the configure flow starts automatically with a warning.
 
-**`--skip` flag:** Pass `--skip` on the command line to bypass the summary screen entirely and launch Claude immediately with the saved config. The flag is parsed by `argv.ts` before `loadConfig` is called. If the saved config is unusable, the launcher exits non-zero with one of two stderr messages (no saved config, or stale/unresolvable config) — it never falls back to the interactive flow. Any unknown flag causes exit code 2. Example: `pnpm exec tsx src/launcher/main.ts --skip`.
+**`--skip` flag:** Pass `--skip` on the command line to bypass the summary screen entirely and launch Claude immediately with the saved config. The flag is parsed by `argv.ts` before `loadConfig` is called. If the saved config is unusable, the launcher exits non-zero with one of two stderr messages (no saved config, or stale/unresolvable config) — it never falls back to the interactive flow. Any unknown flag causes exit code 2. Example: `pnpm exec tsx src/launcher/main.ts --skip`. The short alias `-S` (uppercase) is accepted as a synonym for `--skip` everywhere `--skip` appears.
 
 ## Initial Message Forwarding
 
@@ -72,7 +74,7 @@ tpk --skip <initial-message>
 
 **Rules:**
 
-- `--skip` is required when supplying an initial message. If an initial message is given without `--skip`, the launcher writes `Initial message requires --skip. Usage: tpk --skip <initial-message>` to stderr and exits with code `2`. No wizard banner is printed.
+- `--skip` (or its short alias `-S`) is required when supplying an initial message. If an initial message is given without `--skip`, the launcher writes `Initial message requires --skip. Usage: tpk --skip <initial-message>` to stderr and exits with code `2`. No wizard banner is printed.
 - Only one positional argument is allowed. If two or more are supplied, the launcher writes `Too many positional arguments. Only one initial message is allowed. Usage: tpk [--skip] [<initial-message>]` to stderr and exits with code `2`. No wizard banner is printed.
 - Any token starting with `-` other than `--skip` (including single-dash tokens like `-h` and the bare `-`) is rejected as an unknown flag. It is never captured as the initial message.
 - The message is passed verbatim to `claude` — quoting at the shell level controls whether spaces become one argument or many. The launcher performs no further tokenisation.

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -128,4 +128,58 @@ describe('parseArgs', () => {
       },
     );
   });
+
+  it("returns { skip: true, initialMessage: undefined } for ['-S']", () => {
+    const result = parseArgs(['-S']);
+    assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
+  });
+
+  it("returns { skip: true, initialMessage: undefined } for duplicate ['-S', '-S'] (idempotent)", () => {
+    const result = parseArgs(['-S', '-S']);
+    assert.deepStrictEqual(result, { skip: true, initialMessage: undefined });
+  });
+
+  it("treats ['--skip', '-S'] and ['-S', '--skip'] both as skip:true", () => {
+    assert.deepStrictEqual(parseArgs(['--skip', '-S']), {
+      skip: true,
+      initialMessage: undefined,
+    });
+    assert.deepStrictEqual(parseArgs(['-S', '--skip']), {
+      skip: true,
+      initialMessage: undefined,
+    });
+  });
+
+  it('captures initial message with -S in either order', () => {
+    assert.deepStrictEqual(parseArgs(['-S', '/cmd']), {
+      skip: true,
+      initialMessage: '/cmd',
+    });
+    assert.deepStrictEqual(parseArgs(['/cmd', '-S']), {
+      skip: true,
+      initialMessage: '/cmd',
+    });
+  });
+
+  it('throws UnknownFlagError for lowercase -s (alias is uppercase only)', () => {
+    assert.throws(
+      () => parseArgs(['-s']),
+      (err: unknown) => {
+        assert.ok(err instanceof UnknownFlagError, 'should be UnknownFlagError');
+        assert.ok(
+          (err as UnknownFlagError).message.includes('-s'),
+          'message should contain the offending flag',
+        );
+        assert.ok(
+          (err as UnknownFlagError).message.includes('Usage: tpk [--skip]'),
+          'message should contain the usage hint',
+        );
+        assert.ok(
+          !(err as UnknownFlagError).message.includes('-S'),
+          'usage hint must not advertise the -S alias',
+        );
+        return true;
+      },
+    );
+  });
 });

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -86,6 +86,31 @@ describe('parseArgs', () => {
     );
   });
 
+  it('throws TooManyPositionalsError when two positionals are supplied with -S', () => {
+    assert.throws(
+      () => parseArgs(['-S', 'a', 'b']),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof TooManyPositionalsError,
+          'should be TooManyPositionalsError',
+        );
+        assert.ok(
+          (err as TooManyPositionalsError).message.includes(
+            'Too many positional arguments',
+          ),
+          'message should mention too many positional arguments',
+        );
+        assert.ok(
+          (err as TooManyPositionalsError).message.includes(
+            'Usage: tpk [--skip]',
+          ),
+          'message should contain the usage hint',
+        );
+        return true;
+      },
+    );
+  });
+
   it('still throws UnknownFlagError for an unknown flag in the presence of a positional', () => {
     assert.throws(
       () => parseArgs(['--unknown', '/cmd']),

--- a/src/launcher/argv.test.ts
+++ b/src/launcher/argv.test.ts
@@ -190,7 +190,10 @@ describe('parseArgs', () => {
     assert.throws(
       () => parseArgs(['-s']),
       (err: unknown) => {
-        assert.ok(err instanceof UnknownFlagError, 'should be UnknownFlagError');
+        assert.ok(
+          err instanceof UnknownFlagError,
+          'should be UnknownFlagError',
+        );
         assert.ok(
           (err as UnknownFlagError).message.includes('-s'),
           'message should contain the offending flag',

--- a/src/launcher/argv.ts
+++ b/src/launcher/argv.ts
@@ -1,7 +1,8 @@
 // Parses the argv array passed to the tpk launcher.
 //
 // Rules:
-//   - The literal token `--skip` sets the skip flag (idempotent; duplicates are tolerated).
+//   - The literal token `--skip` (or its short alias `-S`) sets the skip flag (idempotent;
+//     duplicates are tolerated; the two forms may be freely mixed).
 //   - Any other token that starts with `-` (one or two dashes — covers `--unknown`, `-x`, `-h`,
 //     the bare `-`, etc.) throws UnknownFlagError.
 //   - Any token that does NOT start with `-` is captured as the positional initial message
@@ -31,9 +32,9 @@ export class TooManyPositionalsError extends Error {
  * Parse the arguments passed to the tpk launcher.
  *
  * @param argv - the array to parse (pass `process.argv.slice(2)`; never the full argv)
- * @returns `{ skip, initialMessage }` where `skip` is true when `--skip` is present and
+ * @returns `{ skip, initialMessage }` where `skip` is true when `--skip` or `-S` is present and
  *   `initialMessage` is the single optional positional arg (or `undefined` if not supplied)
- * @throws {UnknownFlagError} for any token starting with `-` other than `--skip`
+ * @throws {UnknownFlagError} for any token starting with `-` other than `--skip` or `-S`
  *   (covers single-dash flags like `-h`, the bare `-`, and double-dash flags like `--unknown`)
  * @throws {TooManyPositionalsError} when more than one positional (non-flag) token is supplied
  */
@@ -44,7 +45,7 @@ export function parseArgs(argv: string[]): {
   let skip = false;
   let initialMessage: string | undefined = undefined;
   for (const token of argv) {
-    if (token === '--skip') {
+    if (token === '--skip' || token === '-S') {
       skip = true;
     } else if (token.startsWith('-')) {
       throw new UnknownFlagError(token);


### PR DESCRIPTION
Previously, users skipping a step with the `tpk` launcher had to type the full `--skip` flag every time. This PR adds `-S` as a short alias for `--skip` in the argv parser, reducing keystrokes in common workflows without any breaking changes. Error messages intentionally continue to advertise only the canonical `--skip` form so the short alias remains a power-user convenience rather than a documented API surface.