### PR TITLE
chore(lefthook): skip mypy and pytest during merge and rebase

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Dependency updates are automated via Dependabot (`.github/dependabot.yml`). On a
 
 ## Python Tooling (`dungeon/`)
 
-The `dungeon/` directory is a Python library subproject. Any commit that touches `dungeon/**/*.py` triggers `lefthook` hooks that run `ruff` (lint and format), `mypy` (type-check), and `pytest` (tests). These hooks require `uv` to be installed — see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) if the hooks fail with a `uv: command not found` error.
+The `dungeon/` directory is a Python library subproject. Any commit that touches `dungeon/**/*.py` triggers `lefthook` hooks that run `ruff` (lint and format), `mypy` (type-check), and `pytest` (tests); `mypy` and `pytest` are skipped automatically during merge and rebase operations. These hooks require `uv` to be installed — see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) if the hooks fail with a `uv: command not found` error.
 
 The same checks run in CI via the parallel `python` job in `.github/workflows/ci.yml`. For formatting failures, run `uv run ruff format dungeon/` and commit the result.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -39,7 +39,13 @@ pre-push:
       glob: "dungeon/**/*.py"
       root: dungeon/
       run: uv run mypy src
+      skip:
+        - merge
+        - rebase
     pytest:
       glob: "dungeon/**/*.py"
       root: dungeon/
       run: uv run pytest
+      skip:
+        - merge
+        - rebase


### PR DESCRIPTION
Pre-push hooks ran mypy and pytest on every push, including rebases and merges, re-checking code that was already reviewed and tested on its source branch. Adding skip: [merge, rebase] to these two commands eliminates the unnecessary overhead during maintenance operations while leaving all other pre-push hooks (lint, format, spellcheck) and the CI pipeline entirely unaffected.

Closes #341