### PR TITLE
chore(lefthook): scope ruff pre-commit checks to staged files only

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,11 +10,11 @@ pre-commit:
     ruff-check:
       glob: "dungeon/**/*.py"
       root: dungeon/
-      run: uv run ruff check .
+      run: uv run ruff check {staged_files}
     ruff-format-check:
       glob: "dungeon/**/*.py"
       root: dungeon/
-      run: uv run ruff format --check .
+      run: uv run ruff format --check {staged_files}
 
 pre-push:
   commands:


### PR DESCRIPTION
Pre-commit ruff checks previously scanned the entire dungeon/ directory whenever any Python file was staged. Switching to Lefthook's {staged_files} template scopes each invocation to only the committed files, making pre-commit faster for typical single-file edits. CI's python job continues to run full-directory ruff checks, preserving whole-tree coverage before merge.

Closes #338