### PR TITLE
fix(scripts): accept optional working-directory arg in git-preflight.sh

### DIFF
--- a/claude/commands/merge-pr.md
+++ b/claude/commands/merge-pr.md
@@ -11,7 +11,9 @@ must be delegated to Bitsmith per the DM delegation policy. Those steps are mark
 
 ## Step 1 — Run preflight checks
 
-Run: `bash ~/.claude/scripts/git-preflight.sh merge-pr`
+Run: `bash ~/.claude/scripts/git-preflight.sh merge-pr` (with `{WORKING_DIRECTORY}` appended as the second argument when the worktree context block is present in the session; omit the second argument when running outside a worktree session).
+
+The second argument scopes the script's git branch detection to the worktree, ensuring the correct PR branch is detected. Omit it outside a worktree session — the script falls back to the shell's CWD.
 
 This script verifies GitHub authentication, detects the current branch, and guards against
 protected branches (`main`, `master`, `develop`). On success it prints the detected branch

--- a/claude/commands/sync-pr.md
+++ b/claude/commands/sync-pr.md
@@ -11,7 +11,9 @@ be delegated to Bitsmith per the DM delegation policy. Those steps are marked be
 
 ## Step 1 — Run preflight checks
 
-Run: `bash ~/.claude/scripts/git-preflight.sh sync-pr`
+Run: `bash ~/.claude/scripts/git-preflight.sh sync-pr` (with `{WORKING_DIRECTORY}` appended as the second argument when the worktree context block is present in the session; omit the second argument when running outside a worktree session).
+
+The second argument scopes the script's git branch detection to the worktree, ensuring the correct PR branch is detected. Omit it outside a worktree session — the script falls back to the shell's CWD.
 
 This script verifies GitHub authentication, detects the current branch, and guards against
 protected branches (`main`, `master`, `develop`). On success it prints the detected branch

--- a/claude/scripts/git-preflight.sh
+++ b/claude/scripts/git-preflight.sh
@@ -2,12 +2,26 @@
 
 set -euo pipefail
 
-# Accept one positional arg: the invoking command name ('merge-pr' or 'sync-pr').
+# Accept positional args: $1 = invoking command name ('merge-pr' or 'sync-pr'); $2 = optional working directory (defaults to CWD when absent — used to scope git operations to a worktree).
 CMD="${1:-}"
 if [[ "$CMD" != "merge-pr" && "$CMD" != "sync-pr" ]]; then
   printf '%s\n' "git-preflight.sh: missing or invalid command name argument (expected 'merge-pr' or 'sync-pr')" >&2
   exit 2
 fi
+
+DIR="${2:-}"
+if [[ -n "$DIR" ]]; then
+  if [[ ! -d "$DIR" ]]; then
+    printf '%s\n' "git-preflight.sh: working directory '${DIR}' does not exist or is not a directory" >&2
+    exit 2
+  fi
+  if ! git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    printf '%s\n' "git-preflight.sh: '${DIR}' is not a git working tree" >&2
+    exit 2
+  fi
+fi
+GIT=(git)
+[[ -n "$DIR" ]] && GIT=(git -C "$DIR")
 
 # Step 1: Verify GitHub authentication.
 if ! gh auth status >/dev/null 2>&1; then
@@ -16,7 +30,7 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 
 # Step 2: Detect current branch.
-BRANCH="$(git branch --show-current)"
+BRANCH="$("${GIT[@]}" branch --show-current)"
 
 if [[ -z "$BRANCH" ]]; then
   printf '%s\n' "Cannot operate from a detached HEAD. Check out a branch first." >&2


### PR DESCRIPTION
\`/merge-pr\` and \`/sync-pr\` were failing with "Cannot merge a protected branch" when invoked from worktree sessions because \`git-preflight.sh\` detected \`main\` instead of the PR branch — the script ran \`git branch --show-current\` without accounting for the caller's working directory.

Added an optional second positional argument \`<working-directory>\` that, when supplied, drives all \`git\` calls through \`git -C "$DIR"\` for accurate branch detection in any working tree. This pattern is consistent with \`pr-review-*.sh\` scripts already in the repo.

Omitting the argument preserves the existing behaviour, making this a fully backward-compatible change.