### PR TITLE
chore(lint): harden markdownlint ignore list against dot-file traversal

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "launch": "tsx src/launcher/main.ts",
     "test": "node --import tsx/esm --test 'src/installer/**/*.test.ts' 'src/launcher/**/*.test.ts'",
     "lint": "oxlint src/installer/ src/launcher/",
-    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache' --ignore .worktrees",
+    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache' --ignore .worktrees --ignore .git --ignore .claude/worktrees --ignore dungeon/.venv",
     "spellcheck": "cspell '**/*.{md,ts,sh}' --no-progress --exclude 'node_modules/**' --exclude 'dist/**' --exclude 'pnpm-lock.yaml' --exclude 'plans/**' --exclude 'lessons/**' --exclude 'docs/superpowers/**' --exclude 'claude/cache/**' --exclude '.git/**' --exclude '.worktrees/**'",
     "lint:yaml": "yamllint lefthook.yml .github/ .yamllint.yml",
     "format": "oxfmt --write src/installer/ src/launcher/",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "launch": "tsx src/launcher/main.ts",
     "test": "node --import tsx/esm --test 'src/installer/**/*.test.ts' 'src/launcher/**/*.test.ts'",
     "lint": "oxlint src/installer/ src/launcher/",
-    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache'",
+    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore plans --ignore lessons --ignore 'docs/superpowers' --ignore 'claude/cache' --ignore .worktrees",
     "spellcheck": "cspell '**/*.{md,ts,sh}' --no-progress --exclude 'node_modules/**' --exclude 'dist/**' --exclude 'pnpm-lock.yaml' --exclude 'plans/**' --exclude 'lessons/**' --exclude 'docs/superpowers/**' --exclude 'claude/cache/**' --exclude '.git/**' --exclude '.worktrees/**'",
     "lint:yaml": "yamllint lefthook.yml .github/ .yamllint.yml",
     "format": "oxfmt --write src/installer/ src/launcher/",


### PR DESCRIPTION
Extends the explicit `--ignore` list in the `lint:md` script to match the sibling `spellcheck` script's coverage and guard against any future `--dot` traversal. markdownlint-cli v0.45.0 already excludes hidden directories by default (dot: false glob behaviour), so these additions are defensive rather than functional. Investigated alongside this change: the originally reported pre-commit hang was caused by SSH commit signing blocking when the signing key was absent from the SSH agent — fixed separately via ~/.zshrc.