### PR TITLE
feat(skills): add post-PR lifecycle guidance to open-pull-request skill

### DIFF
--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -220,12 +220,6 @@ When inline comments or change requests arrive:
 - Re-run `validate-before-pr` after implementing feedback, before requesting re-review
 - Do not remove the draft flag or request re-review until all feedback has been addressed
 
-**3. Draft → ready**
-Only remove the draft flag when:
-- All Phase 4 review gates have passed (ACCEPT or ACCEPT-WITH-RESERVATIONS from all reviewers)
-- All outstanding reviewer feedback has been addressed and verified
-- `validate-before-pr` passes on the final state of the branch
-
 ## Relationship to other skills
 
 - **Commits**: Follow **commit-message-guide** for message bodies and footers. It also documents **WIP** and **fixup!** subject lines—pair fixup commits with `git rebase -i --autosquash` to merge them into the target commit.

--- a/claude/skills/open-pull-request/SKILL.md
+++ b/claude/skills/open-pull-request/SKILL.md
@@ -208,6 +208,24 @@ After push, open with draft + assignee, e.g. `gh pr create --draft --assignee @m
 - [ ] PR is opened as a **draft** and **assigned to the user** (`@me` or equivalent)
 - [ ] No AI/tool attribution in title or body
 
+## After PR Creation
+
+**1. Implementation review**
+The PR is in draft state and not ready to merge. Ruinor code review runs as a mandatory next step; treat PR creation as the beginning of the review phase, not the end of the implementation phase.
+
+**2. Acting on reviewer feedback**
+When inline comments or change requests arrive:
+- Read all feedback in full — inline comments, review body, and general comments — before making any changes
+- Address all requested changes in focused commits; do not introduce unrelated refactors or cleanups alongside feedback responses
+- Re-run `validate-before-pr` after implementing feedback, before requesting re-review
+- Do not remove the draft flag or request re-review until all feedback has been addressed
+
+**3. Draft → ready**
+Only remove the draft flag when:
+- All Phase 4 review gates have passed (ACCEPT or ACCEPT-WITH-RESERVATIONS from all reviewers)
+- All outstanding reviewer feedback has been addressed and verified
+- `validate-before-pr` passes on the final state of the branch
+
 ## Relationship to other skills
 
 - **Commits**: Follow **commit-message-guide** for message bodies and footers. It also documents **WIP** and **fixup!** subject lines—pair fixup commits with `git rebase -i --autosquash` to merge them into the target commit.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -53,7 +53,7 @@ Skills are reusable capabilities that enhance Claude's functionality. Three mand
 
 - **`commit-message-guide`** — Enforces conventional commit format for all git commits
 - **`validate-before-pr`** — Runs lint and format checks (via stack detection: npm, Make, Python, Go, Rust) before opening a PR; gates PR creation on passing checks
-- **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation; covers post-creation lifecycle: acting on reviewer feedback and draft-to-ready criteria
+- **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation; covers post-creation lifecycle: mandatory implementation review and acting on reviewer feedback
 
 Additional skills (non-mandatory):
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -53,7 +53,7 @@ Skills are reusable capabilities that enhance Claude's functionality. Three mand
 
 - **`commit-message-guide`** — Enforces conventional commit format for all git commits
 - **`validate-before-pr`** — Runs lint and format checks (via stack detection: npm, Make, Python, Go, Rust) before opening a PR; gates PR creation on passing checks
-- **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation
+- **`open-pull-request`** — Creates pull requests with conventional naming, draft mode, and pre-flight validation; covers post-creation lifecycle: acting on reviewer feedback and draft-to-ready criteria
 
 Additional skills (non-mandatory):
 


### PR DESCRIPTION
The open-pull-request skill previously ended at PR creation, leaving no guidance on the review phase or how to respond to reviewer feedback. Adding an After PR Creation section closes this gap: it establishes that PR creation is the beginning of the review phase (not the end), and provides concrete steps for handling inline comments and change requests. Draft flag management is intentionally left to the user's discretion.

Closes #329
