### PR TITLE
refactor(dungeonmaster): convert step-5e log to directed PR prompt

### DIFF
--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -581,7 +581,7 @@ This routing decision is **re-derivable on demand**: no in-memory `PHASE_3_AGENT
     **Authority statement.** The Phase 5 description is authoritative after a full pipeline run — this step will overwrite any manual `gh pr edit --body` changes the user made between PR creation and the current pipeline completion. This is intentional: the DM-composed description reflects the most recent plan, changes, and reviewer verdicts.
 
     **5e — Worktree log:**
-    Log: "Branch `{WORKTREE_BRANCH}` is ready at `{WORKTREE_PATH}`. Run `/open-pr` to create a pull request, or handle cleanup manually."
+    Log: "Branch `{WORKTREE_BRANCH}` is ready at `{WORKTREE_PATH}`. Open a PR now? Reply `/open-pr` to proceed, or handle cleanup manually."
 
     **Note:** Plan files are stored in `~/.ai-tpk/plans/{REPO_SLUG}/` and are not affected by worktree removal. To clean up plan files after a merge, use the `/merged` command (which offers plan file deletion) or the `/clean-ai-tpk-artifacts` command (age-based cleanup).
 

--- a/claude/references/completion-templates.md
+++ b/claude/references/completion-templates.md
@@ -11,7 +11,7 @@ These three fields appear at the end of Templates A, B, and C. Reproduce them ve
 ```
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
-**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+**Next action:** {contextual directed-prompt suggestion, e.g., "Open a PR now? Reply /open-pr to proceed." or "Merge now? Reply /merge-pr to proceed."}
 ```
 
 **Note on Template D:** Templates A–C reuse the Common Fields block verbatim. Template D uses a specialized subset (Token usage only) due to its post-cleanup context where the Worktree has already been removed and Next action is not applicable. The Worktree field is replaced by the more specific "Worktree removed" field in Template D.
@@ -37,7 +37,7 @@ Used for constructive pipeline sessions (e.g., sessions driven by `/feature`).
 
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
-**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+**Next action:** {contextual directed-prompt suggestion, e.g., "Open a PR now? Reply /open-pr to proceed." or "Merge now? Reply /merge-pr to proceed."}
 
 **Risks / follow-ups:**
 - {item, or "None identified"}
@@ -67,7 +67,7 @@ Used for investigative pipeline sessions (e.g., sessions driven by `/bug`). Exte
 
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
-**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+**Next action:** {contextual directed-prompt suggestion, e.g., "Open a PR now? Reply /open-pr to proceed." or "Merge now? Reply /merge-pr to proceed."}
 
 **Risks / follow-ups:**
 - {item, or "None identified"}
@@ -90,7 +90,7 @@ Used after a pull request is successfully created by `/open-pr`.
 
 **Worktree:** `{WORKTREE_PATH}` on branch `{WORKTREE_BRANCH}` | skipped (no worktree)
 **Token usage:** {input}k in / {output}k out / {cache_write}k cache-write / {cache_read}k cache-read | unavailable
-**Next action:** {contextual next step suggestion, e.g., "Run /open-pr" or "Run /merge-pr"}
+**Next action:** {contextual directed-prompt suggestion, e.g., "Open a PR now? Reply /open-pr to proceed." or "Merge now? Reply /merge-pr to proceed."}
 ```
 
 ---


### PR DESCRIPTION
The DM's Phase 5 step 5e log line and the `completion-templates.md` "Next action" placeholder example both used passive phrasing ("Run /open-pr") that required the user to recall and type the next command. This replaces them with a directed prompt ("Open a PR now? Reply `/open-pr` to proceed") that tells the user exactly how to act, reducing friction at the moment when they're most ready to move forward. No behavioural changes — `/open-pr` remains the canonical entry point for PR creation.