### PR TITLE
chore(agents): upgrade model frontmatter from pinned ids to aliases

### DIFF
--- a/.claude/skills/agent-creator/SKILL.md
+++ b/.claude/skills/agent-creator/SKILL.md
@@ -27,7 +27,7 @@ Start by understanding what the agent should do:
 2. **When should this agent be invoked?** (what user requests or scenarios)
 3. **What should it produce?** (output format, deliverables)
 4. **What tools does it need?** (Read, Write, Edit, Bash, Grep, Glob, Task, etc.)
-5. **What model should power it?** (claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5)
+5. **What model should power it?** (sonnet, opus, haiku)
 
 ### 2. Research Existing Agents
 
@@ -91,7 +91,7 @@ Create the agent file at `claude/agents/{agent-name}.md` following this pattern:
 ---
 name: agent-name
 description: "Brief role description. Include specific use cases and keywords. Use when [scenario 1], [scenario 2], or [scenario 3]."
-model: claude-sonnet-4-6
+model: sonnet
 tools: "Read, Write, Edit, Bash, Grep, Glob"
 ---
 
@@ -216,9 +216,9 @@ description: "Security vulnerability detection specialist (OWASP Top 10, secrets
 
 Select based on the agent's needs:
 
-- **claude-opus-4-7**: Complex reasoning, planning, security analysis
-- **claude-sonnet-4-6**: General-purpose work, orchestration, balanced tasks
-- **claude-haiku-4-5**: Fast, simple, straightforward tasks
+- **opus**: Complex reasoning, planning, security analysis
+- **sonnet**: General-purpose work, orchestration, balanced tasks
+- **haiku**: Fast, simple, straightforward tasks
 
 Most agents use Sonnet. Use Opus for planning/security work requiring deeper reasoning.
 
@@ -277,7 +277,7 @@ For agents that analyze but never modify code:
 ---
 name: riskmancer
 description: "Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)"
-model: claude-opus-4-7
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---
@@ -301,7 +301,7 @@ For agents that coordinate other agents:
 name: dungeonmaster
 description: "Use this agent to coordinate multi-step software development work..."
 tools: "Task, Read, Grep, Glob, Bash"
-model: claude-sonnet-4-6
+model: sonnet
 ---
 ```
 
@@ -349,7 +349,7 @@ For agents that research and plan but don't execute:
 ---
 name: pathfinder
 description: "Strategic planning consultant with interview workflow"
-model: claude-opus-4-7
+model: opus
 level: 4
 tools: "Read, Write, Grep, Glob, Bash, Agent"
 ---
@@ -530,7 +530,7 @@ Let's create a hypothetical "CodeReviewer" agent:
 - Invoke when: "review this code", "check code quality", "any issues with this PR"
 - Produces: Review report with findings and recommendations
 - Tools: Read, Grep, Glob, Bash (read-only)
-- Model: claude-sonnet-4-6
+- Model: sonnet
 
 **2. Choose Name:** "sentinel" (guarding code quality)
 
@@ -539,7 +539,7 @@ Let's create a hypothetical "CodeReviewer" agent:
 ---
 name: sentinel
 description: "Code quality and best practices reviewer. Use when reviewing pull requests, checking code quality, identifying anti-patterns, or ensuring adherence to project conventions."
-model: claude-sonnet-4-6
+model: sonnet
 tools: "Read, Grep, Glob, Bash"
 disallowedTools: Write, Edit
 ---

--- a/claude/agents/askmaw.md
+++ b/claude/agents/askmaw.md
@@ -2,7 +2,7 @@
 name: askmaw
 color: cyan
 description: "Stateless intake and elaboration clerk. Receives an ambiguous user request plus accumulated Q&A history from DM. Returns exactly one output per invocation: either a single clarifying question (Mode A) or a completed structured brief (Mode B). Invoked by DM in a loop before Pathfinder for ambiguous requests."
-model: claude-sonnet-4-6
+model: sonnet
 effort: low
 permissionMode: acceptEdits
 tools: ""

--- a/claude/agents/dungeonmaster.md
+++ b/claude/agents/dungeonmaster.md
@@ -3,7 +3,7 @@ name: dungeonmaster
 color: purple
 description: "Use this agent to coordinate multi-step software development work. It delegates investigation to Tracebloom for 'why is this broken?' tasks, planning to Pathfinder, runs mandatory Ruinor baseline reviews, conditionally invokes specialist reviewers (Riskmancer/Windwarden/Knotcutter/Truthhammer) based on findings or user flags, delegates implementation to Bitsmith, and validates completion against the plan."
 tools: "Task, Read, Grep, Glob, Bash"
-model: claude-sonnet-4-6
+model: sonnet
 effort: high
 ---
 

--- a/claude/agents/everwise.md
+++ b/claude/agents/everwise.md
@@ -2,7 +2,7 @@
 name: everwise
 color: pink
 description: "Use this agent when the user asks for meta-analysis of agent team performance, session chronicle review, or continuous improvement analysis. Learner agent. Analyzes Talekeeper session chronicles to identify recurring failures, inefficiencies, and coordination problems in the agent team. Proposes structured, evidence-based configuration improvements. Never modifies production configs directly — only writes to ~/.ai-tpk/lessons/ directory."
-model: claude-sonnet-4-6
+model: sonnet
 effort: medium
 permissionMode: acceptEdits
 tools: "Read, Grep, Glob, Write"

--- a/claude/agents/knotcutter.md
+++ b/claude/agents/knotcutter.md
@@ -3,7 +3,7 @@ name: knotcutter
 color: yellow
 description: "Radical simplification specialist for complexity elimination reviews."
 tools: "Read, Grep, Glob, Bash"
-model: claude-opus-4-7
+model: opus
 effort: high
 permissionMode: auto
 level: 3

--- a/claude/agents/pathfinder.md
+++ b/claude/agents/pathfinder.md
@@ -2,7 +2,7 @@
 name: pathfinder
 color: blue
 description: "Strategic planning consultant with interview workflow"
-model: claude-opus-4-7
+model: opus
 effort: high
 permissionMode: acceptEdits
 level: 4

--- a/claude/agents/quill.md
+++ b/claude/agents/quill.md
@@ -3,7 +3,7 @@ name: quill
 color: pink
 description: "Documentation specialist. Produces or updates project docs (READMEs, API specs, architecture guides, user manuals) from a session plan and a list of changed files."
 tools: "Read, Grep, Glob, Bash, Write, Edit"
-model: claude-sonnet-4-6
+model: sonnet
 effort: low
 permissionMode: acceptEdits
 ---

--- a/claude/agents/reisannin.md
+++ b/claude/agents/reisannin.md
@@ -1,7 +1,7 @@
 ---
 name: reisannin
 color: purple
-model: claude-sonnet-4-6
+model: sonnet
 effort: high
 tools: "Read, Grep, Glob"
 permissionMode: acceptEdits

--- a/claude/agents/riskmancer.md
+++ b/claude/agents/riskmancer.md
@@ -2,7 +2,7 @@
 name: riskmancer
 color: orange
 description: "Security vulnerability detection specialist (OWASP, secrets, auth, crypto)."
-model: claude-opus-4-7
+model: opus
 effort: high
 permissionMode: auto
 level: 3

--- a/claude/agents/ruinor.md
+++ b/claude/agents/ruinor.md
@@ -2,7 +2,7 @@
 name: ruinor
 color: red
 description: "Mandatory baseline quality gate reviewer issuing REJECT/REVISE/ACCEPT verdicts."
-model: claude-opus-4-7
+model: opus
 effort: high
 permissionMode: auto
 level: 3

--- a/claude/agents/talekeeper.md
+++ b/claude/agents/talekeeper.md
@@ -3,7 +3,7 @@ name: talekeeper
 color: cyan
 description: "Manual narrator agent. Reads enriched session chronicle files and produces human-readable narrative summaries. Must ONLY be invoked by the user directly — never by hooks, the Dungeon Master, or any automated system."
 tools: "Read, Write, Glob"
-model: claude-haiku-4-5
+model: haiku
 permissionMode: acceptEdits
 ---
 

--- a/claude/agents/tracebloom.md
+++ b/claude/agents/tracebloom.md
@@ -2,7 +2,7 @@
 name: tracebloom
 color: brown
 description: "Read-only investigative agent for open-ended 'why is this broken?' tasks. Produces a structured Diagnostic Report with observations, tests performed, root cause (or inconclusive), and recommended next action. Invoked before any plan or fix exists."
-model: claude-sonnet-4-6
+model: sonnet
 effort: low
 permissionMode: auto
 level: 2

--- a/claude/agents/truthhammer.md
+++ b/claude/agents/truthhammer.md
@@ -2,7 +2,7 @@
 name: truthhammer
 color: orange
 description: "Factual validation specialist verifying claims about external systems against authoritative sources."
-model: claude-sonnet-4-6
+model: sonnet
 effort: low
 permissionMode: auto
 level: 3

--- a/claude/agents/windwarden.md
+++ b/claude/agents/windwarden.md
@@ -2,7 +2,7 @@
 name: windwarden
 color: yellow
 description: "Performance and scalability reviewer for plans and code."
-model: claude-sonnet-4-6
+model: sonnet
 effort: medium
 permissionMode: auto
 level: 3

--- a/claude/references/agent-model-policy.md
+++ b/claude/references/agent-model-policy.md
@@ -43,7 +43,7 @@ Current pinning across all 14 agents (post-change):
 
 Total: 4 + 8 + 1 + 1 = 14 agents.
 
-Pre-change: 13 pinned (Bitsmith at Sonnet) + 0 inherit. Post-change: 13 pinned + 1 inherit (Bitsmith). Net change: one agent moves from Sonnet-pinned to inherit.
+All 14 agents now use short aliases (`sonnet`, `opus`, `haiku`, `inherit`) in their frontmatter `model:` fields. Full model IDs (e.g., `claude-sonnet-4-6`) are no longer used in agent definitions — aliases resolve automatically to the current model in each tier.
 
 ## 4. Per-Invocation Override Discipline
 

--- a/claude/references/agent-model-policy.md
+++ b/claude/references/agent-model-policy.md
@@ -8,7 +8,7 @@ When an agent is invoked, the model is resolved in priority order:
 
 1. **Per-invocation `model` parameter** (highest priority) — passed directly on the Agent tool call at the time of invocation. Accepts aliases only: `haiku`, `sonnet`, `opus`. Full model IDs (e.g., `claude-haiku-4-5`) are not accepted here. Example: passing `model: haiku` on the Agent call forces that invocation to use Haiku regardless of the agent's frontmatter.
 
-2. **Agent frontmatter `model:` value** — set in the agent's YAML front matter. This is the default for most agents. Example: `model: claude-opus-4-7` in `ruinor.md` pins every Ruinor invocation to Opus unless priority #1 overrides it. The special value `model: inherit` at this layer skips this priority and falls through to priority #3.
+2. **Agent frontmatter `model:` value** — set in the agent's YAML front matter. This is the default for most agents. Example: `model: opus` in `ruinor.md` pins every Ruinor invocation to Opus unless priority #1 overrides it. The special value `model: inherit` at this layer skips this priority and falls through to priority #3.
 
 3. **Session-level model** (lowest priority) — the model active in the parent session. When an agent declares `model: inherit`, it runs under whatever model the invoking session is using, unless priority #1 provides an override.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,20 +4,20 @@
 
 | Agent | Purpose | Primary Use Cases | Model | Review Type |
 |-------|---------|-------------------|-------|-------------|
-| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | claude-sonnet-4-6 | N/A |
-| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | claude-sonnet-4-6 | N/A |
-| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | claude-sonnet-4-6 | N/A |
-| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | claude-sonnet-4-6 | N/A |
-| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | claude-opus-4-7 | Specialist (opt-in) |
-| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | claude-opus-4-7 | N/A |
-| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | claude-opus-4-7 | Specialist (opt-in) |
-| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | claude-opus-4-7 | Mandatory baseline |
-| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | claude-sonnet-4-6 | Specialist (opt-in) |
-| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | claude-sonnet-4-6 | Specialist (opt-in) |
+| **Dungeon Master** | Orchestrator for multi-step development | Coordinating complex tasks, delegating work, tracking progress | sonnet | N/A |
+| **Askmaw** | Intake and elaboration clerk | Clarifying ambiguous requests through structured interview loops | sonnet | N/A |
+| **Tracebloom** | Read-only investigative tracker | Open-ended "why is this broken?" diagnosis, pre-plan root cause analysis | sonnet | N/A |
+| **Quill** | Documentation specialist | READMEs, API specs, architecture guides, user manuals | sonnet | N/A |
+| **Riskmancer** | Security reviewer | Vulnerability detection, secrets scanning, OWASP analysis | opus | Specialist (opt-in) |
+| **Pathfinder** | Planning consultant | Work plans, requirement gathering, implementation strategy | opus | N/A |
+| **Knotcutter** | Complexity elimination specialist | Simplifying bloated code, removing over-engineering, reducing abstractions | opus | Specialist (opt-in) |
+| **Ruinor** | Quality gate reviewer | Plan/code review, multi-perspective analysis, go/no-go verdicts | opus | Mandatory baseline |
+| **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | sonnet | Specialist (opt-in) |
+| **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | sonnet | Specialist (opt-in) |
 | **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | inherit | N/A |
 | **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
-| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | claude-sonnet-4-6 | N/A |
-| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | claude-sonnet-4-6 | N/A |
+| **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | sonnet | N/A |
+| **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | sonnet | N/A |
 
 ## When to Use Which Agent
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,7 +15,7 @@
 | **Windwarden** | Performance & scalability reviewer | Performance bottleneck detection, algorithmic complexity analysis, scalability validation | sonnet | Specialist (opt-in) |
 | **Truthhammer** | Factual validation specialist | Verifying external system claims, config keys, API signatures, version compatibility | sonnet | Specialist (opt-in) |
 | **Bitsmith** | Precision code executor | Implementing plans, making targeted code changes, minimal-diff edits | inherit | N/A |
-| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | claude-haiku-4-5 | N/A |
+| **Talekeeper** | Session narrator agent | Manual invocation; reads enriched chronicles, produces narrative summaries and Mermaid diagrams | haiku | N/A |
 | **Everwise** | Learner agent | Analyzing session chronicles, identifying recurring failures, proposing config improvements | sonnet | N/A |
 | **Reisannin** | Agentic architecture advisor | Designing new agents, skills, harnesses, workflow topologies; pre-deployment design advisory | sonnet | N/A |
 


### PR DESCRIPTION
Agent model frontmatter fields across all 13 non-Bitsmith agents used legacy pinned model IDs (e.g. claude-sonnet-4-6) that couple the toolkit to specific model versions. This PR replaces them with short aliases (sonnet, opus, haiku) so any future model update is handled by the alias mapping rather than requiring a sweep of every agent file. The agent-model-policy reference and agent-creator skill guidance are updated to match, and the AGENTS.md catalog is refreshed accordingly. No behavioral changes — alias resolution is handled by the model-resolution chain already defined in the policy reference.