### PR TITLE
chore(lefthook): run pre-push and pre-commit linters in parallel

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,6 @@
 # Note: lint-sh and lint-md run at pre-commit only and over the full file set (pnpm script scope), not just staged files.
 pre-commit:
+  parallel: true
   commands:
     lint-sh:
       glob: "**/*.sh"
@@ -17,6 +18,7 @@ pre-commit:
       run: uv run ruff format --check {staged_files}
 
 pre-push:
+  parallel: true
   commands:
     lint:
       glob: "**/*.{js,jsx,ts,tsx,mjs,cjs}"


### PR DESCRIPTION
Sequential pre-commit and pre-push hooks accumulate wall-clock time proportional to the number of linters. Adding \`parallel: true\` to both hook blocks lets lefthook run all independent checks concurrently, cutting developer wait time to roughly the slowest single check. All commands are read-only with no shared filesystem state, making concurrent execution safe.

Closes #339