### PR TITLE
feat(skills): expand file-organization with directory and test placement guidance

### DIFF
--- a/claude/skills/file-organization/SKILL.md
+++ b/claude/skills/file-organization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: file-organization
-description: Guide for sensible file and module organization. Use when designing file structure for a new feature, deciding whether to split or merge files, refactoring a large file, or evaluating whether a new file is justified.
+description: Guide for sensible file and module organization. Use when designing file structure for a new feature, deciding whether to split or merge files, refactoring a large file, evaluating whether a new file is justified, deciding whether to create a new directory, choosing where test files should live, or naming a new directory.
 ---
 
 # Sensible File Organization
@@ -41,3 +41,41 @@ Always explain why each file exists and why further splitting isn't needed. This
 > `auth.ts` — session creation and validation  
 > `auth.types.ts` — shared types used by both auth and middleware  
 > No separate `auth.utils.ts` because all helpers are private to `auth.ts` and have no reuse candidates
+
+## Directory Structure
+
+A directory should represent a coherent responsibility boundary, not just a naming convenience.
+
+**Create a new directory when:**
+- A group of 3 or more files share a responsibility that is clearly distinct from the parent directory's responsibility
+- A sub-domain is large enough that it will grow independently (e.g., `auth/`, `billing/`, `notifications/`)
+- The group needs its own configuration, types, or utilities that would pollute the parent directory
+
+**Do NOT create a new directory when:**
+- You have 1–2 files that would fit comfortably in the parent
+- The new directory would immediately need to be flattened (e.g., `utils/string-utils/` containing one file)
+- The name describes an implementation detail rather than a domain concept — avoid `helpers/`, `misc/`, `common/`, `utils/` at the leaf level
+
+When in doubt, prefer a flat structure and a new file over a new directory. You can always extract a directory later; removing a directory that turned out unnecessary is disruptive.
+
+## Test File Placement
+
+**Default: co-located tests** — place `*.test.ts` (or `*.spec.ts`) next to the source file they test.
+- Benefit: immediately obvious that a source file has tests; changes to source and test happen in the same directory; no parallel directory tree to maintain
+- Use this when: unit testing a single module with a 1:1 relationship between source file and test file
+
+**Separate `tests/` directory** — only when:
+- Tests require shared fixtures, factories, or setup files that are not specific to one source file
+- Integration or end-to-end tests span multiple source modules and don't belong to any one of them
+- The project's existing convention is a `tests/` directory — match what's already there; do not mix both patterns in the same feature area
+
+If the project already uses one convention, continue it. Introducing a second test placement convention in an existing codebase requires an explicit decision and a note in CLAUDE.md.
+
+## Naming Directories
+
+A directory name passes the test if a reader scanning a file tree immediately understands its role without opening any file inside it.
+
+**Good directory names:** describe the domain or responsibility (`auth`, `payments`, `graph`, `pipeline`)
+**Poor directory names:** describe location or type (`utils`, `helpers`, `common`, `shared`, `misc`)
+
+If you cannot name a directory without using a type-descriptor word, it is likely not a genuine responsibility boundary — reconsider whether the files belong in an existing directory instead.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -58,7 +58,7 @@ Skills are reusable capabilities that enhance Claude's functionality. Three mand
 Additional skills (non-mandatory):
 
 - **`write-reliable-tests`** — Guides authorship and review of deterministic, isolated, and idempotent automated tests across unit, integration, and e2e levels; applied automatically whenever test code is being written or evaluated
-- **`file-organization`** — Guide for file and module organization decisions
+- **`file-organization`** — Structural reference for file, module, and directory organization: when to split or merge files, when to create a new directory, where test files should live (co-located vs. separate `tests/`), and how to name directories so their responsibility is immediately legible
 - **`bash-code-quality`** — Defensive coding standards for bash scripts authored as deliverables: strict mode, safe quoting, error trapping, recurring patterns, and anti-patterns; applied automatically when writing or editing `.sh` files or scripts with a bash shebang
 - **`skill-creator`** — Creates and improves skills in this repository
 - **`task-observer`** — Captures lightweight session observations (friction, repeated mistakes, workarounds) as individual timestamp-and-pid-namespaced files under `~/.ai-tpk/observations/`. Observations are reviewed and turned into skill improvements via `/review-observations`, with explicit user approval on a literal unified diff before any skill file is touched. Activates by description-match; does not modify skills autonomously.


### PR DESCRIPTION
The file-organization skill covered individual file decisions but left directory-level structure, test file placement, and directory naming entirely unguided — gaps that consistently surfaced in multi-file feature work. This expands the skill with three new sections providing concrete rules for each: when to create vs. avoid new directories, co-located vs. separate tests/ conventions, and domain-describing vs. type-descriptor naming. The skill's frontmatter description is also updated so it activates for these broader structural concerns.

Closes #331